### PR TITLE
ADR 040: Replace alignment fields with mainAxisAlignment / crossAxisAlignment

### DIFF
--- a/adr/040-layout-alignment.md
+++ b/adr/040-layout-alignment.md
@@ -183,8 +183,6 @@ CrossAxisAlignmentStyleValue:
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
 | `specs-cli` | Recompile | Update any references to `primaryAxisAlignItems` → `mainAxisAlignment` and `counterAxisAlignItems` → `crossAxisAlignment` in output formatting or display logic |
-| `specs-from-figma` | Update value mapping | Map Figma `primaryAxisAlignItems` values (`MIN` → `START`, `MAX` → `END`) and `counterAxisAlignItems` values (`MIN` → `START`, `MAX` → `END`) to new field names and enum values |
-| `specs-plugin` | Update value mapping | Same Figma-to-schema mapping changes as `specs-from-figma` |
 
 ---
 

--- a/adr/040-layout-alignment.md
+++ b/adr/040-layout-alignment.md
@@ -2,7 +2,7 @@
 
 **Branch**: `040-layout-alignment`
 **Created**: 2026-04-23
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 040 | Replace `primaryAxisAlignItems` and `counterAxisAlignItems` with `mainAxisAlignment` and `crossAxisAlignment` | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
@@ -17,6 +16,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 040 | Replace `primaryAxisAlignItems` and `counterAxisAlignItems` with `mainAxisAlignment` and `crossAxisAlignment` | Rename to platform-neutral names; add `MainAxisAlignment` and `CrossAxisAlignment` enums; not token-bindable |
 | 039 | Replace `layoutWrap` and `counterAxisAlignContent` with `wrap` and `wrapAlignment` | Rename to platform-neutral names; add `WrapAlignment` enum (`START \| SPACE_BETWEEN`); not token-bindable |
 | 038 | Tighten layoutMode to String Literal Enum | Narrow `layoutMode` from `Style` to `LayoutMode \| null` (`'NONE' \| 'HORIZONTAL' \| 'VERTICAL'`); exclude TokenReference |
 | 037 | Consolidate Item Spacing into a Bi-Axial Model | Replace `itemSpacing` + `counterAxisSpacing` with single `itemSpacing: Style \| ItemSpacing` using `{ horizontal, vertical }` |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Styles.itemSpacing` — now accepts `Style | ItemSpacing` (scalar when uniform, object when axes differ)
 - `Styles.wrap` — boolean toggle for auto-layout wrapping (replaces `layoutWrap`)
 - `Styles.wrapAlignment` — typed as `WrapAlignment | null`; structural property, not token-bindable (replaces `counterAxisAlignContent`)
+- `MainAxisAlignment` — string literal union type (`'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN'`)
+- `CrossAxisAlignment` — string literal union type (`'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASELINE'`)
+- `Styles.mainAxisAlignment` — typed as `MainAxisAlignment | null`; structural property, not token-bindable (replaces `primaryAxisAlignItems`)
+- `Styles.crossAxisAlignment` — typed as `CrossAxisAlignment | null`; structural property, not token-bindable (replaces `counterAxisAlignItems`)
 
 ### Changed
 
@@ -26,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Styles.counterAxisSpacing` — consolidated into `Styles.itemSpacing` bi-axial model
 - `Styles.layoutWrap` — replaced by `Styles.wrap`
 - `Styles.counterAxisAlignContent` — replaced by `Styles.wrapAlignment`
+- `Styles.primaryAxisAlignItems` — replaced by `Styles.mainAxisAlignment`
+- `Styles.counterAxisAlignItems` — replaced by `Styles.crossAxisAlignment`
 
 ### Migration
 
@@ -33,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Styles.layoutMode` → `LayoutMode | null`: replace generic `Style` handling with exhaustive match on `'NONE' | 'HORIZONTAL' | 'VERTICAL'`
 - `Styles.layoutWrap` → `Styles.wrap`: rename only; same boolean semantics
 - `Styles.counterAxisAlignContent` → `Styles.wrapAlignment`: rename and remap values — `'AUTO'` → `'START'`, `'SPACE_BETWEEN'` → `'SPACE_BETWEEN'`
+- `Styles.primaryAxisAlignItems` → `Styles.mainAxisAlignment`: rename and narrow type — replace generic `Style` handling with exhaustive match on `'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN'`; remap Figma values `'MIN'` → `'START'`, `'MAX'` → `'END'`
+- `Styles.counterAxisAlignItems` → `Styles.crossAxisAlignment`: rename and narrow type — replace generic `Style` handling with exhaustive match on `'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASELINE'`; remap Figma values `'MIN'` → `'START'`, `'MAX'` → `'END'`
 
 
 ## [0.17.0] - 2026-04-13

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -36,9 +36,9 @@
         "typography": { "$ref": "#/definitions/TypographyStyleValue", "description": "Typography properties. TokenReference when the node references a named text style; Typography when defined inline." },
         "textAlignHorizontal": { "$ref": "#/definitions/StringStyleValue", "description": "Horizontal text alignment" },
         "textAlignVertical": { "$ref": "#/definitions/StringStyleValue", "description": "Vertical text alignment" },
-        "primaryAxisAlignItems": { "$ref": "#/definitions/StringStyleValue", "description": "Primary axis item alignment" },
+        "mainAxisAlignment": { "$ref": "#/definitions/MainAxisAlignmentStyleValue", "description": "Alignment along the main axis (depends on layoutMode). Structural property — not token-bindable." },
         "primaryAxisSizingMode": { "$ref": "#/definitions/StringStyleValue", "description": "Primary axis sizing mode" },
-        "counterAxisAlignItems": { "$ref": "#/definitions/StringStyleValue", "description": "Counter axis item alignment" },
+        "crossAxisAlignment": { "$ref": "#/definitions/CrossAxisAlignmentStyleValue", "description": "Alignment along the cross axis (perpendicular to layoutMode). Structural property — not token-bindable." },
         "layoutMode": { "$ref": "#/definitions/LayoutModeStyleValue", "description": "Auto-layout direction. NONE (no auto-layout), HORIZONTAL (row), or VERTICAL (column)." },
         "wrap": { "$ref": "#/definitions/BooleanStyleValue", "description": "Whether auto-layout wrapping is enabled (default: false)." },
         "wrapAlignment": { "$ref": "#/definitions/WrapAlignmentStyleValue", "description": "Space distribution between wrapped lines. Only meaningful when wrap is true." },
@@ -341,6 +341,20 @@
       "description": "Wrap alignment value. Structural property — not token-bindable.",
       "oneOf": [
         { "type": "string", "enum": ["START", "SPACE_BETWEEN"] },
+        { "type": "null" }
+      ]
+    },
+    "MainAxisAlignmentStyleValue": {
+      "description": "Main axis alignment value. Structural property — not token-bindable.",
+      "oneOf": [
+        { "type": "string", "enum": ["START", "END", "CENTER", "SPACE_BETWEEN"] },
+        { "type": "null" }
+      ]
+    },
+    "CrossAxisAlignmentStyleValue": {
+      "description": "Cross axis alignment value. Structural property — not token-bindable.",
+      "oneOf": [
+        { "type": "string", "enum": ["START", "END", "CENTER", "STRETCH", "BASELINE"] },
         { "type": "null" }
       ]
     },

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -8,6 +8,7 @@ import type {
   TokenReference, ColorStyle, GradientStop, GradientCenter, LinearGradient, RadialGradient,
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
+  MainAxisAlignment, CrossAxisAlignment,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -601,3 +602,87 @@ const _oldLayoutWrap: Styles = { layoutWrap: true };
 
 // @ts-expect-error: counterAxisAlignContent no longer exists on Styles
 const _oldCounterAxisAlign: Styles = { counterAxisAlignContent: 'AUTO' };
+
+// ─── MainAxisAlignment ──────────────────────────────────────────────────────
+
+// Valid enum values
+const _maStart: MainAxisAlignment = 'START';
+const _maEnd: MainAxisAlignment = 'END';
+const _maCenter: MainAxisAlignment = 'CENTER';
+const _maSpaceBetween: MainAxisAlignment = 'SPACE_BETWEEN';
+
+// @ts-expect-error: arbitrary string is not valid MainAxisAlignment
+const _maBad: MainAxisAlignment = 'STRETCH';
+
+// @ts-expect-error: number is not valid MainAxisAlignment
+const _maNumber: MainAxisAlignment = 0;
+
+// @ts-expect-error: lowercase is not valid (SCREAMING_CASE required)
+const _maLowercase: MainAxisAlignment = 'center';
+
+// ─── CrossAxisAlignment ─────────────────────────────────────────────────────
+
+// Valid enum values
+const _caStart: CrossAxisAlignment = 'START';
+const _caEnd: CrossAxisAlignment = 'END';
+const _caCenter: CrossAxisAlignment = 'CENTER';
+const _caStretch: CrossAxisAlignment = 'STRETCH';
+const _caBaseline: CrossAxisAlignment = 'BASELINE';
+
+// @ts-expect-error: arbitrary string is not valid CrossAxisAlignment
+const _caBad: CrossAxisAlignment = 'SPACE_BETWEEN';
+
+// @ts-expect-error: number is not valid CrossAxisAlignment
+const _caNumber: CrossAxisAlignment = 0;
+
+// @ts-expect-error: lowercase is not valid (SCREAMING_CASE required)
+const _caLowercase: CrossAxisAlignment = 'stretch';
+
+// ─── Styles.mainAxisAlignment (MainAxisAlignment | null) ─────────────────────
+
+// Valid enum values on Styles
+const withMainStart: Styles = { mainAxisAlignment: 'START' };
+const withMainEnd: Styles = { mainAxisAlignment: 'END' };
+const withMainCenter: Styles = { mainAxisAlignment: 'CENTER' };
+const withMainSpaceBetween: Styles = { mainAxisAlignment: 'SPACE_BETWEEN' };
+
+// null is valid
+const withMainNull: Styles = { mainAxisAlignment: null };
+
+// @ts-expect-error: TokenReference is not valid for mainAxisAlignment (not token-bindable)
+const _maToken: Styles = { mainAxisAlignment: { $token: 'Layout.Align', $type: 'string' } satisfies TokenReference };
+
+// @ts-expect-error: number is not valid for mainAxisAlignment
+const _maStyleNumber: Styles = { mainAxisAlignment: 1 };
+
+// @ts-expect-error: arbitrary string is not valid for mainAxisAlignment
+const _maArbitrary: Styles = { mainAxisAlignment: 'MIN' };
+
+// ─── Styles.crossAxisAlignment (CrossAxisAlignment | null) ───────────────────
+
+// Valid enum values on Styles
+const withCrossStart: Styles = { crossAxisAlignment: 'START' };
+const withCrossEnd: Styles = { crossAxisAlignment: 'END' };
+const withCrossCenter: Styles = { crossAxisAlignment: 'CENTER' };
+const withCrossStretch: Styles = { crossAxisAlignment: 'STRETCH' };
+const withCrossBaseline: Styles = { crossAxisAlignment: 'BASELINE' };
+
+// null is valid
+const withCrossNull: Styles = { crossAxisAlignment: null };
+
+// @ts-expect-error: TokenReference is not valid for crossAxisAlignment (not token-bindable)
+const _caToken: Styles = { crossAxisAlignment: { $token: 'Layout.CrossAlign', $type: 'string' } satisfies TokenReference };
+
+// @ts-expect-error: number is not valid for crossAxisAlignment
+const _caStyleNumber: Styles = { crossAxisAlignment: 1 };
+
+// @ts-expect-error: arbitrary string is not valid for crossAxisAlignment
+const _caArbitrary: Styles = { crossAxisAlignment: 'MAX' };
+
+// ─── Verify primaryAxisAlignItems and counterAxisAlignItems removed ──────────
+
+// @ts-expect-error: primaryAxisAlignItems no longer exists on Styles
+const _oldPrimaryAxis: Styles = { primaryAxisAlignItems: 'MIN' };
+
+// @ts-expect-error: counterAxisAlignItems no longer exists on Styles
+const _oldCounterAxis: Styles = { counterAxisAlignItems: 'MIN' };

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -34,9 +34,11 @@ export type Styles = Partial<{
   textAlignHorizontal: Style;
   textAlignVertical: Style;
   textColor: ColorStyle;
-  primaryAxisAlignItems: Style;
+  /** Alignment along the main axis (depends on `layoutMode`). Structural property — not token-bindable. @since 0.18.0 */
+  mainAxisAlignment: MainAxisAlignment | null;
   primaryAxisSizingMode: Style;
-  counterAxisAlignItems: Style;
+  /** Alignment along the cross axis (perpendicular to `layoutMode`). Structural property — not token-bindable. @since 0.18.0 */
+  crossAxisAlignment: CrossAxisAlignment | null;
   /** Auto-layout direction. Structural property — not token-bindable. @since 0.18.0 */
   layoutMode: LayoutMode | null;
   /** Whether auto-layout wrapping is enabled (default: false). @since 0.18.0 */
@@ -213,6 +215,22 @@ export type LayoutMode = 'NONE' | 'HORIZONTAL' | 'VERTICAL';
 export type WrapAlignment = 'START' | 'SPACE_BETWEEN';
 
 /**
+ * Main axis alignment mode for auto-layout containers.
+ * Controls alignment along the primary axis (depends on `layoutMode`).
+ * Structural property that cannot be token-bound.
+ * @since 0.18.0
+ */
+export type MainAxisAlignment = 'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN';
+
+/**
+ * Cross axis alignment mode for auto-layout containers.
+ * Controls alignment perpendicular to the primary axis (depends on `layoutMode`).
+ * Structural property that cannot be token-bound.
+ * @since 0.18.0
+ */
+export type CrossAxisAlignment = 'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASELINE';
+
+/**
  * Bi-axial item spacing values using absolute visual axes.
  * Used for `itemSpacing` when horizontal and vertical gaps differ.
  * Each field is optional; only axes that differ from the collapsed value are present.
@@ -273,9 +291,9 @@ export type StyleKey =
   | 'textAlignHorizontal'
   | 'textAlignVertical'
   | 'textColor'
-  | 'primaryAxisAlignItems'
+  | 'mainAxisAlignment'
   | 'primaryAxisSizingMode'
-  | 'counterAxisAlignItems'
+  | 'crossAxisAlignment'
   | 'layoutMode'
   | 'wrap'
   | 'wrapAlignment'

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -25,7 +25,7 @@ export type { Config, ResolvedConfig } from './Config.js';
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 


### PR DESCRIPTION
## Summary

- Rename `primaryAxisAlignItems` → `mainAxisAlignment` and `counterAxisAlignItems` → `crossAxisAlignment` on `Styles`
- Narrow both from generic `Style` to dedicated enum types (`MainAxisAlignment | null`, `CrossAxisAlignment | null`)
- Add `MainAxisAlignmentStyleValue` and `CrossAxisAlignmentStyleValue` schema definitions
- Follow the `LayoutMode` / `WrapAlignment` precedent for structural layout enums (not token-bindable)

## Test plan

- [x] TypeScript compilation passes (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON Schema validation passes (4/4 schemas valid)
- [x] Type tests compile (`tests/Styles.test-d.ts` — enum values, `@ts-expect-error` for removed fields and invalid values)
- [x] Review diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)