### PR TITLE
Simplify Getting Started guide

### DIFF
--- a/site/src/content/docs/cli/getting-started.md
+++ b/site/src/content/docs/cli/getting-started.md
@@ -14,71 +14,38 @@ Claude will handle install, config, token setup, fetch, and your first generate 
 :::
 
 **Quick nav:**
-- [Prerequisite: Node.js](#prerequisite-nodejs)
-- [Step 1: Install Specs CLI](#step-1-install-specs-cli)
-- [Step 2: Initialize configuration](#step-2-initialize-configuration)
-- [Step 3: Edit configuration](#step-3-edit-configuration)
-- [Step 4: Set up environment variables](#step-4-set-up-environment-variables)
-- [Step 5: Fetch Figma data](#step-5-fetch-figma-data)
-- [Step 6: Scan components](#step-6-scan-components)
-- [Step 7: Select components](#step-7-select-components)
-- [Step 8: Generate specs](#step-8-generate-specs)
-- [Alternative approaches to generate](#alternative-approaches-to-generate)
-- [CLI Overview](/specs/cli/)
+- [Step 1: Install](#step-1-install)
+- [Step 2: Set up your environment](#step-2-set-up-your-environment)
+- [Step 3: Fetch the Figma file](#step-3-fetch-the-figma-file)
+- [Step 4: Scan and select components](#step-4-scan-and-select-components)
+- [Step 5: Generate specs](#step-5-generate-specs)
 
 ---
 
-## Prerequisite: Node.js
+## Step 1: Install
 
-Specs CLI is a command-line tool that runs on **Node.js** — a runtime that lets you execute JavaScript tools from your terminal. If you don't have Node.js installed, download it:
-
-- **[Download Node.js 18+](https://nodejs.org/)**
-- Choose the LTS (Long Term Support) version
-
-Verify it installed correctly:
-
-```bash
-node --version
-npm --version
-```
-
-Both commands should show version numbers (e.g., `v20.10.0`).
-
-> **What's npm?** npm is Node's package manager — it downloads and installs command-line tools like Specs CLI.
-
-## Step 1: Install Specs CLI
-
-Install globally so you can run it with the `specs` command:
+Specs CLI requires **[Node.js 18+](https://nodejs.org/)** (LTS recommended). Install it if you haven't already, then install Specs CLI globally:
 
 ```bash
 npm install -g @directededges/specs-cli
-```
-
-Verify the installation:
-
-```bash
 specs --version
 ```
 
-> **Alternative: use without installing.** Run on-the-fly with `npx @directededges/specs-cli <command>`. Useful if you only use Specs CLI occasionally.
+## Step 2: Set up your environment
 
-## Step 2: Initialize configuration
+Three things to configure: a config file, your Figma file key, and a Figma access token.
 
-Create a `specs.config.yaml` file with production-ready defaults:
+### Initialize config
+
+Generate a `specs.config.yaml` with sensible defaults:
 
 ```bash
 specs init
 ```
 
-This generates a config file in your current directory with inline documentation and sensible defaults. The next step walks through the sections you'll want to customize.
+### Add your Figma file key
 
-## Step 3: Edit configuration
-
-Open `specs.config.yaml` in your editor. The file has four main sections to configure.
-
-### Figma file key
-
-Each source needs a Figma file key. To find it, copy the link to your Figma file — the key is the string between `/design/` (or `/file/`) and the file name:
+Open `specs.config.yaml` and add your Figma file key. Find it by copying your Figma file's URL — the key is the string between `/design/` (or `/file/`) and the file name:
 
 ```
 https://www.figma.com/design/AbCdEfGhIjKlMnOpQr/My-Design-System
@@ -86,123 +53,36 @@ https://www.figma.com/design/AbCdEfGhIjKlMnOpQr/My-Design-System
                              This is your file key
 ```
 
-Add and name (such as `library`) one or more sources with keys and types of data to download from each:
+Add it under `sources`, which should be uncommented:
 
 ```yaml
 sources:
   library:
     key: AbCdEfGhIjKlMnOpQr
     data: [file, variables, styles]
-  foundations:
-    key: StUvWxYz1234567890
-    data: [variables, styles]
 ```
 
-Each source has a name (e.g., `library`), a `key`, and a `data` array specifying which Figma payloads to fetch. Sources that contain components typically need `file`, while token-only sources may only need `variables` and `styles`.
+### Add your Figma access token
 
-### Data and output directories
-
-```yaml
-dataDirectory: ./data          # Where fetch writes Figma payloads
-outputDirectory: ./specs       # Default location for generated specs
-```
-
-- **`dataDirectory`** is where `specs fetch` saves raw Figma data (JSON files). Other commands like `scan` and `generate` read from here.
-- **`outputDirectory`** is the default destination for generated spec files. You can override it per-command with the `-o` flag.
-
-> **Backward compatibility**: The deprecated `sourceDirectory` field still works as an alias for `dataDirectory` but will emit a warning.
-
-### Config
-
-The `config` section controls how Specs processes components and formats output. These settings are shared with the Figma plugin:
-
-```yaml
-config:
-  format:
-    output: JSON
-    keys: SAFE
-    layout: LAYOUT
-    tokens: TOKEN
-
-  processing:
-    variantDepth: 9999
-    details: LAYERED
-
-  include:
-    invalidVariants: false
-    invalidCombinations: true
-```
-
-- **`format`** — output shape (JSON/YAML, key casing, layout representation, token format)
-- **`processing`** — how components are analyzed (variant depth, detail level, subcomponent detection)
-- **`include`** — what to include in output (invalid variants, invalid combinations)
-
-Optional features like `subcomponents`, `glyphNamePattern`, and `codeOnlyPropsPattern` are off by default. Add them to `processing` when needed — see [Configuration Reference](/specs/config/).
-
-See [Configuration Reference](/specs/config/) for all options and allowed values.
-
-### Output
-
-The `output` section controls how generated files are organized:
-
-```yaml
-output:
-  splitComponents: false  # true = separate file per component
-  splitConcerns: false    # true = separate API from variants
-  useSubfolders: false    # true = component subdirectories
-```
-
-These default to `false`. You can also control these per-command with flags like `--split-components`.
-
-## Step 4: Set up environment variables
-
-Create a `.env` file in your project directory for your Figma token and (optionally) your license key:
+Create a `.env` file in your project directory (and add it to `.gitignore`):
 
 ```
 FIGMA_TOKEN=your_figma_token_here
-SPECS_LICENSE_KEY=your_license_key_here
 ```
 
-Add `.env` to your `.gitignore` so credentials aren't committed:
+To create a token, go to [Figma Settings → Tokens](https://www.figma.com/settings/tokens), click **Create a new token**, and select these scopes: `file_metadata:read`, `file_content:read`, `library_assets:read`, `library_content:read`, and `file_variables:read`.
 
-```
-.env
-```
+A **license key** is optional — Specs CLI works at a free tier without one. To unlock Pro features, add `SPECS_LICENSE_KEY` to your `.env` file. See [Licensing](/specs/overview/licensing/) for details.
 
-Specs CLI automatically loads `.env` from your current directory when you run commands.
+### Other configuration (optional)
 
-### Figma Personal Access Token
+The defaults from `specs init` work well for most setups. When you're ready to customize, these options are available in `specs.config.yaml`:
 
-You need a [Figma REST API](https://www.figma.com/developers/api) token to authenticate.
+- **`dataDirectory` / `outputDirectory`** — where fetched data is stored and specs are written. Defaults: `./data` and `./specs`.
+- **`config`** — controls output format (JSON/YAML, key casing, token format), processing behavior (variant depth, detail level), and what to include. See [Configuration Reference](/specs/schema/config/).
+- **`output`** — controls file organization: split per component, split by concern, use subfolders. All default to `false`.
 
-1. Go to [Figma Settings → Tokens](https://www.figma.com/settings/tokens)
-2. Click **Create a new token**
-3. Choose a name (e.g., "Specs CLI")
-4. Select scopes:
-  - `file_metadata:read` (file metadata)
-  - `file_content:read` (file contents, nodes)
-  - `library_assets:read` (published components and styles)
-  - `library_content:read` (published styles of files)
-  - `file_variables:read` (variables in files, Enterprise plan only)
-5. Click **Create token** and copy it
-
-> **Alternative:** You can also export the token in your shell: `export FIGMA_TOKEN="your_token_here"`.
-
-### License key (optional)
-
-Specs CLI works at a **free tier** without a license key. Free-tier specs include full component structure — anatomy, props, default variant, layout, and raw style values.
-
-With a **Pro license key**, specs also include all non-default variants, design token references, named style references, prop bindings, and invalid variant combination analysis. See [Licensing](/specs/licensing/) for full details.
-
-The license key is resolved in this priority order: `--license` flag > `SPECS_LICENSE_KEY` env > `ANOVA_LICENSE_KEY` env.
-
-Add `SPECS_LICENSE_KEY` to your `.env` file as shown above, or pass it per-command with the `-l` flag:
-
-```bash
-specs generate -l "your-license-key"
-```
-
-## Step 5: Fetch Figma data
+## Step 3: Fetch the Figma file
 
 Download raw data from your configured Figma sources:
 
@@ -210,23 +90,15 @@ Download raw data from your configured Figma sources:
 specs fetch
 ```
 
-This writes JSON data downloaded from the Figma REST API to your `dataDirectory` (e.g., `./data/library.file.json`, `./data/library.variables.json`).
+## Step 4: Scan and select components
 
-## Step 6: Scan components
-
-Discover components in a fetched file and build a manifest of components to potentially generate specs. By default, all components are checked.
+Scan your fetched data to build a manifest of available components:
 
 ```bash
 specs scan
 ```
 
-With no arguments, `scan` uses your configured source from `specs.config.yaml`. If you have multiple sources, pass `--source <alias>` to pick one (e.g., `specs scan --source library`). You can still pass an explicit path to override (`specs scan data/library.file.json`).
-
-With no `-o` flag, the manifest is written to `{dataDirectory}/{alias}.manifest.md` (e.g., `data/library.manifest.md`). This is also where `specs generate` looks for its default input.
-
-## Step 7: Select components
-
-Open `data/library.manifest.md` and select components to generate specs for. Check `[x]` to include, uncheck `[ ]` to exclude.
+Then open the generated manifest (e.g., `data/library.manifest.md`) and check the components you want:
 
 ```md
 - [ ] _random Test experiment component
@@ -236,19 +108,17 @@ Open `data/library.manifest.md` and select components to generate specs for. Che
 - [ ] Slot utility
 ```
 
-## Step 8: Generate specs
+## Step 5: Generate specs
 
-Generate specs for the selected components:
+By default, the `generate` command creates specs for all selected components.
 
 ```bash
 specs generate
 ```
 
-With no arguments, `generate` reads the default manifest (`{dataDirectory}/{alias}.manifest.md`) and writes output to `outputDirectory` from your config. Each selected component is processed and written according to your `output` settings (single file, split per component, or split by concern). You can still pass explicit paths with `<manifest>` or `-o <path>` to override either default.
+Once generated, open the specs file to review the results!
 
----
-
-## Alternative approaches to generate
+Alternatively, you can generate specs for one or some components.
 
 ### Single component
 
@@ -270,9 +140,9 @@ specs generate data/library.file.json \
   -o specs/subset.yaml
 ```
 
-### CI/CD pipeline
+##  Operationalize: CI/CD pipeline
 
-Automate spec generation in your build:
+To operationalize spec generation, teams use a github action script that runs at a specific cadence.
 
 ```yaml
 # .github/workflows/generate-specs.yml

--- a/site/src/custom.css
+++ b/site/src/custom.css
@@ -41,7 +41,7 @@ ul.top-level > li > a.large[aria-current='page']:focus {
 }
 
 /* Prepend the Pro badge before label text in the Licensing nav link */
-a[href*="/overview/licensing"] {
+.sidebar-content a[href*="/overview/licensing"] {
 	display: flex;
 	flex-direction: row-reverse;
 	justify-content: flex-end;


### PR DESCRIPTION
## Summary
- Consolidates 8 steps into 5 approachable steps for first-time users
- Merges prerequisites, init, config editing, and env setup into "Install" and "Set up your environment"
- Moves Data/Output directories, Config, and Output sections into a skippable "Other configuration (optional)" bullet list
- Reduces license key to a single sentence linking to the Licensing page
- Combines scan + select into one step
- Fixes sidebar-only CSS selector for licensing link that was breaking inline content links

🤖 Generated with [Claude Code](https://claude.com/claude-code)