### PR TITLE
release: @directededges/specs-cli v0.10.1

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-04-14
+
+### Changed
+
+- **Bump `@directededges/specs-from-figma` to ^0.14.1** — Picks up the fix for empty variant filtering in LAYERED mode, where variants with configuration but no element or layout differences were not being excluded when `emptyVariants: false`.
+
 ## [0.10.0] - 2026-04-13
 
 Renames `audit` → `scan`, `sourceDirectory` → `dataDirectory`, and the config file from `.specs.config.yaml` to `specs.config.yaml`. Adds a `--data-dir` flag and makes config format values case-insensitive. Config types now use `ResolvedConfig` for full default guarantees.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.1] - 2026-04-14
 
+Dependency patch: picks up a fix from specs-from-figma for empty variant filtering in LAYERED mode.
+
 ### Changed
 
 - **Bump `@directededges/specs-from-figma` to ^0.14.1** — Picks up the fix for empty variant filtering in LAYERED mode, where variants with configuration but no element or layout differences were not being excluded when `emptyVariants: false`.
+
+### Dependency updates
+
+- **@directededges/specs-from-figma 0.14.1** — Fixes the `emptyVariants: false` filter in LAYERED mode. Previously, variants that had a configuration object but no `elements` array (e.g., variants with only layout differences removed) were incorrectly retained in output. The filter now correctly excludes variants that lack both element and layout differences from their layered baseline.
 
 ## [0.10.0] - 2026-04-13
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Command-line interface for Specs design system operations",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@directededges/specs-schema": "^0.17.0",
-    "@directededges/specs-from-figma": "^0.14.0",
+    "@directededges/specs-from-figma": "^0.14.1",
     "commander": "^11.1.0",
     "fs-extra": "^11.2.0",
     "yaml": "^2.3.4",


### PR DESCRIPTION
## Summary
- Release @directededges/specs-cli v0.10.1
- Compatible with @directededges/specs-schema ^0.17.0 and @directededges/specs-from-figma ^0.14.1
- See packages/cli/CHANGELOG.md for details