### PR TITLE
ADR 038: Tighten layoutMode to string literal enum

### DIFF
--- a/adr/038-layout-mode-enum.md
+++ b/adr/038-layout-mode-enum.md
@@ -2,7 +2,7 @@
 
 **Branch**: `038-layout-mode-enum`
 **Created**: 2026-04-20
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/038-layout-mode-enum.md
+++ b/adr/038-layout-mode-enum.md
@@ -1,0 +1,164 @@
+# ADR: Tighten layoutMode to String Literal Enum
+
+**Branch**: `038-layout-mode-enum`
+**Created**: 2026-04-20
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The `Styles` type currently defines `layoutMode` as `Style`, which is the broadest value union in the schema — accepting string, number, boolean, null, `TokenReference`, `PropBinding`, and `Conditional`. In the JSON schema, it maps to `StringStyleValue` (string | TokenReference | null).
+
+In practice, `layoutMode` only ever holds one of three Figma API values:
+- `"NONE"` — no auto-layout
+- `"HORIZONTAL"` — horizontal auto-layout
+- `"VERTICAL"` — vertical auto-layout
+
+This field is a structural layout declaration, not a visual property. It is never token-bound (you don't reference a variable for "should this be a row or column"), never prop-bound, and never conditional. The current loose typing allows impossible values that no producer will ever emit.
+
+---
+
+## Decision Drivers
+
+- **Type precision**: The public contract should reflect the actual value domain. Accepting `number`, `boolean`, `PropBinding`, or `Conditional` for a layout direction enum is misleading.
+- **Consumer safety**: Narrowing the type lets consumers exhaustively switch on the three values without needing a fallback for impossible branches.
+- **Schema as documentation**: An `enum` constraint in the JSON schema is self-documenting — consumers can read the allowed values directly from the schema without consulting Figma docs.
+- **TokenReference exclusion**: Layout mode is a structural property (like `aspectRatio`). Figma does not support variable-binding for `layoutMode`. Excluding `TokenReference` is accurate to the data model.
+- **Semver discipline**: Narrowing a type from `Style` to a string literal union is a breaking change — existing consumers that type-check against the broader union will get compile errors.
+
+---
+
+## Options Considered
+
+### Option A: Narrow to `LayoutMode | null` with enum type *(Selected)*
+
+Replace `layoutMode: Style` with a dedicated type:
+
+```typescript
+type LayoutMode = 'NONE' | 'HORIZONTAL' | 'VERTICAL';
+```
+
+And the field becomes:
+
+```yaml
+layoutMode: LayoutMode | null
+```
+
+In the schema, replace the `StringStyleValue` ref with a dedicated `LayoutModeStyleValue` using a string enum.
+
+**Pros**:
+- Precise — only valid values are representable
+- Self-documenting enum in the schema
+- Enables exhaustive pattern matching in consumers
+- Consistent with `aspectRatio` pattern (structural property, no TokenReference)
+
+**Cons / Trade-offs**:
+- Breaking change — consumers typed against `Style` will need to update
+- If Figma ever adds a new layout mode value, the enum must be updated (low risk — this API has been stable since auto-layout was introduced)
+
+---
+
+### Option B: Keep `StringStyleValue` but add `enum` constraint in schema only *(Rejected)*
+
+Leave the TypeScript type as `Style` but add an `enum` constraint in the JSON schema.
+
+**Rejected because**: Creates drift between types and schema. The TypeScript type would still accept impossible values while the schema rejects them. Violates constitution principle I (types and schema must describe the same structure).
+
+---
+
+### Option C: Keep current type as-is *(Rejected)*
+
+Leave `layoutMode: Style` unchanged.
+
+**Rejected because**: Allows impossible values (numbers, booleans, conditionals) that no producer will ever emit. Misses an opportunity for type precision that benefits all consumers.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Styles.ts` | Change field `layoutMode` from `Style` to `LayoutMode \| null` | MAJOR |
+| `Styles.ts` | Add new type `LayoutMode = 'NONE' \| 'HORIZONTAL' \| 'VERTICAL'` | MINOR (part of MAJOR) |
+
+**Example — new shape** (`types/Styles.ts`):
+
+```yaml
+# Before
+Styles (partial):
+  layoutMode: Style
+
+# After
+Styles (partial):
+  layoutMode: LayoutMode | null
+
+LayoutMode: 'NONE' | 'HORIZONTAL' | 'VERTICAL'
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `styles.schema.json` | Change `layoutMode` from `StringStyleValue` ref to `LayoutModeStyleValue` | MAJOR |
+| `styles.schema.json` | Add definition `LayoutModeStyleValue` (oneOf: enum string, null) | MINOR (part of MAJOR) |
+
+**Example — new shape** (`schema/styles.schema.json`):
+
+```yaml
+# New definition
+LayoutModeStyleValue:
+  description: "Layout mode. Structural property — not token-bindable."
+  oneOf:
+    - type: string
+      enum: ["NONE", "HORIZONTAL", "VERTICAL"]
+    - type: "null"
+
+# Updated property
+properties.layoutMode:
+  $ref: "#/definitions/LayoutModeStyleValue"
+  description: "Auto-layout direction. NONE (no auto-layout), HORIZONTAL (row), or VERTICAL (column)."
+```
+
+### Notes
+
+- `null` is retained because `layoutMode` is optional on `Styles` (it's `Partial<{...}>`), and the schema allows null for absent/omitted values.
+- `TokenReference` is intentionally excluded — Figma does not support variable-binding for layout mode. This matches the `AspectRatioStyle` precedent.
+- The `StyleKey` union is unchanged — `'layoutMode'` remains a valid key.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**: `LayoutMode` type literal union ↔ `LayoutModeStyleValue` schema enum constraint; null allowed in both; TokenReference excluded from both.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-cli` | Breaking — type narrows from `Style` to `LayoutMode \| null` | Update any code that handles `layoutMode` as a generic `Style`. The narrower type simplifies display logic (no token/binding branches needed). |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.18.0` (`MAJOR` relative to 0.x convention — type narrowing is breaking)
+
+**Justification**: Narrowing `layoutMode` from `Style` to `LayoutMode | null` removes previously valid type branches (TokenReference, PropBinding, Conditional, number, boolean). Per constitution III: removing valid values from a field type is a breaking change. Under 0.x conventions, this is captured within the existing 0.18.0 minor bump.
+
+---
+
+## Consequences
+
+- Consumers can exhaustively match on `'NONE' | 'HORIZONTAL' | 'VERTICAL'` without impossible-value fallbacks
+- The schema is self-documenting — allowed values are visible in the enum constraint
+- `TokenReference` is excluded, accurately reflecting that layout mode cannot be variable-bound in Figma
+- If Figma adds a new layout mode in the future, both the type and schema must be updated (acceptable maintenance cost for a rarely-changing structural enum)
+- Pattern established for tightening other structural string properties (e.g., `layoutWrap`, `layoutPositioning`) in future ADRs

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 038 | Tighten layoutMode to String Literal Enum | |
 | 037 | Consolidate Item Spacing into a Bi-Axial Model | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
@@ -18,6 +17,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 038 | Tighten layoutMode to String Literal Enum | Narrow `layoutMode` from `Style` to `LayoutMode \| null` (`'NONE' \| 'HORIZONTAL' \| 'VERTICAL'`); exclude TokenReference |
 | 037 | Consolidate Item Spacing into a Bi-Axial Model | Replace `itemSpacing` + `counterAxisSpacing` with single `itemSpacing: Style \| ItemSpacing` using `{ horizontal, vertical }` |
 | 036 | Remove `name` and `baseline` from `Variant` | Remove unused `name` and `baseline` optional fields from `Variant` type and schema (breaking) |
 | 035 | Make Config Properties with Defaults Optional | Make 5 required Config properties optional with defaults; add `ResolvedConfig` type for fully-resolved shape |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 038 | Tighten layoutMode to String Literal Enum | |
 | 037 | Consolidate Item Spacing into a Bi-Axial Model | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ItemSpacing` — bi-axial spacing interface with optional `horizontal` and `vertical` fields
 - `Styles.itemSpacing` — now accepts `Style | ItemSpacing` (scalar when uniform, object when axes differ)
+- `LayoutMode` — string literal union type (`'NONE' | 'HORIZONTAL' | 'VERTICAL'`)
 
 ### Changed
 
 - `Styles.itemSpacing` — widened from `Style` to `Style | ItemSpacing`
+- `Styles.layoutMode` — narrowed from `Style` to `LayoutMode | null` (enum constraint, no TokenReference)
 
 ### Removed
 
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Migration
 
 - `Styles.counterAxisSpacing` → `Styles.itemSpacing.vertical`: read the `vertical` sub-field of the `ItemSpacing` object when axes differ; scalar `itemSpacing` applies uniformly
+- `Styles.layoutMode` → `LayoutMode | null`: replace generic `Style` handling with exhaustive match on `'NONE' | 'HORIZONTAL' | 'VERTICAL'`
 
 
 ## [0.17.0] - 2026-04-13

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -40,7 +40,7 @@
         "primaryAxisSizingMode": { "$ref": "#/definitions/StringStyleValue", "description": "Primary axis sizing mode" },
         "counterAxisAlignItems": { "$ref": "#/definitions/StringStyleValue", "description": "Counter axis item alignment" },
         "counterAxisAlignContent": { "$ref": "#/definitions/StringStyleValue", "description": "Counter axis content alignment" },
-        "layoutMode": { "$ref": "#/definitions/StringStyleValue", "description": "Layout mode" },
+        "layoutMode": { "$ref": "#/definitions/LayoutModeStyleValue", "description": "Auto-layout direction. NONE (no auto-layout), HORIZONTAL (row), or VERTICAL (column)." },
         "layoutWrap": { "$ref": "#/definitions/StringStyleValue", "description": "Layout wrap mode" },
         "itemReverseZIndex": { "$ref": "#/definitions/BooleanStyleValue", "description": "Reverse z-index stacking" },
         "itemSpacing": { "$ref": "#/definitions/ItemSpacingStyleValue", "description": "Gap between items. Scalar when uniform; object with horizontal/vertical when axes differ." },
@@ -327,6 +327,13 @@
         { "type": "number" },
         { "$ref": "#/definitions/ItemSpacing" },
         { "$ref": "#/definitions/TokenReference" },
+        { "type": "null" }
+      ]
+    },
+    "LayoutModeStyleValue": {
+      "description": "Layout mode value. Structural property — not token-bindable.",
+      "oneOf": [
+        { "type": "string", "enum": ["NONE", "HORIZONTAL", "VERTICAL"] },
         { "type": "null" }
       ]
     },

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -7,7 +7,7 @@ import type {
   Styles, Shadow, Blur, Effects, Typography,
   TokenReference, ColorStyle, GradientStop, GradientCenter, LinearGradient, RadialGradient,
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
-  Sides, Corners, ItemSpacing,
+  Sides, Corners, ItemSpacing, LayoutMode,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -514,3 +514,35 @@ const nullItemSpacing: Styles = { itemSpacing: null };
 
 // @ts-expect-error: counterAxisSpacing no longer exists on Styles
 const _oldCounterAxisSpacing: Styles = { counterAxisSpacing: 8 };
+
+// ─── LayoutMode ─────────────────────────────────────────────────────────────
+
+// Valid enum values
+const _lmNone: LayoutMode = 'NONE';
+const _lmHorizontal: LayoutMode = 'HORIZONTAL';
+const _lmVertical: LayoutMode = 'VERTICAL';
+
+// @ts-expect-error: arbitrary string is not valid LayoutMode
+const _lmBad: LayoutMode = 'GRID';
+
+// @ts-expect-error: number is not valid LayoutMode
+const _lmNumber: LayoutMode = 0;
+
+// ─── Styles.layoutMode (LayoutMode | null) ──────────────────────────────────
+
+// Valid enum values on Styles
+const withLayoutNone: Styles = { layoutMode: 'NONE' };
+const withLayoutHorizontal: Styles = { layoutMode: 'HORIZONTAL' };
+const withLayoutVertical: Styles = { layoutMode: 'VERTICAL' };
+
+// null is valid
+const withLayoutNull: Styles = { layoutMode: null };
+
+// @ts-expect-error: TokenReference is not valid for layoutMode (not token-bindable)
+const _lmToken: Styles = { layoutMode: { $token: 'Layout.Mode', $type: 'string' } satisfies TokenReference };
+
+// @ts-expect-error: number is not valid for layoutMode
+const _lmStyleNumber: Styles = { layoutMode: 1 };
+
+// @ts-expect-error: arbitrary string is not valid for layoutMode
+const _lmArbitrary: Styles = { layoutMode: 'ROW' };

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -38,7 +38,8 @@ export type Styles = Partial<{
   primaryAxisSizingMode: Style;
   counterAxisAlignItems: Style;
   counterAxisAlignContent: Style;
-  layoutMode: Style;
+  /** Auto-layout direction. Structural property — not token-bindable. @since 0.18.0 */
+  layoutMode: LayoutMode | null;
   layoutWrap: Style;
   itemReverseZIndex: Style;
   /** Item spacing. Scalar when uniform; `ItemSpacing` object when horizontal and vertical gaps differ. @since 0.18.0 */
@@ -195,6 +196,12 @@ export interface Sides {
   /** Inline-start value (left in LTR, right in RTL) */
   start?: Style;
 }
+
+/**
+ * Auto-layout direction mode. Structural property that cannot be token-bound.
+ * @since 0.18.0
+ */
+export type LayoutMode = 'NONE' | 'HORIZONTAL' | 'VERTICAL';
 
 /**
  * Bi-axial item spacing values using absolute visual axes.

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -25,7 +25,7 @@ export type { Config, ResolvedConfig } from './Config.js';
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 


### PR DESCRIPTION
## Summary

- Narrows `layoutMode` from general `Style` to `LayoutMode | null` (`'NONE' | 'HORIZONTAL' | 'VERTICAL'`)
- Adds `LayoutModeStyleValue` schema definition with string enum constraint
- Excludes `TokenReference` — layout mode is structural, not token-bindable (same precedent as `aspectRatio`)
- BREAKING: consumers typed against `Style` for `layoutMode` must update

## Test plan

- [x] TypeScript compilation passes (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON schema is valid
- [x] Type-check tests pass — valid enum values compile, invalid values (`TokenReference`, numbers, arbitrary strings) produce `@ts-expect-error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)