### PR TITLE
release: @directededges/specs-cli v0.10.2

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-04-14
+
+Dependency patch: picks up the DTCG-compliant token path separator fix from specs-from-figma.
+
+### Changed
+
+- **Bump `@directededges/specs-from-figma` to ^0.14.2** — Picks up the fix for `$token` path separators violating DTCG character restrictions.
+
+### Dependency updates
+
+- **@directededges/specs-from-figma 0.14.2** — Token references (`$token` values) in TOKEN, TOKEN_NAME, TOKEN_FIGMA_EXTENSIONS, and CUSTOM profiles now use `/` as the path separator instead of `.` (period). The DTCG spec (§5.1.1) prohibits `.` in token and group names, and this aligns all profiles with the existing FIGMA_NAME behavior.
+
 ## [0.10.1] - 2026-04-14
 
 Dependency patch: picks up a fix from specs-from-figma for empty variant filtering in LAYERED mode.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Command-line interface for Specs design system operations",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@directededges/specs-schema": "^0.17.0",
-    "@directededges/specs-from-figma": "^0.14.1",
+    "@directededges/specs-from-figma": "^0.14.2",
     "commander": "^11.1.0",
     "fs-extra": "^11.2.0",
     "yaml": "^2.3.4",


### PR DESCRIPTION
## Summary
- Release @directededges/specs-cli v0.10.2
- Compatible with @directededges/specs-schema ^0.17.0 and @directededges/specs-from-figma ^0.14.2
- See packages/cli/CHANGELOG.md for details