### PR TITLE
release: @directededges/specs-cli v0.12.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-04-24
+
+Dependency update: picks up specs-schema 0.18.0 layout property renames and specs-from-figma 0.15.0 bi-axial spacing model.
+
+### Dependency updates
+
+- **@directededges/specs-schema 0.18.0** — Layout alignment properties renamed from Figma axis terminology to platform-neutral names: `primaryAxisAlignItems` → `mainAxisAlignment`, `counterAxisAlignItems` → `crossAxisAlignment`, `counterAxisAlignContent` → `wrapAlignment`, `layoutWrap` → `wrap`. `counterAxisSpacing` consolidated into a bi-axial `itemSpacing` model. `layoutMode` narrowed from generic style to strict `'NONE' | 'HORIZONTAL' | 'VERTICAL'` enum.
+- **@directededges/specs-from-figma 0.15.0** — Wrap-enabled auto-layout frames now emit bi-axial `itemSpacing` with `horizontal`/`vertical` fields instead of separate `itemSpacing`/`counterAxisSpacing` keys. Alignment values remapped from Figma terminology (`MIN` → `START`, `MAX` → `END`). `wrapAlignment` is only emitted when `wrap: true`, stripped as dead otherwise.
+
 ## [0.11.0] - 2026-04-16
 
 Fix: config file split options (`splitComponents`, `splitConcerns`, `useSubfolders`) were ignored because Commander's explicit `false` default shadowed the config values. Also makes `generate` and `scan` runnable with zero arguments using a default file path derived from config.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Command-line interface for Specs design system operations",
   "type": "module",
   "main": "./dist/index.js",
@@ -20,8 +20,8 @@
     "test": "cd ../.. && vitest -c vitest.config.ts packages/cli/tests"
   },
   "dependencies": {
-    "@directededges/specs-schema": "^0.17.0",
-    "@directededges/specs-from-figma": "^0.14.2",
+    "@directededges/specs-schema": "^0.18.0",
+    "@directededges/specs-from-figma": "^0.15.0",
     "commander": "^11.1.0",
     "fs-extra": "^11.2.0",
     "yaml": "^2.3.4",


### PR DESCRIPTION
## Summary
- Release @directededges/specs-cli v0.12.0
- Compatible with @directededges/specs-schema ^0.18.0 and @directededges/specs-from-figma ^0.15.0
- See packages/cli/CHANGELOG.md for details