### PR TITLE
ADR 037: Consolidate itemSpacing into bi-axial model

### DIFF
--- a/adr/037-item-spacing.md
+++ b/adr/037-item-spacing.md
@@ -1,0 +1,193 @@
+# ADR: Consolidate Item Spacing into a Bi-Axial Model
+
+**Branch**: `037-item-spacing`
+**Created**: 2026-04-20
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The `Styles` type currently exposes two separate properties for auto-layout gap spacing:
+
+- `itemSpacing` — gap between children along the primary axis
+- `counterAxisSpacing` — gap between wrapped rows/columns (only relevant when `layoutWrap` is enabled)
+
+In Figma's underlying API these are distinct fields (`itemSpacing` and `counterAxisSpacing`), but from a design-system consumer's perspective they represent a single concept: **the gap between items in a layout container**, which may differ between the horizontal and vertical axes.
+
+This mirrors how CSS `gap` works — a single property with `row-gap` and `column-gap` sub-values. The current schema splits this into two unrelated fields with Figma-specific naming (`counterAxisSpacing`) that leaks implementation vocabulary into the shared contract.
+
+---
+
+## Decision Drivers
+
+- **Consumer clarity**: Field names should communicate intent without requiring knowledge of Figma's axis model. `counterAxisSpacing` is opaque to consumers unfamiliar with Figma internals.
+- **Structural coherence**: The schema already uses compound objects for related per-axis/per-side values (`padding` → `Sides`, `cornerRadius` → `Corners`). Spacing should follow the same pattern.
+- **No abbreviations**: Constitution requires full, unabbreviated words. Both `horizontal` and `vertical` satisfy this.
+- **Semver discipline**: Removing `counterAxisSpacing` is a breaking change (field removal). This must be a MAJOR-bump change within this release cycle.
+- **Type ↔ Schema symmetry**: Any structural change must be reflected identically in both `types/Styles.ts` and `schema/styles.schema.json`.
+
+---
+
+## Options Considered
+
+### Option A: Bi-axial `itemSpacing` with `{ horizontal, vertical }` model *(Selected)*
+
+Replace both `itemSpacing: Style` and `counterAxisSpacing: Style` with a single field:
+
+```yaml
+itemSpacing: Style | ItemSpacing
+```
+
+Where `ItemSpacing` is a new interface:
+
+```typescript
+interface ItemSpacing {
+  horizontal?: Style;
+  vertical?: Style;
+}
+```
+
+When spacing is uniform across both axes (or only one axis applies because wrap is off), the value remains a scalar `Style`. When horizontal and vertical gaps differ, the value becomes an `ItemSpacing` object.
+
+This follows the same scalar-or-object pattern used by `padding` (`Style | Sides`) and `cornerRadius` (`Style | Corners`).
+
+**Pros**:
+- Single, well-named property covers both cases
+- Matches CSS mental model (`gap` → `row-gap` / `column-gap`)
+- Eliminates Figma-specific vocabulary (`counterAxis`) from the public contract
+- Follows the established scalar-or-compound pattern already in `Styles`
+
+**Cons / Trade-offs**:
+- Breaking change — consumers using `counterAxisSpacing` must migrate
+- Axis naming (`horizontal` / `vertical`) is absolute rather than relative to layout direction; this is intentional — it maps to the resolved visual direction rather than requiring consumers to reason about primary/counter axis
+
+---
+
+### Option B: Rename `counterAxisSpacing` to `wrapSpacing` *(Rejected)*
+
+Keep two separate fields but rename `counterAxisSpacing` to something more readable:
+
+```yaml
+itemSpacing: Style
+wrapSpacing: Style
+```
+
+**Rejected because**: Still splits a single concept into two fields. Does not follow the scalar-or-compound pattern. Still a MAJOR bump (rename = removal + addition) with less structural benefit.
+
+---
+
+### Option C: Keep current fields as-is *(Rejected)*
+
+Leave `itemSpacing` and `counterAxisSpacing` unchanged.
+
+**Rejected because**: `counterAxisSpacing` violates the naming clarity driver. The field name requires Figma-specific knowledge to understand. Does not leverage the scalar-or-compound pattern the schema already uses for similar concepts.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Styles.ts` | Remove field `counterAxisSpacing: Style` | MAJOR |
+| `Styles.ts` | Change field `itemSpacing` from `Style` to `Style \| ItemSpacing` | MAJOR |
+| `Styles.ts` | Add new interface `ItemSpacing` | MINOR (part of MAJOR) |
+| `Styles.ts` | Update `StylePropertyName` union — remove `'counterAxisSpacing'` | MAJOR |
+
+**Example — new shape** (`types/Styles.ts`):
+
+```yaml
+# Before
+Styles (partial):
+  itemSpacing: Style
+  counterAxisSpacing: Style
+
+# After
+Styles (partial):
+  itemSpacing: Style | ItemSpacing
+
+ItemSpacing:
+  horizontal?: Style   # gap between items along horizontal axis
+  vertical?: Style     # gap between items along vertical axis
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `styles.schema.json` | Remove property `counterAxisSpacing` from `Styles/properties` | MAJOR |
+| `styles.schema.json` | Change `itemSpacing` from `NumberStyleValue` ref to `ItemSpacingStyleValue` (new oneOf) | MAJOR |
+| `styles.schema.json` | Add definition `ItemSpacingValue` (object with optional `horizontal`, `vertical`) | MINOR (part of MAJOR) |
+| `styles.schema.json` | Add definition `ItemSpacingStyleValue` (oneOf: number, ItemSpacingValue, TokenReference, null) | MINOR (part of MAJOR) |
+
+**Example — new shape** (`schema/styles.schema.json`):
+
+```yaml
+# New definition
+ItemSpacingValue:
+  type: object
+  properties:
+    horizontal:
+      $ref: "#/definitions/NumberStyleValue"
+    vertical:
+      $ref: "#/definitions/NumberStyleValue"
+  additionalProperties: false
+
+ItemSpacingStyleValue:
+  description: "Item spacing. Scalar number when uniform; ItemSpacingValue when axes differ."
+  oneOf:
+    - type: number
+    - $ref: "#/definitions/ItemSpacingValue"
+    - $ref: "#/definitions/TokenReference"
+    - type: "null"
+
+# Updated property
+properties.itemSpacing:
+  $ref: "#/definitions/ItemSpacingStyleValue"
+  description: "Gap between items. Scalar when uniform; object with horizontal/vertical when axes differ."
+
+# Removed
+properties.counterAxisSpacing: (deleted)
+```
+
+### Notes
+
+- The `horizontal` / `vertical` naming uses absolute visual axes rather than relative primary/counter terminology. This is consistent with the schema's existing use of absolute directions (e.g., `top`, `end`, `bottom`, `start` in `Sides`).
+- When `layoutWrap` is off, only one axis is meaningful and the value will typically be scalar. The `ItemSpacing` object form only appears when both axes have distinct gap values.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**: `ItemSpacing` interface ↔ `ItemSpacingValue` schema definition; `Style | ItemSpacing` union on `itemSpacing` field ↔ `ItemSpacingStyleValue` oneOf; `counterAxisSpacing` removed from both type and schema simultaneously.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-cli` | Breaking — field rename affects output shape | Update any references to `counterAxisSpacing` in formatting/display logic. Consumers of CLI output must handle the new `itemSpacing` object form. |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.18.0` (`MAJOR` relative to 0.x convention — field removal is breaking)
+
+**Justification**: Removing `counterAxisSpacing` and changing the type of `itemSpacing` from `Style` to `Style | ItemSpacing` constitutes removal and restructuring of existing public API fields. Per constitution III: "Removing or renaming an exported type or a named field within a type is a breaking change and MUST follow semantic versioning." Under 0.x conventions, this is captured by the minor version bump (0.17 → 0.18).
+
+---
+
+## Consequences
+
+- Consumers can represent horizontal and vertical item gaps in a single, coherent property using familiar axis terminology
+- The Figma-specific term `counterAxisSpacing` is eliminated from the public contract
+- All consumers validating against `styles.schema.json` must update to handle the new `itemSpacing` oneOf shape
+- The scalar-or-compound pattern (`Style | CompoundType`) is reinforced as the standard approach for multi-value style properties
+- `specs-from-figma` and `anova-plugin` will need to map Figma's `itemSpacing` + `counterAxisSpacing` fields into the new unified structure (managed by their own release processes)

--- a/adr/037-item-spacing.md
+++ b/adr/037-item-spacing.md
@@ -2,7 +2,7 @@
 
 **Branch**: `037-item-spacing`
 **Created**: 2026-04-20
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 037 | Consolidate Item Spacing into a Bi-Axial Model | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
@@ -17,6 +16,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 037 | Consolidate Item Spacing into a Bi-Axial Model | Replace `itemSpacing` + `counterAxisSpacing` with single `itemSpacing: Style \| ItemSpacing` using `{ horizontal, vertical }` |
 | 036 | Remove `name` and `baseline` from `Variant` | Remove unused `name` and `baseline` optional fields from `Variant` type and schema (breaking) |
 | 035 | Make Config Properties with Defaults Optional | Make 5 required Config properties optional with defaults; add `ResolvedConfig` type for fully-resolved shape |
 | 033 | Typography fontFamily/fontStyle — Remove Number, Add TokenReference | Fix font fields: remove impossible `number` branch, add `TokenReference` for variable-bound font properties |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 037 | Consolidate Item Spacing into a Bi-Axial Model | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,9 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ItemSpacing` — bi-axial spacing interface with optional `horizontal` and `vertical` fields
+- `Styles.itemSpacing` — now accepts `Style | ItemSpacing` (scalar when uniform, object when axes differ)
+
 ### Changed
 
+- `Styles.itemSpacing` — widened from `Style` to `Style | ItemSpacing`
+
 ### Removed
+
+- `Styles.counterAxisSpacing` — consolidated into `Styles.itemSpacing` bi-axial model
+
+### Migration
+
+- `Styles.counterAxisSpacing` → `Styles.itemSpacing.vertical`: read the `vertical` sub-field of the `ItemSpacing` object when axes differ; scalar `itemSpacing` applies uniformly
 
 
 ## [0.17.0] - 2026-04-13

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -43,9 +43,8 @@
         "layoutMode": { "$ref": "#/definitions/StringStyleValue", "description": "Layout mode" },
         "layoutWrap": { "$ref": "#/definitions/StringStyleValue", "description": "Layout wrap mode" },
         "itemReverseZIndex": { "$ref": "#/definitions/BooleanStyleValue", "description": "Reverse z-index stacking" },
-        "itemSpacing": { "$ref": "#/definitions/NumberStyleValue", "description": "Item spacing" },
+        "itemSpacing": { "$ref": "#/definitions/ItemSpacingStyleValue", "description": "Gap between items. Scalar when uniform; object with horizontal/vertical when axes differ." },
         "padding": { "$ref": "#/definitions/SidesStyleValue", "description": "Padding. Scalar when uniform; Sides object when per-side values differ." },
-        "counterAxisSpacing": { "$ref": "#/definitions/NumberStyleValue", "description": "Counter axis spacing" },
         "cornerSmoothing": { "$ref": "#/definitions/NumberStyleValue", "description": "Degree of corner smoothing (0 = standard circular corners, 1 = fully smooth iOS-style squircle). Applies to FRAME, COMPONENT, RECTANGLE, POLYGON, STAR, VECTOR, and ELLIPSE element types." },
         "aspectRatio": { "$ref": "#/definitions/AspectRatioStyleValue", "description": "Aspect ratio constraint. Present only when the node has a locked ratio; omitted otherwise." }
       },
@@ -309,6 +308,24 @@
       "oneOf": [
         { "type": "number" },
         { "$ref": "#/definitions/Corners" },
+        { "$ref": "#/definitions/TokenReference" },
+        { "type": "null" }
+      ]
+    },
+    "ItemSpacing": {
+      "type": "object",
+      "description": "Bi-axial item spacing values using absolute visual axes. Used for itemSpacing when horizontal and vertical gaps differ.",
+      "properties": {
+        "horizontal": { "$ref": "#/definitions/NumberStyleValue", "description": "Horizontal gap between items" },
+        "vertical": { "$ref": "#/definitions/NumberStyleValue", "description": "Vertical gap between items" }
+      },
+      "additionalProperties": false
+    },
+    "ItemSpacingStyleValue": {
+      "description": "Item spacing value. Scalar number when uniform; ItemSpacing object when horizontal and vertical gaps differ; TokenReference for token binding; null when absent.",
+      "oneOf": [
+        { "type": "number" },
+        { "$ref": "#/definitions/ItemSpacing" },
         { "$ref": "#/definitions/TokenReference" },
         { "type": "null" }
       ]

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -7,7 +7,7 @@ import type {
   Styles, Shadow, Blur, Effects, Typography,
   TokenReference, ColorStyle, GradientStop, GradientCenter, LinearGradient, RadialGradient,
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
-  Sides, Corners,
+  Sides, Corners, ItemSpacing,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -478,3 +478,39 @@ const _oldBottomLeftRadius: Styles = { bottomLeftRadius: 4 };
 
 // @ts-expect-error: bottomRightRadius no longer exists on Styles
 const _oldBottomRightRadius: Styles = { bottomRightRadius: 4 };
+
+// ─── ItemSpacing ───────────────────��────────────────────────────────────────
+
+// All keys optional — empty ItemSpacing is valid
+const emptyItemSpacing: ItemSpacing = {};
+
+// Full ItemSpacing with numeric values
+const fullItemSpacing: ItemSpacing = { horizontal: 16, vertical: 8 };
+
+// Individual axes with TokenReference
+const tokenItemSpacing: ItemSpacing = {
+  horizontal: { $token: 'Space.Gap.H', $type: 'dimension' } satisfies TokenReference,
+  vertical: 8,
+};
+
+// null is valid for individual axis (absent/not set)
+const nullAxisSpacing: ItemSpacing = { horizontal: null, vertical: 12 };
+
+// ─── Styles.itemSpacing (scalar or ItemSpacing) ─────────────────────────────
+
+// Scalar number (uniform spacing)
+const uniformItemSpacing: Styles = { itemSpacing: 16 };
+
+// ItemSpacing object (per-axis)
+const perAxisItemSpacing: Styles = { itemSpacing: { horizontal: 16, vertical: 8 } };
+
+// TokenReference for itemSpacing
+const tokenItemSpacingStyle: Styles = {
+  itemSpacing: { $token: 'Space.Gap', $type: 'dimension' } satisfies TokenReference,
+};
+
+// null is valid
+const nullItemSpacing: Styles = { itemSpacing: null };
+
+// @ts-expect-error: counterAxisSpacing no longer exists on Styles
+const _oldCounterAxisSpacing: Styles = { counterAxisSpacing: 8 };

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -41,10 +41,10 @@ export type Styles = Partial<{
   layoutMode: Style;
   layoutWrap: Style;
   itemReverseZIndex: Style;
-  itemSpacing: Style;
+  /** Item spacing. Scalar when uniform; `ItemSpacing` object when horizontal and vertical gaps differ. @since 0.18.0 */
+  itemSpacing: Style | ItemSpacing;
   /** Padding. Scalar when uniform; `Sides` object when per-side values differ. @since 1.0.0 */
   padding: Style | Sides;
-  counterAxisSpacing: Style;
   cornerSmoothing: Style;
   aspectRatio: AspectRatioStyle;
 }>;
@@ -197,6 +197,19 @@ export interface Sides {
 }
 
 /**
+ * Bi-axial item spacing values using absolute visual axes.
+ * Used for `itemSpacing` when horizontal and vertical gaps differ.
+ * Each field is optional; only axes that differ from the collapsed value are present.
+ * @since 0.18.0
+ */
+export interface ItemSpacing {
+  /** Horizontal gap between items */
+  horizontal?: Style;
+  /** Vertical gap between items */
+  vertical?: Style;
+}
+
+/**
  * Per-corner values using logical inline-axis directions (`topStart`/`topEnd`/`bottomStart`/`bottomEnd`).
  * Used for `cornerRadius` when corners differ.
  * Each field is optional; only corners that differ from the collapsed value are present.
@@ -253,6 +266,5 @@ export type StyleKey =
   | 'itemReverseZIndex'
   | 'itemSpacing'
   | 'padding'
-  | 'counterAxisSpacing'
   | 'cornerSmoothing'
   | 'aspectRatio';

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -25,7 +25,7 @@ export type { Config, ResolvedConfig } from './Config.js';
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 


### PR DESCRIPTION
## Summary

- Replaces `itemSpacing` + `counterAxisSpacing` with a single `itemSpacing: Style | ItemSpacing`
- New `ItemSpacing` interface with optional `horizontal` and `vertical` fields
- Follows the established scalar-or-compound pattern (like `padding`/`Sides`, `cornerRadius`/`Corners`)
- BREAKING: `counterAxisSpacing` removed from `Styles` type and schema

## Test plan

- [x] TypeScript compilation passes (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON schema files are valid
- [x] Type-check tests pass (`tsc --noEmit --strict tests/*.test-d.ts`)
- [x] `@ts-expect-error` confirms `counterAxisSpacing` no longer compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)