### PR TITLE
ADR 035: Make Config properties with defaults optional

### DIFF
--- a/adr/035-optional-config-defaults.md
+++ b/adr/035-optional-config-defaults.md
@@ -1,0 +1,262 @@
+# ADR: Make Config Properties with Defaults Optional
+
+**Branch**: `035-optional-config-defaults`
+**Created**: 2026-04-10
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The `Config` interface in `types/Config.ts` has an inconsistency in how required vs. optional properties are declared. Five properties that have well-defined defaults in `DEFAULT_CONFIG` are marked as required:
+
+- `processing.variantDepth` (default: `9999`)
+- `processing.details` (default: `'LAYERED'`)
+- `format.output` (default: `'JSON'`)
+- `format.keys` (default: `'SAFE'`)
+- `format.layout` (default: `'LAYOUT'`)
+
+Meanwhile, other properties with equally well-defined defaults are already optional:
+
+- `format.tokens` (default: `'TOKEN'`)
+- `include.invalidVariants` (default: `false`)
+- `include.invalidCombinations` (default: `true`)
+- `include.emptyVariants` (default: `false`)
+
+This inconsistency means a consumer providing a partial config (e.g., only overriding `format.keys`) must still supply every required field, even when the intent is "use defaults for everything else." The CLI's `ConfigLoader.deepMerge` already handles partial configs at runtime by merging over `DEFAULT_CONFIG`, but the TypeScript type rejects the same partial input at compile time.
+
+The JSON schema mirrors this inconsistency: `processing.required` lists `["variantDepth", "details"]`, `format.required` lists `["output", "keys", "layout"]`, while `include.required` is `[]`.
+
+---
+
+## Decision Drivers
+
+- **Consistency**: Properties with defaults should follow the same optional-with-default pattern already established by `format.tokens` and the `include.*` properties
+- **Resilience**: `Config` should be tolerant of missing fields — callers should be able to provide only overrides, trusting `DEFAULT_CONFIG` for the rest
+- **Additive-only (MINOR)**: Making required fields optional is a relaxation — existing valid configs remain valid, so this is not a breaking change
+- **Type ↔ Schema symmetry**: Changes to `types/Config.ts` must be mirrored in `component.schema.json` (Constitution I)
+- **No runtime logic**: This package must not add functions or processing logic (Constitution II) — `DEFAULT_CONFIG` remains the only runtime export
+- **Shared contract coherence**: The type must serve all consumers equally (Constitution III) — no single downstream package's merge pattern should dictate the contract
+
+---
+
+## Options Considered
+
+### Option A: Make five properties optional with `default` annotations in schema *(Selected)*
+
+Mark `processing.variantDepth`, `processing.details`, `format.output`, `format.keys`, and `format.layout` as optional (`?`) in the TypeScript interface. Remove them from the `required` arrays in the JSON schema. Add `default` values to each property in the schema (matching `DEFAULT_CONFIG`). Export a `ResolvedConfig` type (pure type alias, no runtime logic) where all properties are required, for use by consumers that need the fully-resolved shape.
+
+**Pros**:
+- Aligns all defaulted properties under a single pattern — optional with documented default
+- `ResolvedConfig` gives consumers compile-time safety after merging without adding runtime logic to this package
+- Schema `default` annotations make defaults machine-discoverable for tooling and documentation
+- Non-breaking: every existing valid `Config` still satisfies the relaxed type
+
+**Cons / Trade-offs**:
+- Consumers accessing properties directly on `Config` must now handle `undefined` (or use `ResolvedConfig` after merging)
+- `DEFAULT_CONFIG` type changes from `Config` to `ResolvedConfig` (since it provides all values)
+
+---
+
+### Option B: Keep `Config` fully required, add a separate `PartialConfig` input type *(Rejected)*
+
+Leave `Config` as-is (all five properties required). Add a `PartialConfig` type using `DeepPartial<Config>` for input, and let consumers cast to `Config` after merging.
+
+**Rejected because**:
+- Perpetuates the inconsistency — `format.tokens` and `include.*` are already optional in `Config`, so `Config` is already partially "partial"
+- Introduces a third type (`PartialConfig`) when two (`Config` + `ResolvedConfig`) would suffice
+- Doesn't fix the schema inconsistency — `required` arrays would still list fields that have defaults
+
+---
+
+### Option C: Make all five optional, no `ResolvedConfig` type *(Rejected)*
+
+Make the five properties optional but don't export a resolved variant. Consumers use `Config` directly and handle `undefined` with nullish coalescing.
+
+**Rejected because**:
+- Forces every consumer to independently implement fallback logic for the same five properties
+- No compile-time guarantee that merging was performed before accessing values
+- Violates the spirit of the shared contract — the "resolved shape" is a genuine shared concept
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Config.ts` | Make `processing.variantDepth` optional | MINOR |
+| `Config.ts` | Make `processing.details` optional | MINOR |
+| `Config.ts` | Make `format.output` optional | MINOR |
+| `Config.ts` | Make `format.keys` optional | MINOR |
+| `Config.ts` | Make `format.layout` optional | MINOR |
+| `Config.ts` | Add `ResolvedConfig` type (all properties required) | MINOR |
+| `Config.ts` | Type `DEFAULT_CONFIG` as `ResolvedConfig` | PATCH |
+| `index.ts` | Export `ResolvedConfig` type | MINOR |
+
+**Example — `Config` before/after** (`types/Config.ts`):
+```yaml
+# Before — processing
+processing:
+  subcomponents?: { scope?: ...; match: string[]; exclude?: ... }
+  glyphNamePattern?: string
+  codeOnlyPropsPattern?: string
+  slotConstraints?: boolean
+  variantDepth: 1 | 2 | 3 | 9999        # required
+  details: 'FULL' | 'LAYERED'            # required
+  inferNumberProps?: boolean
+
+# After — processing
+processing:
+  subcomponents?: { scope?: ...; match: string[]; exclude?: ... }
+  glyphNamePattern?: string
+  codeOnlyPropsPattern?: string
+  slotConstraints?: boolean
+  variantDepth?: 1 | 2 | 3 | 9999       # optional — default 9999
+  details?: 'FULL' | 'LAYERED'           # optional — default LAYERED
+  inferNumberProps?: boolean
+```
+
+```yaml
+# Before — format
+format:
+  output: 'JSON' | 'YAML'               # required
+  keys: 'SAFE' | 'CAMEL' | ...          # required
+  layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH'  # required
+  tokens?: 'TOKEN' | ...                 # already optional
+
+# After — format
+format:
+  output?: 'JSON' | 'YAML'              # optional — default JSON
+  keys?: 'SAFE' | 'CAMEL' | ...         # optional — default SAFE
+  layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH'  # optional — default LAYOUT
+  tokens?: 'TOKEN' | ...                 # unchanged
+```
+
+**Example — `ResolvedConfig`** (`types/Config.ts`):
+```typescript
+# ResolvedConfig makes all Config properties required (except feature-toggle
+# optionals like subcomponents, glyphNamePattern, codeOnlyPropsPattern, etc.)
+ResolvedConfig:
+  processing:
+    subcomponents?: { ... }              # still optional (feature toggle)
+    glyphNamePattern?: string            # still optional (feature toggle)
+    codeOnlyPropsPattern?: string        # still optional (feature toggle)
+    slotConstraints?: boolean            # still optional (feature toggle)
+    variantDepth: 1 | 2 | 3 | 9999      # required
+    details: 'FULL' | 'LAYERED'         # required
+    inferNumberProps?: boolean           # still optional (feature toggle)
+  format:
+    output: 'JSON' | 'YAML'             # required
+    keys: 'SAFE' | 'CAMEL' | ...        # required
+    layout: 'LAYOUT' | ...              # required
+    tokens?: 'TOKEN' | ...              # still optional (has default but
+                                        #   follows existing optional pattern)
+  include:
+    invalidVariants?: boolean            # still optional
+    invalidCombinations?: boolean        # still optional
+    emptyVariants?: boolean              # still optional
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Remove `variantDepth` and `details` from `processing.required` | MINOR |
+| `component.schema.json` | Remove `output`, `keys`, `layout` from `format.required` | MINOR |
+| `component.schema.json` | Add `default` to `variantDepth` (`9999`), `details` (`"LAYERED"`), `output` (`"JSON"`), `keys` (`"SAFE"`), `layout` (`"LAYOUT"`) | MINOR |
+
+**Example — schema before/after** (`schema/component.schema.json`):
+```yaml
+# Before — processing
+processing:
+  required: ["variantDepth", "details"]
+  properties:
+    variantDepth:
+      type: number
+      enum: [1, 2, 3, 9999]
+    details:
+      type: string
+      enum: ["FULL", "LAYERED"]
+
+# After — processing
+processing:
+  required: []
+  properties:
+    variantDepth:
+      type: number
+      enum: [1, 2, 3, 9999]
+      default: 9999
+    details:
+      type: string
+      enum: ["FULL", "LAYERED"]
+      default: "LAYERED"
+```
+
+```yaml
+# Before — format
+format:
+  required: ["output", "keys", "layout"]
+
+# After — format
+format:
+  required: []
+  properties:
+    output:
+      default: "JSON"
+    keys:
+      default: "SAFE"
+    layout:
+      default: "LAYOUT"
+```
+
+### Notes
+
+- `format.tokens` is already optional with a `default: "TOKEN"` annotation in the schema — no change needed
+- `include.*` properties are already optional with `required: []` — no change needed
+- Feature-toggle properties (`subcomponents`, `glyphNamePattern`, `codeOnlyPropsPattern`, `slotConstraints`, `inferNumberProps`) remain optional because their absence means "feature disabled" — a semantically different pattern from "use default value"
+- `ResolvedConfig` is a pure type alias — it contains no runtime logic and complies with Constitution II
+- `DEFAULT_CONFIG` is retyped as `ResolvedConfig` since it provides all required values
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**:
+  - `processing.variantDepth`: optional in TS ↔ removed from `required[]`, `default: 9999` in schema
+  - `processing.details`: optional in TS ↔ removed from `required[]`, `default: "LAYERED"` in schema
+  - `format.output`: optional in TS ↔ removed from `required[]`, `default: "JSON"` in schema
+  - `format.keys`: optional in TS ↔ removed from `required[]`, `default: "SAFE"` in schema
+  - `format.layout`: optional in TS ↔ removed from `required[]`, `default: "LAYOUT"` in schema
+  - `ResolvedConfig`: TS-only type (no schema representation needed — it describes the same shape with stricter requiredness, not a new data structure)
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-cli` | None — `ConfigLoader.deepMerge` already produces a fully-resolved config from partial input. Retype internal resolved config as `ResolvedConfig` for clarity. | Optional: update `ConfigLoader.mergeConfig` return type to `ResolvedConfig` |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.17.0` → `0.17.0` (already on this release; change is MINOR-compatible)
+
+**Justification**: All changes are relaxations — required fields become optional. No existing valid `Config` is invalidated. New `ResolvedConfig` type is additive. Per Constitution: "MINOR for additive types or new optional fields."
+
+---
+
+## Consequences
+
+- All five defaulted properties follow a single, consistent pattern: optional with documented default
+- Consumers can provide minimal config objects (e.g., `{ processing: {}, format: {}, include: {} }`) and rely on `DEFAULT_CONFIG` for omitted values
+- `ResolvedConfig` gives downstream packages compile-time assurance that merging has been performed
+- `DEFAULT_CONFIG` is typed as `ResolvedConfig`, making it the canonical "fully specified" config
+- Downstream merge utilities (CLI's `ConfigLoader.deepMerge`, plugin's `settingsToModelConfig`) continue to work unchanged — they already produce fully-resolved configs
+- Schema validators consuming `component.schema.json` will now accept configs without the five previously-required fields

--- a/adr/035-optional-config-defaults.md
+++ b/adr/035-optional-config-defaults.md
@@ -2,7 +2,7 @@
 
 **Branch**: `035-optional-config-defaults`
 **Created**: 2026-04-10
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |
@@ -16,6 +15,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 035 | Make Config Properties with Defaults Optional | Make 5 required Config properties optional with defaults; add `ResolvedConfig` type for fully-resolved shape |
 | 033 | Typography fontFamily/fontStyle — Remove Number, Add TokenReference | Fix font fields: remove impossible `number` branch, add `TokenReference` for variable-bound font properties |
 | 032 | Typography leadingTrim — Correct to String Enum | Fix `leadingTrim` from incorrect `number \| "mixed"` to correct `"NONE" \| "CAP_HEIGHT" \| "mixed"` string enum |
 | 031 | Subcomponent Search Scope Config | Replace `subcomponentNamePattern` with structured `processing.subcomponents` object (`scope`, `match[]`, `exclude[]`) |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `CLIConfig.config` — typed as `ResolvedConfig` instead of `Config`, reflecting that the CLI always works with a fully-resolved config after merging with defaults
-- `ConfigLoader.mergeConfig` — return type narrowed to `ResolvedConfig`
+- Config types now distinguish partial input from resolved output — `CLIConfig.config` and `ConfigLoader.mergeConfig` use `ResolvedConfig` (all defaults guaranteed) instead of `Config` (which now permits omitted fields)
 
 ### Removed
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `CLIConfig.config` — typed as `ResolvedConfig` instead of `Config`, reflecting that the CLI always works with a fully-resolved config after merging with defaults
+- `ConfigLoader.mergeConfig` — return type narrowed to `ResolvedConfig`
+
 ### Removed
 
 

--- a/packages/cli/src/Config/ConfigLoader.ts
+++ b/packages/cli/src/Config/ConfigLoader.ts
@@ -8,7 +8,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import yaml from 'yaml';
-import { DEFAULT_CONFIG, type Config } from '@directededges/specs-schema';
+import { DEFAULT_CONFIG, type Config, type ResolvedConfig } from '@directededges/specs-schema';
 import { CONFIG_DEFAULTS } from './ConfigDefaults.js';
 import type { CLIConfig } from '../Types/CLIConfig.js';
 import type { OutputConfig, OutputFormat } from '../Types/OutputConfig.js';
@@ -109,7 +109,7 @@ export class ConfigLoader {
   /**
    * Merge model config from file with defaults
    */
-  private mergeConfig(fileModel: unknown): Config {
+  private mergeConfig(fileModel: unknown): ResolvedConfig {
     if (!fileModel) {
       return DEFAULT_CONFIG;
     }
@@ -124,8 +124,8 @@ export class ConfigLoader {
   /**
    * Validate and correct model config, replacing invalid values with defaults
    */
-  private validateAndCorrectConfig(config: Config): Config {
-    const corrected = JSON.parse(JSON.stringify(config)) as Config;
+  private validateAndCorrectConfig(config: Config): ResolvedConfig {
+    const corrected = JSON.parse(JSON.stringify(config)) as ResolvedConfig;
 
     // Guard against null/undefined nested config objects from YAML parsing
     // (YAML parsing of keys with only comments produces null instead of empty object)

--- a/packages/cli/src/Types/CLIConfig.ts
+++ b/packages/cli/src/Types/CLIConfig.ts
@@ -2,7 +2,7 @@
  * CLI configuration structure
  */
 
-import type { Config } from '@directededges/specs-schema';
+import type { ResolvedConfig } from '@directededges/specs-schema';
 import type { OutputConfig } from './OutputConfig.js';
 
 export type CliSourceDataKind = 'file' | 'variables' | 'styles';
@@ -16,7 +16,7 @@ export interface CLIConfig {
   sourceDirectory?: string;
   outputDirectory?: string;
   author?: string;
-  config: Config;
+  config: ResolvedConfig;
   output?: OutputConfig;
   sources?: Record<string, CliSourceConfig>;
 }

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ResolvedConfig` — fully-resolved config type with all defaultable properties required; use after merging with `DEFAULT_CONFIG`
+
 ### Changed
+
+- `Config.processing.variantDepth` — now optional; defaults to 9999
+- `Config.processing.details` — now optional; defaults to LAYERED
+- `Config.format.output` — now optional; defaults to JSON
+- `Config.format.keys` — now optional; defaults to SAFE
+- `Config.format.layout` — now optional; defaults to LAYOUT
+- `DEFAULT_CONFIG` — typed as `ResolvedConfig` instead of `Config`
 
 ### Removed
 

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -802,20 +802,21 @@
                 2,
                 3,
                 9999
-              ]
+              ],
+              "default": 9999,
+              "description": "Depth of variant expansion: 1-3 or 9999 for unlimited. Defaults to 9999."
             },
             "details": {
               "type": "string",
               "enum": [
                 "FULL",
                 "LAYERED"
-              ]
+              ],
+              "default": "LAYERED",
+              "description": "Level of detail in output. Defaults to LAYERED."
             }
           },
-          "required": [
-            "variantDepth",
-            "details"
-          ],
+          "required": [],
           "additionalProperties": false
         },
         "format": {
@@ -826,7 +827,9 @@
               "enum": [
                 "JSON",
                 "YAML"
-              ]
+              ],
+              "default": "JSON",
+              "description": "Output format. Defaults to JSON."
             },
             "keys": {
               "type": "string",
@@ -837,7 +840,9 @@
                 "KEBAB",
                 "PASCAL",
                 "TRAIN"
-              ]
+              ],
+              "default": "SAFE",
+              "description": "Key naming convention. Defaults to SAFE."
             },
             "layout": {
               "type": "string",
@@ -845,7 +850,9 @@
                 "LAYOUT",
                 "PARENT_CHILDREN",
                 "BOTH"
-              ]
+              ],
+              "default": "LAYOUT",
+              "description": "Layout representation format. Defaults to LAYOUT."
             },
             "tokens": {
               "type": "string",
@@ -860,11 +867,7 @@
               "description": "Token reference serialization profile. Optional; defaults to TOKEN. CUSTOM delegates projection entirely to the transformer."
             }
           },
-          "required": [
-            "output",
-            "keys",
-            "layout"
-          ],
+          "required": [],
           "additionalProperties": false
         },
         "include": {

--- a/packages/schema/tests/Config.test-d.ts
+++ b/packages/schema/tests/Config.test-d.ts
@@ -1,19 +1,16 @@
 /**
- * Type-level tests for Config.
+ * Type-level tests for Config and ResolvedConfig.
  * These files are intentionally never executed — they are compiled with tsc
  * to assert that the type shape is correct.
  */
-import type { Config } from '../types/index.js';
+import type { Config, ResolvedConfig } from '../types/index.js';
 import { DEFAULT_CONFIG } from '../types/index.js';
 
 // ─── Helper: minimal valid processing + format + include ──────────────────────
 
-const minProcessing: Config['processing'] = {
-  variantDepth: 9999,
-  details: 'LAYERED',
-};
-const minFormat: Config['format'] = { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT' };
-const minInclude: Config['include'] = { invalidVariants: false, invalidCombinations: true };
+const minProcessing: Config['processing'] = {};
+const minFormat: Config['format'] = {};
+const minInclude: Config['include'] = {};
 
 // ─── Full Config with all fields ──────────────────────────────────────────────
 
@@ -44,13 +41,41 @@ const fullConfig: Config = {
   },
 };
 
-// ─── Minimal Config — only required fields ────────────────────────────────────
+// ─── Minimal Config — only required fields (all empty blocks) ────────────────
 
 const minimalConfig: Config = {
   processing: minProcessing,
   format: minFormat,
   include: minInclude,
 };
+
+// ─── Config with zero overrides — all defaultable fields omitted ─────────────
+
+const bareConfig: Config = {
+  processing: {},
+  format: {},
+  include: {},
+};
+
+// ─── processing.variantDepth is optional ─────────────────────────────────────
+
+const _variantDepthUndefined: Config['processing']['variantDepth'] = undefined;
+
+// ─── processing.details is optional ──────────────────────────────────────────
+
+const _detailsUndefined: Config['processing']['details'] = undefined;
+
+// ─── format.output is optional ───────────────────────────────────────────────
+
+const _outputUndefined: Config['format']['output'] = undefined;
+
+// ─── format.keys is optional ─────────────────────────────────────────────────
+
+const _keysUndefined: Config['format']['keys'] = undefined;
+
+// ─── format.layout is optional ───────────────────────────────────────────────
+
+const _layoutUndefined: Config['format']['layout'] = undefined;
 
 // ─── subcomponents.scope is optional, defaults to NESTED ──────────────────────
 
@@ -126,13 +151,47 @@ const tokenFigmaExtConfig: Config = { ...fullConfig, format: { ...fullConfig.for
 const figmaNameConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'FIGMA_NAME' } };
 const customConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'CUSTOM' } };
 
-// ─── DEFAULT_CONFIG is a valid Config ─────────────────────────────────────────
+// ─── DEFAULT_CONFIG is a valid ResolvedConfig ────────────────────────────────
 
-const defaultIsValid: Config = DEFAULT_CONFIG;
+const defaultIsResolved: ResolvedConfig = DEFAULT_CONFIG;
+
+// ─── DEFAULT_CONFIG satisfies Config (ResolvedConfig extends Config) ─────────
+
+const defaultIsValidConfig: Config = DEFAULT_CONFIG;
 
 // ─── DEFAULT_CONFIG.format.tokens should be 'TOKEN' ──────────────────────────
 
 const defaultTokensValue: typeof DEFAULT_CONFIG.format.tokens = 'TOKEN';
+
+// ─── ResolvedConfig requires variantDepth, details, output, keys, layout ─────
+
+const resolved: ResolvedConfig = {
+  processing: { variantDepth: 9999, details: 'LAYERED' },
+  format: { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT' },
+  include: {},
+};
+
+// ─── ResolvedConfig requires defaultable fields — cannot omit them ────────────
+
+// variantDepth is required on ResolvedConfig.processing
+type _VDRequired = ResolvedConfig['processing']['variantDepth'] extends (1 | 2 | 3 | 9999) ? true : never;
+const _vdRequired: _VDRequired = true;
+
+// details is required on ResolvedConfig.processing
+type _DRequired = ResolvedConfig['processing']['details'] extends ('FULL' | 'LAYERED') ? true : never;
+const _dRequired: _DRequired = true;
+
+// output is required on ResolvedConfig.format
+type _ORequired = ResolvedConfig['format']['output'] extends ('JSON' | 'YAML') ? true : never;
+const _oRequired: _ORequired = true;
+
+// keys is required on ResolvedConfig.format
+type _KRequired = ResolvedConfig['format']['keys'] extends ('SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN') ? true : never;
+const _kRequired: _KRequired = true;
+
+// layout is required on ResolvedConfig.format
+type _LRequired = ResolvedConfig['format']['layout'] extends ('LAYOUT' | 'PARENT_CHILDREN' | 'BOTH') ? true : never;
+const _lRequired: _LRequired = true;
 
 // ─── glyphNamePattern is optional ─────────────────────────────────────────────
 

--- a/packages/schema/types/Config.ts
+++ b/packages/schema/types/Config.ts
@@ -23,20 +23,20 @@ export interface Config {
     codeOnlyPropsPattern?: string;
     /** Whether to consolidate slot constraints (anyOf, minItems, maxItems) from code-only props into the slot property. Optional; defaults to false. @since 0.14.0 */
     slotConstraints?: boolean;
-    /** Depth of variant expansion: 1-3 or 9999 for unlimited */
-    variantDepth: 1 | 2 | 3 | 9999;
-    /** Level of detail in output */
-    details: 'FULL' | 'LAYERED';
+    /** Depth of variant expansion: 1-3 or 9999 for unlimited. Optional; defaults to 9999. */
+    variantDepth?: 1 | 2 | 3 | 9999;
+    /** Level of detail in output. Optional; defaults to LAYERED. */
+    details?: 'FULL' | 'LAYERED';
     /** When true, TEXT code-only props whose default and all examples parse as valid numbers (no leading zeros) are emitted as NumberProp instead of StringProp */
     inferNumberProps?: boolean;
   };
   format: {
-    /** Output format */
-    output: 'JSON' | 'YAML';
-    /** Key naming convention */
-    keys: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
-    /** Layout representation format */
-    layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
+    /** Output format. Optional; defaults to JSON. */
+    output?: 'JSON' | 'YAML';
+    /** Key naming convention. Optional; defaults to SAFE. */
+    keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
+    /** Layout representation format. Optional; defaults to LAYOUT. */
+    layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /** Token reference serialization profile. Optional; defaults to TOKEN. */
     tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
   };
@@ -46,6 +46,58 @@ export interface Config {
     /** Include invalid combinations. Optional; defaults to true. */
     invalidCombinations?: boolean;
     /** Include layered variants that contain no elements. When false (default), exclude empty variants from output. When true, include all variants regardless of element presence. Optional; defaults to false. @since 1.0.0 */
+    emptyVariants?: boolean;
+  };
+}
+
+/**
+ * Fully-resolved model configuration with all defaultable properties guaranteed present.
+ * Produced by merging a partial `Config` with `DEFAULT_CONFIG`.
+ * Feature-toggle properties (`subcomponents`, `glyphNamePattern`, `codeOnlyPropsPattern`,
+ * `slotConstraints`, `inferNumberProps`) remain optional — their absence means the feature is disabled.
+ *
+ * @since 0.17.0
+ */
+export interface ResolvedConfig {
+  processing: {
+    /** Subcomponent discovery settings. Optional; absence means no subcomponent detection. */
+    subcomponents?: {
+      /** Where to search for subcomponents. NESTED = anatomy only (default); PAGE = also search the Figma page. */
+      scope?: 'NESTED' | 'PAGE';
+      /** Template patterns defining which assets are subcomponents. Uses {C} (component name) and {S} (subcomponent name) placeholders. */
+      match: string[];
+      /** Template patterns defining which matched assets to exclude. Same {C}/{S} syntax as match. */
+      exclude?: string[];
+    };
+    /** Naming pattern used to detect glyph content assets. Optional; absence means no glyph detection. */
+    glyphNamePattern?: string;
+    /** Naming pattern used to detect the code-only props container layer. Optional; absence means no code-only prop extraction. */
+    codeOnlyPropsPattern?: string;
+    /** Whether to consolidate slot constraints from code-only props into the slot property. Optional; defaults to false. */
+    slotConstraints?: boolean;
+    /** Depth of variant expansion: 1-3 or 9999 for unlimited. */
+    variantDepth: 1 | 2 | 3 | 9999;
+    /** Level of detail in output. */
+    details: 'FULL' | 'LAYERED';
+    /** When true, TEXT code-only props whose default and all examples parse as valid numbers are emitted as NumberProp instead of StringProp. */
+    inferNumberProps?: boolean;
+  };
+  format: {
+    /** Output format. */
+    output: 'JSON' | 'YAML';
+    /** Key naming convention. */
+    keys: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
+    /** Layout representation format. */
+    layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
+    /** Token reference serialization profile. Optional; defaults to TOKEN. */
+    tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
+  };
+  include: {
+    /** Include invalid variants. Optional; defaults to false. */
+    invalidVariants?: boolean;
+    /** Include invalid combinations. Optional; defaults to true. */
+    invalidCombinations?: boolean;
+    /** Include layered variants that contain no elements. Optional; defaults to false. */
     emptyVariants?: boolean;
   };
 }
@@ -66,7 +118,7 @@ export interface Config {
  * - include.invalidCombinations: true helps designers identify property conflicts
  * - include.emptyVariants: false reduces output size by excluding semantically empty layered variants
  */
-export const DEFAULT_CONFIG: Config = {
+export const DEFAULT_CONFIG: ResolvedConfig = {
   processing: {
     subcomponents: {
       match: ['{C} / _ / {S}'],

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -21,7 +21,7 @@ export type { Children } from './Children.js';
 
 // Configuration types
 export type { PropConfigurations } from './PropConfigurations.js';
-export type { Config } from './Config.js';
+export type { Config, ResolvedConfig } from './Config.js';
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types


### PR DESCRIPTION
## Summary

- Make 5 required `Config` properties optional (`processing.variantDepth`, `processing.details`, `format.output`, `format.keys`, `format.layout`) — they all have well-defined defaults in `DEFAULT_CONFIG`
- Add `ResolvedConfig` type for the fully-resolved shape after merging with defaults
- Retype `DEFAULT_CONFIG` as `ResolvedConfig`
- Add `default` annotations to matching JSON schema properties

## Test plan

- [x] TypeScript compilation passes (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON Schema validation passes (4/4 schemas)
- [x] Type tests compile (`tests/Config.test-d.ts`)
- [ ] Review diff for correctness
- [ ] Merge into release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)