### PR TITLE
feat!: remove Variant.name and Variant.baseline (ADR 036)

### DIFF
--- a/adr/036-remove-variant-name-baseline.md
+++ b/adr/036-remove-variant-name-baseline.md
@@ -2,7 +2,7 @@
 
 **Branch**: `036-remove-variant-name-baseline`
 **Created**: 2026-04-13
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: nathanacurtis (author)
 **Supersedes**: *(none)*
 
@@ -144,9 +144,9 @@ invalid:
 
 ## Semver Decision
 
-**Version bump**: `[CURRENT] → [NEXT MAJOR]` (`MAJOR`)
+**Version bump**: included in `0.17.0` (already unreleased `MAJOR`)
 
-**Justification**: Per Constitution III, removing a field from an exported type is a breaking change and requires a MAJOR version bump. Two fields are removed from `Variant`.
+**Justification**: Per Constitution III, removing a field from an exported type is a breaking change. However, `0.17.0` is already an unreleased MAJOR bump that includes other breaking changes (ADR 034, ADR 035). This removal is folded into the same release rather than requiring a separate version bump.
 
 Impact analysis:
 - Consumers that reference `variant.name` or `variant.baseline` will get TypeScript compilation errors (caught at build time)

--- a/adr/036-remove-variant-name-baseline.md
+++ b/adr/036-remove-variant-name-baseline.md
@@ -1,0 +1,174 @@
+# ADR: Remove `name` and `baseline` from `Variant`
+
+**Branch**: `036-remove-variant-name-baseline`
+**Created**: 2026-04-13
+**Status**: DRAFT
+**Deciders**: nathanacurtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The `Variant` type in `types/Variant.ts` defines two optional string fields — `name` and `baseline` — that are no longer produced or consumed by any package in the ecosystem:
+
+- `specs-from-figma` removed `name` from `Variant.data()` output (commit `dc8c217`). `baseline` was never assigned in variant output.
+- `specs-cli` does not read or display either field.
+- No serialized spec output includes these fields.
+
+Both fields are vestigial: they exist in the type and schema contract but carry no data. Retaining them inflates the API surface and misleads consumers into thinking they convey meaningful information.
+
+GitHub issue: [#5 — Variant name, baseline should be retired](https://github.com/DirectedEdges/specs/issues/5)
+
+---
+
+## Decision Drivers
+
+- **Remove dead API surface**: Unused fields violate Constitution III's "minimal, stable, intentional public API" principle
+- **Type ↔ schema symmetry**: Both `types/Variant.ts` and `schema/component.schema.json` must be updated in lockstep (Constitution I)
+- **No runtime logic**: This change is purely a type/schema deletion — no logic involved (Constitution II)
+- **Accept breaking change**: Removing fields from an exported type is a breaking change requiring a MAJOR bump (Constitution III)
+- **Schema validity**: The JSON schema must remain valid after removal (Constitution IV)
+
+---
+
+## Options Considered
+
+### Option A: Remove both fields entirely *(Selected)*
+
+Delete `name` and `baseline` from `Variant` in both `types/Variant.ts` and `schema/component.schema.json`.
+
+**Pros**:
+- Eliminates dead API surface — no consumer uses these fields
+- Clean removal rather than lingering deprecation
+- Aligns the contract with actual output reality
+- Simple, minimal change
+
+**Cons / Trade-offs**:
+- Breaking change — any consumer that references `Variant.name` or `Variant.baseline` will get TypeScript compilation errors
+- Requires MAJOR version bump
+- Existing serialized specs containing these fields will fail strict schema validation
+
+---
+
+### Option B: Deprecate with `@deprecated` JSDoc but retain *(Rejected)*
+
+Mark both fields as deprecated in the TypeScript type and add `deprecated: true` in the schema, but keep them present.
+
+**Rejected because**: Both fields are already unused in all output. Deprecating fields that carry no data adds process overhead (a future removal ADR) with no consumer benefit. Since no serialized output includes these fields, there is nothing to migrate. Clean removal is simpler and more honest.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Variant.ts` | Remove optional field `name?: string` | MAJOR |
+| `Variant.ts` | Remove optional field `baseline?: string` | MAJOR |
+
+**Example — new shape** (`types/Variant.ts`):
+```yaml
+# Before
+Variant:
+  name?: string
+  baseline?: string
+  configuration?: PropConfigurations
+  invalid?: boolean
+  elements?: Elements
+  layout?: Layout
+
+# After
+Variant:
+  configuration?: PropConfigurations
+  invalid?: boolean
+  elements?: Elements
+  layout?: Layout
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Remove `name` property from `#/definitions/Variant/properties` | MAJOR |
+| `component.schema.json` | Remove `baseline` property from `#/definitions/Variant/properties` | MAJOR |
+
+**Example — new shape** (`schema/component.schema.json`):
+```yaml
+# Before — #/definitions/Variant/properties
+name:
+  type: string
+baseline:
+  type: string
+configuration:
+  $ref: "#/definitions/PropConfigurations"
+invalid:
+  type: boolean
+# ...
+
+# After — #/definitions/Variant/properties
+configuration:
+  $ref: "#/definitions/PropConfigurations"
+invalid:
+  type: boolean
+# ...
+```
+
+### Notes
+
+- Neither field appears in the `required` array of the `Variant` schema definition, so removal does not affect required-field validation logic.
+- `name` was historically used to hold a human-readable variant label. This responsibility now belongs to the `configuration` object, which fully describes the variant's prop state.
+- `baseline` was intended to identify the baseline variant for diffing but was never populated in output. Baseline determination is an internal processing concern of `specs-from-figma`, not a contract-level concept.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**:
+  - `name` removed from both `types/Variant.ts` (optional field) and `schema/component.schema.json` (`#/definitions/Variant/properties/name`)
+  - `baseline` removed from both `types/Variant.ts` (optional field) and `schema/component.schema.json` (`#/definitions/Variant/properties/baseline`)
+  - Remaining fields (`configuration`, `invalid`, `elements`, `layout`) unchanged in both artifacts
+  - Field count: 6 → 4
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-cli` | None — does not reference `Variant.name` or `Variant.baseline` | Recompile against updated types |
+
+---
+
+## Semver Decision
+
+**Version bump**: `[CURRENT] → [NEXT MAJOR]` (`MAJOR`)
+
+**Justification**: Per Constitution III, removing a field from an exported type is a breaking change and requires a MAJOR version bump. Two fields are removed from `Variant`.
+
+Impact analysis:
+- Consumers that reference `variant.name` or `variant.baseline` will get TypeScript compilation errors (caught at build time)
+- Since neither field is populated in any output, real-world impact is minimal
+- Existing serialized specs do not contain these fields, so schema validation is unaffected in practice
+
+---
+
+## Consequences
+
+### Positive
+
+- `Variant` type accurately reflects its actual output shape — four meaningful fields with no dead weight
+- API surface reduced — consumers are not misled by fields that carry no data
+- Closes [#5](https://github.com/DirectedEdges/specs/issues/5)
+
+### Breaking changes
+
+- TypeScript compilation errors for any code referencing `Variant.name` or `Variant.baseline`
+- Strict schema validation will reject specs containing these fields (though none exist in practice)
+
+### Migration path
+
+- Search codebase for `Variant` references to `name` or `baseline` and remove them
+- No runtime migration needed since fields were never populated

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 036 | Remove `name` and `baseline` from `Variant` | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 036 | Remove `name` and `baseline` from `Variant` | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
@@ -17,6 +16,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 036 | Remove `name` and `baseline` from `Variant` | Remove unused `name` and `baseline` optional fields from `Variant` type and schema (breaking) |
 | 035 | Make Config Properties with Defaults Optional | Make 5 required Config properties optional with defaults; add `ResolvedConfig` type for fully-resolved shape |
 | 033 | Typography fontFamily/fontStyle — Remove Number, Add TokenReference | Fix font fields: remove impossible `number` branch, add `TokenReference` for variable-bound font properties |
 | 032 | Typography leadingTrim — Correct to String Enum | Fix `leadingTrim` from incorrect `number \| "mixed"` to correct `"NONE" \| "CAP_HEIGHT" \| "mixed"` string enum |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `subcomponents.scope` — required when subcomponents is present (default `NESTED`)
 - `DEFAULT_CONFIG` — typed as `ResolvedConfig`; now explicitly includes `slotConstraints: false`, `inferNumberProps: false`; removed `subcomponents` (feature toggle — off by default, matching the Figma plugin)
 
+### Removed
+
+- `Variant.name` — unused optional label; variant identity is fully described by `configuration`
+- `Variant.baseline` — never populated in output; baseline determination is an internal processing concern
+
+### Migration
+
+- `Variant.name` → removed: delete any references; use `Variant.configuration` to identify variants
+- `Variant.baseline` → removed: delete any references; no replacement needed (field was never populated)
+
 
 ## [0.16.0] - 2026-04-05
 

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -367,12 +367,6 @@
       "description": "",
       "examples": [],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "baseline": {
-          "type": "string"
-        },
         "configuration": {
           "$ref": "#/definitions/PropConfigurations"
         },

--- a/packages/schema/tests/Variant.test-d.ts
+++ b/packages/schema/tests/Variant.test-d.ts
@@ -1,0 +1,27 @@
+/**
+ * Type-level tests for Variant.
+ * These files are intentionally never executed — they are compiled with tsc
+ * to assert that the type shape is correct.
+ */
+import type { Variant } from '../types/index.js';
+
+// ─── Valid: Variant with all remaining fields ────────────────────────────────
+
+const full: Variant = {
+  configuration: { size: 'large' },
+  invalid: false,
+  elements: {},
+  layout: [],
+};
+
+// ─── Valid: empty Variant (all fields optional) ──────────────────────────────
+
+const empty: Variant = {};
+
+// ─── Removed fields must not compile ─────────────────────────────────────────
+
+// @ts-expect-error — `name` was removed in ADR 036
+const withName: Variant = { name: 'foo' };
+
+// @ts-expect-error — `baseline` was removed in ADR 036
+const withBaseline: Variant = { baseline: 'bar' };

--- a/packages/schema/types/Variant.ts
+++ b/packages/schema/types/Variant.ts
@@ -11,8 +11,6 @@ export type Variants = Variant[];
  * Represents a single variant of a component.
  */
 export type Variant = {
-  name?: string;
-  baseline?: string;
   configuration?: PropConfigurations;
   invalid?: boolean;
   elements?: Elements;


### PR DESCRIPTION
## Summary

- Remove unused optional `name` and `baseline` fields from `Variant` type and JSON schema
- Neither field was populated in output or consumed by any downstream package
- ADR 036 accepted — all validation gates pass (tsc, schema, type tests)

Closes #5

## Test plan

- [x] TypeScript compilation passes (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON schema validation passes (4/4 schemas)
- [x] Type-level tests compile (`Variant.test-d.ts` confirms removed fields error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)