### PR TITLE
ADR 041: Constraint-based layout positioning

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -53,6 +53,7 @@ Rationale: These types are a published contract. Loose typing undermines compila
 
 - **Naming — no abbreviations**: Type names, field names, schema properties, and API identifiers MUST use full, unabbreviated words. Prefer `Operation` over `Op`, `Button` over `Btn`, `Configuration` over `Config`. Clarity takes priority over brevity in the public contract. Accepted exceptions: `Config` (grandfathered), `args` (universally understood shorthand for arguments).
 - **Naming — enum casing in Styles**: String literal union types used as enum values in `Styles` and its child types (`Typography`, `Gradient`, `Effects`) MUST use `SCREAMING_CASE` (e.g., `'NONE'`, `'HORIZONTAL'`, `'SPACE_BETWEEN'`). Exception: values defined by external standards (e.g., DTCG `$type` values like `'color'`, CSS Color Level 4 color spaces like `'srgb'`) preserve their standard's casing.
+- **Typing — structural enums vs. `Style`**: When a `Styles` property has a closed, known set of values and is **not token-bindable** (i.e., the value is structural or computed — never a `TokenReference`, `PropBinding`, or `Conditional`), it MUST be typed as a named type rather than `Style`. For string enums, define a string literal union (e.g., `LayoutMode`, `Position`) and type the property as `TypeName | null`. For non-string structural values, define a named narrow type (e.g., `PositionOffset` as `number | string | null`). Conversely, properties whose values may be token-bound, prop-bound, or conditional MUST use `Style` (or a domain-specific type like `ColorStyle`). Established examples: `LayoutMode`, `MainAxisAlignment`, `CrossAxisAlignment`, `WrapAlignment`, `Position`, `PositionOffset`.
 - **Language/Tooling**: TypeScript strict mode (`tsconfig.build.json`); ESM only; no runtime dependencies permitted (devDependencies: `typescript` only).
 - **Build**: `tsc -p tsconfig.build.json` emits `.js` shims into `dist/`. The source of truth is `types/*.ts` — `dist/` is a compatibility artifact only.
 - **No test framework required** for a pure types/schema package, but schema consistency checks and type compilation serve as the quality gate.
@@ -90,4 +91,4 @@ Rationale: These types are a published contract. Loose typing undermines compila
   - PATCH: Clarifications, wording, formatting; no semantic change.
 - **Compliance**: Reviewers MUST check Constitution Check items at every feature milestone and before any `MAJOR` or `MINOR` package version bump.
 
-**Version**: 1.2.0 | **Ratified**: 2026-02-18 | **Last Amended**: 2026-04-20
+**Version**: 1.3.0 | **Ratified**: 2026-02-18 | **Last Amended**: 2026-04-27

--- a/adr/041-layout-positioning.md
+++ b/adr/041-layout-positioning.md
@@ -2,7 +2,7 @@
 
 **Branch**: `041-layout-positioning`
 **Created**: 2026-04-27
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/041-layout-positioning.md
+++ b/adr/041-layout-positioning.md
@@ -1,0 +1,235 @@
+# ADR: Layout Positioning — Constraint-Based Naming
+
+**Branch**: `041-layout-positioning`
+**Created**: 2026-04-27
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The current `Styles` type exposes three Figma-derived positioning properties:
+
+- `x` — horizontal pixel offset
+- `y` — vertical pixel offset
+- `layoutPositioning` — `"AUTO"` or `"ABSOLUTE"` string controlling whether a child participates in auto-layout
+
+These names mirror the Figma API verbatim. However, `x` and `y` are opaque to platform consumers — they carry no information about *how* the element is anchored. Figma's `constraints` property (MIN, MAX, CENTER, STRETCH, SCALE per axis) determines anchor semantics, but that information is currently discarded at the schema boundary.
+
+Meanwhile, `layoutPositioning` uses Figma's internal API name rather than the CSS-aligned `position` concept familiar to web and native platform engineers.
+
+This creates two gaps:
+
+1. **Lost anchor semantics**: A consumer receiving `x: 24` has no way to know whether `24` means "24 px from the left edge" (MIN constraint), "24 px from the right edge" (MAX), or "centered with a 24 px offset" (CENTER). This forces every downstream platform to re-derive semantics that should be declared at the schema level.
+2. **Figma-coupled naming**: `layoutPositioning` is Figma jargon; `x`/`y` are axis-raw. Code-centric consumers expect CSS-aligned property names like `position`, `top`, `start`, `bottom`, `end`.
+
+---
+
+## Decision Drivers
+
+- **Code-centric naming**: Property names should align with platform concepts (CSS logical/physical positioning) rather than Figma API names
+- **Semantic completeness**: The schema should capture the *meaning* of a positional value (which edge it anchors to), not just the raw number
+- **Additive-only change path**: New properties can be added as MINOR; removing `x`, `y`, and `layoutPositioning` is MAJOR — the ADR must define a clean deprecation/removal path
+- **Type and schema symmetry**: Every type change must have a corresponding schema change (Constitution I)
+- **No runtime logic in this package**: The constraint-to-property mapping is a transformation concern for `specs-from-figma`, not for `specs-schema` (Constitution II)
+
+---
+
+## Options Considered
+
+### Option A: Constraint-Based Positioning Properties *(Selected)*
+
+Replace `x`, `y`, and `layoutPositioning` with semantically richer properties derived from Figma's `constraints`:
+
+**New properties on `Styles`:**
+
+| Property | Type | When present |
+|----------|------|-------------|
+| `position` | `Style` | Always (replaces `layoutPositioning`) — values: `"AUTO"`, `"ABSOLUTE"` |
+| `top` | `Style` | Vertical constraint is `MIN` or `STRETCH` |
+| `bottom` | `Style` | Vertical constraint is `MAX` or `STRETCH` |
+| `start` | `Style` | Horizontal constraint is `MIN` or `STRETCH` |
+| `end` | `Style` | Horizontal constraint is `MAX` or `STRETCH` |
+| `centerHorizontalOffset` | `Style` | Horizontal constraint is `CENTER` |
+| `centerVerticalOffset` | `Style` | Vertical constraint is `CENTER` |
+
+**Constraint mapping logic** (performed by `specs-from-figma`, not this package):
+
+| Figma Constraint | Horizontal → | Vertical → |
+|-----------------|--------------|------------|
+| `MIN` | `start` (px from inline-start edge) | `top` (px from block-start edge) |
+| `MAX` | `end` (px from inline-end edge) | `bottom` (px from block-end edge) |
+| `CENTER` | `centerHorizontalOffset` (px offset from center) | `centerVerticalOffset` (px offset from center) |
+| `STRETCH` | `start` + `end` (both edges) | `top` + `bottom` (both edges) |
+| `SCALE` | `start` (percentage string, e.g. `"25%"`) | `top` (percentage string, e.g. `"25%"`) |
+
+For `SCALE`, the value is expressed as a percentage string (e.g., `"25%"`) rather than a pixel number, signaling proportional positioning to consumers.
+
+**Removed properties:** `x`, `y`, `layoutPositioning`
+
+**Pros**:
+- Consumers immediately know anchor semantics without re-deriving from Figma constraints
+- Names align with CSS logical properties (`start`/`end`) and physical properties (`top`/`bottom`)
+- `position` is universally understood across web, iOS, and Android platforms
+- `STRETCH` naturally decomposes into two edges, matching how CSS `inset` works
+- `SCALE` represented as percentage strings avoids type ambiguity (number vs. percentage)
+
+**Cons / Trade-offs**:
+- Breaking change: removes three existing properties (`x`, `y`, `layoutPositioning`)
+- Requires `specs-from-figma` to implement constraint-to-property mapping transformation
+- `centerHorizontalOffset` / `centerVerticalOffset` are longer names, but they're unambiguous
+
+---
+
+### Option B: Keep `x`/`y`, Add Constraint Metadata *(Rejected)*
+
+Keep `x`, `y`, and `layoutPositioning` unchanged. Add a new `constraints` composite object alongside them that describes the anchor mode per axis.
+
+```yaml
+# Example output
+x: 24
+y: 16
+layoutPositioning: "ABSOLUTE"
+constraints:
+  horizontal: "MIN"
+  vertical: "CENTER"
+```
+
+**Rejected because**: This duplicates information — the consumer still receives `x: 24` and must cross-reference `constraints.horizontal` to interpret it. The schema grows without improving ergonomics. Consumers already have the raw numbers; the gap is in naming and semantics, not in missing metadata.
+
+---
+
+### Option C: Do Nothing *(Rejected)*
+
+Keep the current `x`, `y`, and `layoutPositioning` properties unchanged.
+
+**Rejected because**: Consumers remain unable to determine anchor semantics from the schema output alone. Every platform integration must independently solve the same mapping problem that should be resolved at the schema level. This violates the "semantic completeness" driver.
+
+---
+
+## Decision
+
+### Type changes (`types/Styles.ts`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Styles.ts` | Remove field `x` | MAJOR |
+| `Styles.ts` | Remove field `y` | MAJOR |
+| `Styles.ts` | Remove field `layoutPositioning` | MAJOR |
+| `Styles.ts` | Add optional field `position` | MINOR |
+| `Styles.ts` | Add optional field `top` | MINOR |
+| `Styles.ts` | Add optional field `bottom` | MINOR |
+| `Styles.ts` | Add optional field `start` | MINOR |
+| `Styles.ts` | Add optional field `end` | MINOR |
+| `Styles.ts` | Add optional field `centerHorizontalOffset` | MINOR |
+| `Styles.ts` | Add optional field `centerVerticalOffset` | MINOR |
+| `Styles.ts` | Update `StyleKey` union: remove `'x'`, `'y'`, `'layoutPositioning'`; add `'position'`, `'top'`, `'bottom'`, `'start'`, `'end'`, `'centerHorizontalOffset'`, `'centerVerticalOffset'` | MAJOR |
+
+**Example — new shape** (`types/Styles.ts`):
+```yaml
+# Before
+Styles:
+  x: Style
+  y: Style
+  layoutPositioning: Style
+
+# After
+Styles:
+  position: Style           # "AUTO" | "ABSOLUTE" (replaces layoutPositioning)
+  top: Style                # vertical offset from top (MIN or STRETCH)
+  bottom: Style             # vertical offset from bottom (MAX or STRETCH)
+  start: Style              # horizontal offset from inline-start (MIN or STRETCH)
+  end: Style                # horizontal offset from inline-end (MAX or STRETCH)
+  centerHorizontalOffset: Style  # horizontal offset from center (CENTER)
+  centerVerticalOffset: Style    # vertical offset from center (CENTER)
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `styles.schema.json` | Remove properties `x`, `y`, `layoutPositioning` | MAJOR |
+| `styles.schema.json` | Add properties `position`, `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset` | MINOR |
+
+**Example — new shape** (`schema/styles.schema.json`):
+```yaml
+# Removed properties
+x: { $ref: "#/definitions/NumberStyleValue" }
+y: { $ref: "#/definitions/NumberStyleValue" }
+layoutPositioning: { $ref: "#/definitions/StringStyleValue" }
+
+# New properties
+position:
+  $ref: "#/definitions/StringStyleValue"
+  description: "Layout positioning mode — AUTO (participates in parent auto-layout) or ABSOLUTE"
+top:
+  $ref: "#/definitions/NumberStyleValue"
+  description: "Offset from block-start (top) edge. Present when vertical constraint is MIN or STRETCH. Percentage string when SCALE."
+bottom:
+  $ref: "#/definitions/NumberStyleValue"
+  description: "Offset from block-end (bottom) edge. Present when vertical constraint is MAX or STRETCH."
+start:
+  $ref: "#/definitions/NumberStyleValue"
+  description: "Offset from inline-start edge. Present when horizontal constraint is MIN or STRETCH. Percentage string when SCALE."
+end:
+  $ref: "#/definitions/NumberStyleValue"
+  description: "Offset from inline-end edge. Present when horizontal constraint is MAX or STRETCH."
+centerHorizontalOffset:
+  $ref: "#/definitions/NumberStyleValue"
+  description: "Horizontal offset from center. Present when horizontal constraint is CENTER."
+centerVerticalOffset:
+  $ref: "#/definitions/NumberStyleValue"
+  description: "Vertical offset from center. Present when vertical constraint is CENTER."
+```
+
+### Notes
+
+- `top`/`bottom`/`start`/`end` and `centerHorizontalOffset`/`centerVerticalOffset` carry `NumberStyleValue` type because their values are pixel numbers (or percentage strings for SCALE). The schema ref `NumberStyleValue` already accepts `string | number | null | TokenReference | PropBinding | Conditional` via `Style`, which accommodates percentage strings.
+- `position` carries `StringStyleValue` because its values are string literals (`"AUTO"`, `"ABSOLUTE"`).
+- Only properties relevant to the node's constraints are emitted. A node with horizontal `MIN` + vertical `CENTER` would produce `start`, `centerVerticalOffset`, and `position` — no other positioning fields.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — every removed and added type field has a corresponding schema property change
+- **Parity check**:
+  - `Styles.position` ↔ `styles.schema.json#/definitions/StylesObject/properties/position`
+  - `Styles.top` ↔ `…/properties/top`
+  - `Styles.bottom` ↔ `…/properties/bottom`
+  - `Styles.start` ↔ `…/properties/start`
+  - `Styles.end` ↔ `…/properties/end`
+  - `Styles.centerHorizontalOffset` ↔ `…/properties/centerHorizontalOffset`
+  - `Styles.centerVerticalOffset` ↔ `…/properties/centerVerticalOffset`
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Must implement constraint-to-property mapping: read Figma `constraints` per axis and emit the appropriate directional property instead of raw `x`/`y`. Rename `layoutPositioning` → `position` in output. | Implement new transformation logic for constraint mapping; update style key references |
+| `specs-cli` | Recompile against updated types. No logic change — the CLI passes through whatever `specs-from-figma` produces. | Recompile |
+| `specs-plugin` | Recompile against updated types. Same passthrough behavior as CLI. | Recompile |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.18.0 → 0.19.0` (`MINOR` within pre-1.0 — removing fields before 1.0 is acceptable as a minor bump per pre-1.0 convention)
+
+**Justification**: The package is pre-1.0. Removing `x`, `y`, and `layoutPositioning` while adding replacement properties constitutes a breaking schema change, but pre-1.0 semver allows breaking changes in MINOR bumps. This change ships in the `0.19.0` release.
+
+---
+
+## Consequences
+
+- Consumers receive semantically meaningful positioning properties that map directly to CSS positioning concepts
+- The `x`/`y` ambiguity is eliminated — every positional value now indicates which edge it's anchored to
+- `STRETCH` is naturally represented as two simultaneous edge values, matching CSS `inset` behavior
+- `SCALE` (percentage) is distinguishable from pixel values by string type (`"25%"` vs `24`)
+- `CENTER` gets dedicated offset properties, avoiding overloading `top`/`start` with center semantics
+- `specs-from-figma` must implement the constraint-aware transformation — this is the primary implementation cost
+- All existing test fixtures containing `x`, `y`, or `layoutPositioning` will need updating across `specs-testing`

--- a/adr/041-layout-positioning.md
+++ b/adr/041-layout-positioning.md
@@ -43,17 +43,22 @@ This creates two gaps:
 
 Replace `x`, `y`, and `layoutPositioning` with semantically richer properties derived from Figma's `constraints`:
 
+**New types:**
+
+- `Position` — `'AUTO' | 'ABSOLUTE'` string literal union. Structural property that cannot be token-bound (same pattern as `LayoutMode`, `MainAxisAlignment`, etc.)
+- `PositionOffset` — `number | string | null`. A pixel value (`number`), a percentage string (`string`, e.g. `"25%"` for SCALE), or `null`. Narrower than `Style` — excludes `TokenReference`, `PropBinding`, and `Conditional` since positional offsets are computed from Figma layout, not token-bindable.
+
 **New properties on `Styles`:**
 
 | Property | Type | When present |
 |----------|------|-------------|
-| `position` | `Style` | Always (replaces `layoutPositioning`) — values: `"AUTO"`, `"ABSOLUTE"` |
-| `top` | `Style` | Vertical constraint is `MIN` or `STRETCH` |
-| `bottom` | `Style` | Vertical constraint is `MAX` or `STRETCH` |
-| `start` | `Style` | Horizontal constraint is `MIN` or `STRETCH` |
-| `end` | `Style` | Horizontal constraint is `MAX` or `STRETCH` |
-| `centerHorizontalOffset` | `Style` | Horizontal constraint is `CENTER` |
-| `centerVerticalOffset` | `Style` | Vertical constraint is `CENTER` |
+| `position` | `Position \| null` | Always (replaces `layoutPositioning`) — `"AUTO"` or `"ABSOLUTE"` |
+| `top` | `PositionOffset` | Vertical constraint is `MIN`, `STRETCH`, or `SCALE` |
+| `bottom` | `PositionOffset` | Vertical constraint is `MAX` or `STRETCH` |
+| `start` | `PositionOffset` | Horizontal constraint is `MIN`, `STRETCH`, or `SCALE` |
+| `end` | `PositionOffset` | Horizontal constraint is `MAX` or `STRETCH` |
+| `centerHorizontalOffset` | `PositionOffset` | Horizontal constraint is `CENTER` |
+| `centerVerticalOffset` | `PositionOffset` | Vertical constraint is `CENTER` |
 
 **Constraint mapping logic** (performed by `specs-from-figma`, not this package):
 
@@ -65,7 +70,9 @@ Replace `x`, `y`, and `layoutPositioning` with semantically richer properties de
 | `STRETCH` | `start` + `end` (both edges) | `top` + `bottom` (both edges) |
 | `SCALE` | `start` (percentage string, e.g. `"25%"`) | `top` (percentage string, e.g. `"25%"`) |
 
-For `SCALE`, the value is expressed as a percentage string (e.g., `"25%"`) rather than a pixel number, signaling proportional positioning to consumers.
+For `STRETCH`, both edge properties are emitted simultaneously (e.g., `start` + `end` or `top` + `bottom`).
+
+For `SCALE`, the value is emitted on the same property as `MIN` (`start` or `top`) but as a percentage string instead of a pixel number, signaling proportional positioning to consumers.
 
 **Removed properties:** `x`, `y`, `layoutPositioning`
 
@@ -118,13 +125,15 @@ Keep the current `x`, `y`, and `layoutPositioning` properties unchanged.
 | `Styles.ts` | Remove field `x` | MAJOR |
 | `Styles.ts` | Remove field `y` | MAJOR |
 | `Styles.ts` | Remove field `layoutPositioning` | MAJOR |
-| `Styles.ts` | Add optional field `position` | MINOR |
-| `Styles.ts` | Add optional field `top` | MINOR |
-| `Styles.ts` | Add optional field `bottom` | MINOR |
-| `Styles.ts` | Add optional field `start` | MINOR |
-| `Styles.ts` | Add optional field `end` | MINOR |
-| `Styles.ts` | Add optional field `centerHorizontalOffset` | MINOR |
-| `Styles.ts` | Add optional field `centerVerticalOffset` | MINOR |
+| `Styles.ts` | Add type `Position` (`'AUTO' \| 'ABSOLUTE'`) | MINOR |
+| `Styles.ts` | Add type `PositionOffset` (`number \| string \| null`) | MINOR |
+| `Styles.ts` | Add optional field `position: Position \| null` | MINOR |
+| `Styles.ts` | Add optional field `top: PositionOffset` | MINOR |
+| `Styles.ts` | Add optional field `bottom: PositionOffset` | MINOR |
+| `Styles.ts` | Add optional field `start: PositionOffset` | MINOR |
+| `Styles.ts` | Add optional field `end: PositionOffset` | MINOR |
+| `Styles.ts` | Add optional field `centerHorizontalOffset: PositionOffset` | MINOR |
+| `Styles.ts` | Add optional field `centerVerticalOffset: PositionOffset` | MINOR |
 | `Styles.ts` | Update `StyleKey` union: remove `'x'`, `'y'`, `'layoutPositioning'`; add `'position'`, `'top'`, `'bottom'`, `'start'`, `'end'`, `'centerHorizontalOffset'`, `'centerVerticalOffset'` | MAJOR |
 
 **Example — new shape** (`types/Styles.ts`):
@@ -135,15 +144,19 @@ Styles:
   y: Style
   layoutPositioning: Style
 
-# After
+# After — new types
+Position: 'AUTO' | 'ABSOLUTE'      # structural enum, not token-bindable
+PositionOffset: number | string | null  # px number, percentage string, or null
+
+# After — new properties on Styles
 Styles:
-  position: Style           # "AUTO" | "ABSOLUTE" (replaces layoutPositioning)
-  top: Style                # vertical offset from top (MIN or STRETCH)
-  bottom: Style             # vertical offset from bottom (MAX or STRETCH)
-  start: Style              # horizontal offset from inline-start (MIN or STRETCH)
-  end: Style                # horizontal offset from inline-end (MAX or STRETCH)
-  centerHorizontalOffset: Style  # horizontal offset from center (CENTER)
-  centerVerticalOffset: Style    # vertical offset from center (CENTER)
+  position: Position | null         # replaces layoutPositioning
+  top: PositionOffset               # vertical: MIN, STRETCH, or SCALE
+  bottom: PositionOffset            # vertical: MAX or STRETCH
+  start: PositionOffset             # horizontal: MIN, STRETCH, or SCALE
+  end: PositionOffset               # horizontal: MAX or STRETCH
+  centerHorizontalOffset: PositionOffset  # horizontal: CENTER
+  centerVerticalOffset: PositionOffset    # vertical: CENTER
 ```
 
 ### Schema changes (`schema/`)
@@ -151,6 +164,8 @@ Styles:
 | File | Change | Bump |
 |------|--------|------|
 | `styles.schema.json` | Remove properties `x`, `y`, `layoutPositioning` | MAJOR |
+| `styles.schema.json` | Add definition `Position` (enum: `AUTO`, `ABSOLUTE`) | MINOR |
+| `styles.schema.json` | Add definition `PositionOffset` (number, string, or null) | MINOR |
 | `styles.schema.json` | Add properties `position`, `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset` | MINOR |
 
 **Example — new shape** (`schema/styles.schema.json`):
@@ -160,34 +175,50 @@ x: { $ref: "#/definitions/NumberStyleValue" }
 y: { $ref: "#/definitions/NumberStyleValue" }
 layoutPositioning: { $ref: "#/definitions/StringStyleValue" }
 
+# New definitions
+Position:
+  type: string
+  enum: [AUTO, ABSOLUTE]
+  description: "Layout positioning mode. Structural — not token-bindable."
+
+PositionOffset:
+  description: "Positional offset value. Pixel number, percentage string (SCALE), or null."
+  oneOf:
+    - type: number
+    - type: string
+    - type: "null"
+
 # New properties
 position:
-  $ref: "#/definitions/StringStyleValue"
   description: "Layout positioning mode — AUTO (participates in parent auto-layout) or ABSOLUTE"
+  oneOf:
+    - $ref: "#/definitions/Position"
+    - type: "null"
 top:
-  $ref: "#/definitions/NumberStyleValue"
-  description: "Offset from block-start (top) edge. Present when vertical constraint is MIN or STRETCH. Percentage string when SCALE."
+  $ref: "#/definitions/PositionOffset"
+  description: "Offset from block-start (top) edge. Present when vertical constraint is MIN, STRETCH, or SCALE."
 bottom:
-  $ref: "#/definitions/NumberStyleValue"
+  $ref: "#/definitions/PositionOffset"
   description: "Offset from block-end (bottom) edge. Present when vertical constraint is MAX or STRETCH."
 start:
-  $ref: "#/definitions/NumberStyleValue"
-  description: "Offset from inline-start edge. Present when horizontal constraint is MIN or STRETCH. Percentage string when SCALE."
+  $ref: "#/definitions/PositionOffset"
+  description: "Offset from inline-start edge. Present when horizontal constraint is MIN, STRETCH, or SCALE."
 end:
-  $ref: "#/definitions/NumberStyleValue"
+  $ref: "#/definitions/PositionOffset"
   description: "Offset from inline-end edge. Present when horizontal constraint is MAX or STRETCH."
 centerHorizontalOffset:
-  $ref: "#/definitions/NumberStyleValue"
+  $ref: "#/definitions/PositionOffset"
   description: "Horizontal offset from center. Present when horizontal constraint is CENTER."
 centerVerticalOffset:
-  $ref: "#/definitions/NumberStyleValue"
+  $ref: "#/definitions/PositionOffset"
   description: "Vertical offset from center. Present when vertical constraint is CENTER."
 ```
 
 ### Notes
 
-- `top`/`bottom`/`start`/`end` and `centerHorizontalOffset`/`centerVerticalOffset` carry `NumberStyleValue` type because their values are pixel numbers (or percentage strings for SCALE). The schema ref `NumberStyleValue` already accepts `string | number | null | TokenReference | PropBinding | Conditional` via `Style`, which accommodates percentage strings.
-- `position` carries `StringStyleValue` because its values are string literals (`"AUTO"`, `"ABSOLUTE"`).
+- **Narrower than `Style`**: Both `Position` and `PositionOffset` are deliberately narrower than the general `Style` type. Positional values are computed from Figma's layout engine — they cannot be token-bound, prop-bound, or conditional. This follows the precedent set by `LayoutMode`, `MainAxisAlignment`, `CrossAxisAlignment`, and `WrapAlignment`.
+- `position` is `Position | null` — the `null` case follows the same pattern as `layoutMode: LayoutMode | null` for properties that may be absent.
+- `PositionOffset` is `number | string | null` — `number` for pixel values, `string` for percentage values (SCALE constraint, e.g. `"25%"`), `null` when absent.
 - Only properties relevant to the node's constraints are emitted. A node with horizontal `MIN` + vertical `CENTER` would produce `start`, `centerVerticalOffset`, and `position` — no other positioning fields.
 
 ---

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 041 | Layout Positioning — Constraint-Based Naming | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 041 | Layout Positioning — Constraint-Based Naming | |
 | 035 | Make Config Properties with Defaults Optional | |
 | 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
@@ -17,6 +16,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 041 | Layout Positioning — Constraint-Based Naming | Replace `x`/`y`/`layoutPositioning` with constraint-based `position`, `start`, `end`, `top`, `bottom`, center offsets |
 | 040 | Replace `primaryAxisAlignItems` and `counterAxisAlignItems` with `mainAxisAlignment` and `crossAxisAlignment` | Rename to platform-neutral names; add `MainAxisAlignment` and `CrossAxisAlignment` enums; not token-bindable |
 | 039 | Replace `layoutWrap` and `counterAxisAlignContent` with `wrap` and `wrapAlignment` | Rename to platform-neutral names; add `WrapAlignment` enum (`START \| SPACE_BETWEEN`); not token-bindable |
 | 038 | Tighten layoutMode to String Literal Enum | Narrow `layoutMode` from `Style` to `LayoutMode \| null` (`'NONE' \| 'HORIZONTAL' \| 'VERTICAL'`); exclude TokenReference |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the Specs schema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - Unreleased
+
+Replaces Figma-raw `x`, `y`, and `layoutPositioning` with constraint-based positioning properties. `position` replaces `layoutPositioning` as a strict `Position` enum. Directional offsets (`top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset`) replace `x`/`y` with anchor semantics derived from Figma constraints. See the [Layout Positioning guide](/specs/guides/layout-positioning/) for constraint mapping rules and platform usage examples.
+
+### Added
+
+- `Styles.position` — typed as `Position` (`'AUTO' | 'ABSOLUTE'`) or `null`; structural property, not token-bindable (replaces `layoutPositioning`)
+- `Styles.top` — typed as `PositionOffset` (`number | string | null`); block-start offset from vertical MIN, STRETCH, or SCALE constraint
+- `Styles.bottom` — typed as `PositionOffset`; block-end offset from vertical MAX or STRETCH constraint
+- `Styles.start` — typed as `PositionOffset`; inline-start offset from horizontal MIN, STRETCH, or SCALE constraint
+- `Styles.end` — typed as `PositionOffset`; inline-end offset from horizontal MAX or STRETCH constraint
+- `Styles.centerHorizontalOffset` — typed as `PositionOffset`; horizontal offset from center (CENTER constraint)
+- `Styles.centerVerticalOffset` — typed as `PositionOffset`; vertical offset from center (CENTER constraint)
+
+### Removed
+
+- `Styles.x` — replaced by `Styles.start`, `Styles.end`, or `Styles.centerHorizontalOffset` depending on constraint
+- `Styles.y` — replaced by `Styles.top`, `Styles.bottom`, or `Styles.centerVerticalOffset` depending on constraint
+- `Styles.layoutPositioning` — replaced by `Styles.position`
+
+### Migration
+
+- `Styles.x` → `Styles.start` / `Styles.end` / `Styles.centerHorizontalOffset`: determine which property to read based on the node's horizontal constraint; SCALE values are percentage strings (e.g. `"25%"`)
+- `Styles.y` → `Styles.top` / `Styles.bottom` / `Styles.centerVerticalOffset`: same constraint-based mapping for the vertical axis
+- `Styles.layoutPositioning` → `Styles.position`: rename and narrow type — replace generic `Style` handling with exhaustive match on `'AUTO' | 'ABSOLUTE'`
+
+
 ## [0.18.0] - 2026-04-24
 
 Replaces Figma-native layout property names with semantic equivalents for auto-layout alignment and wrapping. Introduces a bi-axial `itemSpacing` model that consolidates `counterAxisSpacing` into a single property, and narrows `layoutMode` from a generic `Style` to a strict enum. Five renamed alignment/wrap fields use plain-language names (`mainAxisAlignment`, `crossAxisAlignment`, `wrapAlignment`, `wrap`) instead of Figma axis terminology. The documentation site was considerably rearchitected with updated content and navigation.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-schema",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Specs UI Component Schema - TypeScript types and JSON schema definitions for component specifications",
   "license": "CC-BY-4.0",
   "author": "Nathan Curtis <nathan@directededges.com>",

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -25,9 +25,13 @@
         "minHeight": { "$ref": "#/definitions/NumberStyleValue", "description": "Minimum height" },
         "maxWidth": { "$ref": "#/definitions/NumberStyleValue", "description": "Maximum width" },
         "maxHeight": { "$ref": "#/definitions/NumberStyleValue", "description": "Maximum height" },
-        "x": { "$ref": "#/definitions/NumberStyleValue", "description": "X position" },
-        "y": { "$ref": "#/definitions/NumberStyleValue", "description": "Y position" },
-        "layoutPositioning": { "$ref": "#/definitions/StringStyleValue", "description": "Layout positioning mode" },
+        "position": { "$ref": "#/definitions/PositionStyleValue", "description": "Layout positioning mode — AUTO (participates in parent auto-layout) or ABSOLUTE. Structural property — not token-bindable." },
+        "top": { "$ref": "#/definitions/PositionOffset", "description": "Offset from block-start (top) edge. Present when vertical constraint is MIN, STRETCH, or SCALE." },
+        "bottom": { "$ref": "#/definitions/PositionOffset", "description": "Offset from block-end (bottom) edge. Present when vertical constraint is MAX or STRETCH." },
+        "start": { "$ref": "#/definitions/PositionOffset", "description": "Offset from inline-start edge. Present when horizontal constraint is MIN, STRETCH, or SCALE." },
+        "end": { "$ref": "#/definitions/PositionOffset", "description": "Offset from inline-end edge. Present when horizontal constraint is MAX or STRETCH." },
+        "centerHorizontalOffset": { "$ref": "#/definitions/PositionOffset", "description": "Horizontal offset from center. Present when horizontal constraint is CENTER." },
+        "centerVerticalOffset": { "$ref": "#/definitions/PositionOffset", "description": "Vertical offset from center. Present when vertical constraint is CENTER." },
         "layoutSizingHorizontal": { "$ref": "#/definitions/StringStyleValue", "description": "Horizontal sizing mode" },
         "layoutSizingVertical": { "$ref": "#/definitions/StringStyleValue", "description": "Vertical sizing mode" },
         "strokes": { "$ref": "#/definitions/ColorStyleValue", "description": "Stroke colors" },
@@ -355,6 +359,21 @@
       "description": "Cross axis alignment value. Structural property — not token-bindable.",
       "oneOf": [
         { "type": "string", "enum": ["START", "END", "CENTER", "STRETCH", "BASELINE"] },
+        { "type": "null" }
+      ]
+    },
+    "PositionStyleValue": {
+      "description": "Position value. Structural property — not token-bindable.",
+      "oneOf": [
+        { "type": "string", "enum": ["AUTO", "ABSOLUTE"] },
+        { "type": "null" }
+      ]
+    },
+    "PositionOffset": {
+      "description": "Positional offset value. Pixel number, percentage string (SCALE constraint), or null. Not token-bindable.",
+      "oneOf": [
+        { "type": "number" },
+        { "type": "string" },
         { "type": "null" }
       ]
     },

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -8,7 +8,7 @@ import type {
   TokenReference, ColorStyle, GradientStop, GradientCenter, LinearGradient, RadialGradient,
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
-  MainAxisAlignment, CrossAxisAlignment,
+  MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -686,3 +686,103 @@ const _oldPrimaryAxis: Styles = { primaryAxisAlignItems: 'MIN' };
 
 // @ts-expect-error: counterAxisAlignItems no longer exists on Styles
 const _oldCounterAxis: Styles = { counterAxisAlignItems: 'MIN' };
+
+// ─── Position ─────────────────────────────────────────────────────────────────
+
+// Valid enum values
+const _posAuto: Position = 'AUTO';
+const _posAbsolute: Position = 'ABSOLUTE';
+
+// @ts-expect-error: arbitrary string is not valid Position
+const _posBad: Position = 'RELATIVE';
+
+// @ts-expect-error: number is not valid Position
+const _posNumber: Position = 0;
+
+// @ts-expect-error: lowercase is not valid (SCREAMING_CASE required)
+const _posLowercase: Position = 'auto';
+
+// ─── PositionOffset ───────────────────────────────────────────────────────────
+
+// number (pixel value)
+const _poPx: PositionOffset = 24;
+
+// string (percentage for SCALE constraint)
+const _poPercent: PositionOffset = '25%';
+
+// null (absent)
+const _poNull: PositionOffset = null;
+
+// @ts-expect-error: boolean is not valid PositionOffset
+const _poBool: PositionOffset = true;
+
+// @ts-expect-error: object is not valid PositionOffset
+const _poObj: PositionOffset = { value: 24 };
+
+// TokenReference must NOT be valid — positional offsets are not token-bindable
+// @ts-expect-error: TokenReference is not assignable to PositionOffset
+const _poToken: PositionOffset = { $token: 'Space.4', $type: 'dimension' } satisfies TokenReference;
+
+// ─── Styles.position (Position | null) ────────────────────────────────────────
+
+// Valid enum values on Styles
+const withPositionAuto: Styles = { position: 'AUTO' };
+const withPositionAbsolute: Styles = { position: 'ABSOLUTE' };
+
+// null is valid
+const withPositionNull: Styles = { position: null };
+
+// @ts-expect-error: TokenReference is not valid for position (not token-bindable)
+const _posToken: Styles = { position: { $token: 'Layout.Position', $type: 'string' } satisfies TokenReference };
+
+// @ts-expect-error: number is not valid for position
+const _posStyleNumber: Styles = { position: 1 };
+
+// @ts-expect-error: arbitrary string is not valid for position
+const _posArbitrary: Styles = { position: 'RELATIVE' };
+
+// ─── Styles positioning offsets (PositionOffset) ──────────────────────────────
+
+// Pixel number values
+const withTop: Styles = { top: 24 };
+const withBottom: Styles = { bottom: 0 };
+const withStart: Styles = { start: 16 };
+const withEnd: Styles = { end: 8 };
+const withCenterH: Styles = { centerHorizontalOffset: 0 };
+const withCenterV: Styles = { centerVerticalOffset: -12 };
+
+// Percentage string values (SCALE constraint)
+const withTopPercent: Styles = { top: '25%' };
+const withStartPercent: Styles = { start: '10%' };
+
+// null is valid
+const withTopNull: Styles = { top: null };
+const withStartNull: Styles = { start: null };
+
+// STRETCH: both edges simultaneously
+const withStretchH: Styles = { start: 16, end: 16 };
+const withStretchV: Styles = { top: 8, bottom: 8 };
+
+// Combined positioning example
+const absoluteWithOffsets: Styles = {
+  position: 'ABSOLUTE',
+  start: 24,
+  top: 16,
+};
+
+// @ts-expect-error: TokenReference is not valid for top (not token-bindable)
+const _topToken: Styles = { top: { $token: 'Space.4', $type: 'dimension' } satisfies TokenReference };
+
+// @ts-expect-error: boolean is not valid for start
+const _startBool: Styles = { start: true };
+
+// ─── Verify x, y, and layoutPositioning removed from Styles ──────────────────
+
+// @ts-expect-error: x no longer exists on Styles
+const _oldX: Styles = { x: 24 };
+
+// @ts-expect-error: y no longer exists on Styles
+const _oldY: Styles = { y: 16 };
+
+// @ts-expect-error: layoutPositioning no longer exists on Styles
+const _oldLayoutPositioning: Styles = { layoutPositioning: 'ABSOLUTE' };

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -21,9 +21,20 @@ export type Styles = Partial<{
   minHeight: Style;
   maxWidth: Style;
   maxHeight: Style;
-  x: Style;
-  y: Style;
-  layoutPositioning: Style;
+  /** Layout positioning mode — AUTO (participates in parent auto-layout) or ABSOLUTE. Structural property — not token-bindable. @since 0.19.0 */
+  position: Position | null;
+  /** Offset from block-start (top) edge. Present when vertical constraint is MIN, STRETCH, or SCALE. Pixel number or percentage string. @since 0.19.0 */
+  top: PositionOffset;
+  /** Offset from block-end (bottom) edge. Present when vertical constraint is MAX or STRETCH. Pixel number. @since 0.19.0 */
+  bottom: PositionOffset;
+  /** Offset from inline-start edge. Present when horizontal constraint is MIN, STRETCH, or SCALE. Pixel number or percentage string. @since 0.19.0 */
+  start: PositionOffset;
+  /** Offset from inline-end edge. Present when horizontal constraint is MAX or STRETCH. Pixel number. @since 0.19.0 */
+  end: PositionOffset;
+  /** Horizontal offset from center. Present when horizontal constraint is CENTER. @since 0.19.0 */
+  centerHorizontalOffset: PositionOffset;
+  /** Vertical offset from center. Present when vertical constraint is CENTER. @since 0.19.0 */
+  centerVerticalOffset: PositionOffset;
   layoutSizingHorizontal: Style;
   layoutSizingVertical: Style;
   strokes: ColorStyle;
@@ -202,6 +213,19 @@ export interface Sides {
 }
 
 /**
+ * Layout positioning mode. Structural property that cannot be token-bound.
+ * @since 0.19.0
+ */
+export type Position = 'AUTO' | 'ABSOLUTE';
+
+/**
+ * Positional offset value. Pixel number, percentage string (SCALE constraint, e.g. "25%"), or null.
+ * Narrower than `Style` — positional offsets are computed from Figma layout, not token-bindable.
+ * @since 0.19.0
+ */
+export type PositionOffset = number | string | null;
+
+/**
  * Auto-layout direction mode. Structural property that cannot be token-bound.
  * @since 0.18.0
  */
@@ -279,9 +303,13 @@ export type StyleKey =
   | 'minHeight'
   | 'maxWidth'
   | 'maxHeight'
-  | 'x'
-  | 'y'
-  | 'layoutPositioning'
+  | 'position'
+  | 'top'
+  | 'bottom'
+  | 'start'
+  | 'end'
+  | 'centerHorizontalOffset'
+  | 'centerVerticalOffset'
   | 'layoutSizingHorizontal'
   | 'layoutSizingVertical'
   | 'strokes'

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -25,7 +25,7 @@ export type { Config, ResolvedConfig } from './Config.js';
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 

--- a/site/src/content/docs/guides/layout-positioning.md
+++ b/site/src/content/docs/guides/layout-positioning.md
@@ -1,0 +1,243 @@
+---
+title: "Layout Positioning"
+description: "How Figma constraints map to semantic positioning properties in the spec output"
+---
+
+Figma stores element position as raw `x`/`y` pixel coordinates plus a `constraints` object that describes how the element is anchored within its parent. Specs transforms these into semantic positioning properties that tell consumers *where* the element is anchored — not just the pixel offset.
+
+## The Problem
+
+A raw `x: 24` tells you nothing about intent. Is the element pinned 24 px from the left edge? From the right? Centered with a 24 px offset? Every platform consumer would need to re-derive anchor semantics from Figma constraints — duplicating logic that should be resolved once at the schema level.
+
+## What It Does
+
+Specs reads the Figma `constraints` object (one constraint per axis) and emits the appropriate directional property instead of raw `x`/`y`. The `position` property replaces Figma's `layoutPositioning`.
+
+### Constraint → Property Mapping
+
+| Figma Constraint | Horizontal | Vertical |
+|-----------------|------------|----------|
+| `MIN` | `start` | `top` |
+| `MAX` | `end` | `bottom` |
+| `CENTER` | `centerHorizontalOffset` | `centerVerticalOffset` |
+| `STRETCH` | `start` + `end` | `top` + `bottom` |
+| `SCALE` | `start` (as `"25%"`) | `top` (as `"25%"`) |
+
+Only properties relevant to the node's constraints are emitted. A node with horizontal `MIN` and vertical `CENTER` produces `start`, `centerVerticalOffset`, and `position` — no other positioning fields.
+
+## Examples
+
+### MIN — Pinned to an Edge
+
+A layer pinned to the top-left corner, 24 px from the left edge and 16 px from the top:
+
+```yaml
+# Figma
+x: 24
+y: 16
+constraints: { horizontal: MIN, vertical: MIN }
+layoutPositioning: ABSOLUTE
+
+# Spec output
+position: ABSOLUTE
+start: 24
+top: 16
+```
+
+The consumer knows immediately: this element is anchored to the inline-start and block-start edges.
+
+### MAX — Pinned to the Opposite Edge
+
+A close button pinned to the top-right corner, 12 px from the right edge and 12 px from the top:
+
+```yaml
+# Figma
+x: 356    # computed from parent width
+y: 12
+constraints: { horizontal: MAX, vertical: MIN }
+layoutPositioning: ABSOLUTE
+
+# Spec output
+position: ABSOLUTE
+end: 12
+top: 12
+```
+
+Figma stores `x` as the distance from the left, but the constraint says "pin to the right." Specs converts this to `end: 12` — the offset from the inline-end edge.
+
+### CENTER — Offset from Center
+
+A tooltip arrow centered horizontally with a slight vertical offset:
+
+```yaml
+# Figma
+x: 148    # computed from parent center
+y: -4
+constraints: { horizontal: CENTER, vertical: CENTER }
+layoutPositioning: ABSOLUTE
+
+# Spec output
+position: ABSOLUTE
+centerHorizontalOffset: 0
+centerVerticalOffset: -4
+```
+
+`centerHorizontalOffset: 0` means perfectly centered horizontally. `centerVerticalOffset: -4` means 4 px above center.
+
+### STRETCH — Pinned to Both Edges
+
+A divider that stretches the full width of its parent with 16 px insets:
+
+```yaml
+# Figma
+x: 16
+y: 200
+constraints: { horizontal: STRETCH, vertical: MIN }
+layoutPositioning: ABSOLUTE
+
+# Spec output
+position: ABSOLUTE
+start: 16
+end: 16
+top: 200
+```
+
+Both `start` and `end` are emitted simultaneously — the element is anchored to both horizontal edges. This maps directly to CSS `left` + `right` or `inset-inline`.
+
+### SCALE — Proportional Positioning
+
+A watermark positioned at 25% from the left edge, scaling with the parent:
+
+```yaml
+# Figma
+x: 100    # 25% of 400px parent
+y: 0
+constraints: { horizontal: SCALE, vertical: MIN }
+layoutPositioning: ABSOLUTE
+
+# Spec output
+position: ABSOLUTE
+start: "25%"
+top: 0
+```
+
+SCALE values are emitted as percentage strings (e.g., `"25%"`) instead of pixel numbers, signaling proportional positioning. Consumers can distinguish percentage from pixel by checking the value type: `string` = percentage, `number` = pixels.
+
+## Types
+
+| Type | Values | Description |
+|------|--------|-------------|
+| `Position` | `'AUTO' \| 'ABSOLUTE'` | Whether the element participates in auto-layout or is absolutely positioned |
+| `PositionOffset` | `number \| string \| null` | Pixel value, percentage string, or null. Not token-bindable |
+
+Both types are narrower than `Style` — positional values are computed from Figma's layout engine and cannot be bound to tokens, props, or conditionals.
+
+## Platform Usage
+
+The semantic properties map directly to platform positioning APIs. Below are examples showing how a consumer might translate spec output into web CSS and iOS layout code.
+
+### Web (CSS)
+
+```css
+/* MIN — start: 24, top: 16 */
+.pinned-top-left {
+  position: absolute;
+  inset-inline-start: 24px;
+  top: 16px;
+}
+
+/* MAX — end: 12, top: 12 */
+.close-button {
+  position: absolute;
+  inset-inline-end: 12px;
+  top: 12px;
+}
+
+/* CENTER — centerHorizontalOffset: 0, centerVerticalOffset: -4 */
+.tooltip-arrow {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, calc(-50% - 4px));
+}
+
+/* STRETCH — start: 16, end: 16, top: 200 */
+.divider {
+  position: absolute;
+  inset-inline-start: 16px;
+  inset-inline-end: 16px;
+  top: 200px;
+}
+
+/* SCALE — start: "25%", top: 0 */
+.watermark {
+  position: absolute;
+  inset-inline-start: 25%;
+  top: 0;
+}
+```
+
+Key mapping: `start` → `inset-inline-start` (or `left` in LTR), `end` → `inset-inline-end` (or `right` in LTR), `top` → `top`, `bottom` → `bottom`. Center offsets require a `translate` transform from the 50% midpoint. Percentage strings from SCALE map directly to CSS percentage values.
+
+### iOS (SwiftUI)
+
+```swift
+// MIN — start: 24, top: 16
+ZStack(alignment: .topLeading) {
+    parent
+    child
+        .padding(.leading, 24)
+        .padding(.top, 16)
+}
+
+// MAX — end: 12, top: 12
+ZStack(alignment: .topTrailing) {
+    parent
+    child
+        .padding(.trailing, 12)
+        .padding(.top, 12)
+}
+
+// CENTER — centerHorizontalOffset: 0, centerVerticalOffset: -4
+ZStack {
+    parent
+    child
+        .offset(x: 0, y: -4)
+}
+
+// STRETCH — start: 16, end: 16, top: 200
+ZStack(alignment: .top) {
+    parent
+    child
+        .padding(.horizontal, 16)
+        .padding(.top, 200)
+        .frame(maxWidth: .infinity)
+}
+
+// SCALE — start: "25%", top: 0
+GeometryReader { geo in
+    child
+        .position(x: geo.size.width * 0.25, y: 0)
+}
+```
+
+Key mapping: `start` → `.leading` padding, `end` → `.trailing` padding, `top` → `.top` padding, `bottom` → `.bottom` padding. Center offsets use `.offset(x:y:)` within a centered `ZStack`. Percentage strings from SCALE use `GeometryReader` to compute proportional positions.
+
+## AUTO vs ABSOLUTE
+
+The `position` property controls whether the element participates in its parent's auto-layout:
+
+- `AUTO` — the element flows within auto-layout. Offset properties describe where the layout engine placed it
+- `ABSOLUTE` — the element is removed from the layout flow and positioned relative to the parent frame's edges
+
+```yaml
+# Auto-layout child (flows in parent)
+position: AUTO
+start: 16
+top: 8
+
+# Absolutely positioned overlay
+position: ABSOLUTE
+end: 0
+top: 0
+```

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -25,7 +25,13 @@ type Styles = Partial<{ /* 48 properties */ }>;
 | `itemReverseZIndex` | layout | container |
 | `itemSpacing` | spacing | container |
 | `layoutMode` | layout | container |
-| `layoutPositioning` | layout | all |
+| `position` | layout | all |
+| `top` | position | all |
+| `bottom` | position | all |
+| `start` | position | all |
+| `end` | position | all |
+| `centerHorizontalOffset` | position | all |
+| `centerVerticalOffset` | position | all |
 | `layoutSizingHorizontal` | layout | all |
 | `layoutSizingVertical` | layout | all |
 | `locked` | visibility | all |
@@ -49,8 +55,6 @@ type Styles = Partial<{ /* 48 properties */ }>;
 | `width` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon, line |
 | `wrap` | layout | container |
 | `wrapAlignment` | layout | container |
-| `x` | position | all |
-| `y` | position | all |
 
 ## Key Mapping from Figma
 
@@ -65,6 +69,13 @@ Several spec style keys differ from the Figma node property they read from. Spec
 | `wrapAlignment` | `counterAxisAlignContent` | [ADR 039](/specs/../adr/039-wrap-alignment/) |
 | `mainAxisAlignment` | `primaryAxisAlignItems` | [ADR 040](/specs/../adr/040-layout-alignment/) |
 | `crossAxisAlignment` | `counterAxisAlignItems` | [ADR 040](/specs/../adr/040-layout-alignment/) |
+| `position` | `layoutPositioning` | [ADR 041](/specs/../adr/041-layout-positioning/) |
+| `top` | `y` (constraint MIN/STRETCH/SCALE) | [ADR 041](/specs/../adr/041-layout-positioning/) |
+| `bottom` | `y` (constraint MAX/STRETCH) | [ADR 041](/specs/../adr/041-layout-positioning/) |
+| `start` | `x` (constraint MIN/STRETCH/SCALE) | [ADR 041](/specs/../adr/041-layout-positioning/) |
+| `end` | `x` (constraint MAX/STRETCH) | [ADR 041](/specs/../adr/041-layout-positioning/) |
+| `centerHorizontalOffset` | `x` (constraint CENTER) | [ADR 041](/specs/../adr/041-layout-positioning/) |
+| `centerVerticalOffset` | `y` (constraint CENTER) | [ADR 041](/specs/../adr/041-layout-positioning/) |
 
 All other style keys — `width`, `height`, `opacity`, `padding`, `itemSpacing`, `cornerRadius`, `strokeWeight`, `rotation`, etc. — use the same name as the Figma node property.
 
@@ -91,6 +102,8 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 | `WrapAlignment` | Wrap line distribution enum | `"START"`, `"SPACE_BETWEEN"` |
 | `MainAxisAlignment` | Main axis alignment enum | `"START"`, `"END"`, `"CENTER"`, `"SPACE_BETWEEN"` |
 | `CrossAxisAlignment` | Cross axis alignment enum | `"START"`, `"END"`, `"CENTER"`, `"STRETCH"`, `"BASELINE"` |
+| `Position` | Layout positioning mode enum | `"AUTO"`, `"ABSOLUTE"` |
+| `PositionOffset` | Positional offset value | `24` (px), `"25%"` (SCALE), `null` |
 | `AspectRatio` | Width-to-height ratio | `{ x: 16, y: 9 }` |
 
 ### Relating properties to values
@@ -106,4 +119,6 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 - `wrapAlignment` accepts `WrapAlignment | null` — not token-bindable.
 - `mainAxisAlignment` accepts `MainAxisAlignment | null` — not token-bindable.
 - `crossAxisAlignment` accepts `CrossAxisAlignment | null` — not token-bindable.
+- `position` accepts `Position | null` — not token-bindable.
+- `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset` accept `PositionOffset` (`number | string | null`) — not token-bindable.
 - `aspectRatio` accepts `AspectRatio | null`.


### PR DESCRIPTION
## Summary

- Replace `x`, `y`, `layoutPositioning` with constraint-based positioning properties derived from Figma constraints
- Add `Position` enum (`'AUTO' | 'ABSOLUTE'`) and `PositionOffset` type (`number | string | null`)
- Add 7 directional properties: `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset`
- Bump schema to 0.19.0

## Files changed

- **Types**: `Styles.ts`, `index.ts` — new types and properties, removed old ones
- **Schema**: `styles.schema.json` — matching schema definitions
- **Tests**: `Styles.test-d.ts` — ~100 lines of type-level assertions
- **Docs**: `styles.md` updated, new `guides/layout-positioning.md` with transformation rules and platform examples (CSS, SwiftUI)
- **CHANGELOG**: 0.19.0 Unreleased section with Added/Removed/Migration
- **ADR**: 041-layout-positioning marked ACCEPTED, INDEX updated

## Validation gates

- [x] `tsc -p tsconfig.build.json --noEmit` — pass
- [x] `validate-schema.sh` — 4/4 pass
- [x] `tsc --noEmit --strict tests/*.test-d.ts` — pass

## Test plan

- [ ] Verify TypeScript compilation in downstream packages after schema update
- [ ] Confirm JSON schema validation passes for real component output with new positioning properties
- [ ] Review layout-positioning guide for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)