### PR TITLE
ADR 043: Custom Color Format Configuration

### DIFF
--- a/.github/agents/Specs.adr.implement.agent.md
+++ b/.github/agents/Specs.adr.implement.agent.md
@@ -65,11 +65,12 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **All gates have now passed. Steps 10–12 are REQUIRED before reporting completion. Do not skip to step 13.**
 
 10. **Update docs**:
-    - Read `docs/schema/` files that correspond to the changed types (e.g., `docs/schema/styles.md` for `Styles` changes, `docs/schema/typography.md` for `Typography` changes).
-    - For each property added, removed, or renamed in the ADR: update the Properties table, the Values table, and the "Relating properties to values" section to reflect the new state.
+    - Docs live in `site/src/content/docs/`. Schema type pages are under `site/src/content/docs/schema/` (e.g., `schema/styles.md` for `Styles`, `schema/config.md` for `Config`). Individual config option pages are under `site/src/content/docs/config/` (e.g., `config/tokens.md`, `config/keys.md`).
+    - For each property added, removed, or renamed in the ADR: update the relevant doc page's Properties table, Values table, and "Relating properties to values" section to reflect the new state.
     - For new dedicated types (e.g., `LayoutMode`, `WrapAlignment`, `ItemSpacing`): add a row to the Values table describing the type and its valid values.
+    - For new config options: check if an individual config option page should be created under `config/` following the pattern of existing pages (e.g., `config/tokens.md`, `config/keys.md`).
     - Do not create new doc pages for types that are only used as field values on an existing documented type — document them inline in the parent type's page.
-    - If no `docs/schema/` file exists for the changed type, skip this step.
+    - If no doc file exists for the changed type, skip this step.
 
 11. **Update CHANGELOG.md**:
     - The release branch scaffolds an `## [X.Y.Z] - Unreleased` heading with empty sections. Add entries into the existing scaffold — do **not** replace `Unreleased` with a date (the date is set at release time). If no scaffold heading exists, prepend one using `Unreleased` as the date.

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -16,56 +16,42 @@ However, many consumers prefer a **flat string** representation of color values 
 
 - Code generation pipelines that need `#FF6600` or `hsla(24, 100%, 50%, 1)` directly
 - Documentation tools that display human-readable color values
-- Legacy system integration that expects a specific color notation
+- Integration with tools that expect a specific color notation
 
-The previous version of Specs (v1) supported a format toggle between hex and HSLA. Figma's own UI exposes a broader set of color formats:
+The previous version of Specs (v1) supported a format toggle between hex and HSLA. Specs v2 has not yet shipped a release with the `ColorValue` object — users have received hex strings by default to date. Changing the default away from hex would disrupt existing workflows for no user-requested reason.
 
-- **HEX** — `#RRGGBB` (6-digit, no alpha)
-- **HEXA** — `#RRGGBBAA` (8-digit, with alpha)
-- **RGB** — `rgb(R, G, B)` functional notation
-- **HSLA** — `hsla(H, S%, L%, A)` functional notation
-- **HSB** — `hsb(H, S%, B%)` (Figma's native model, also known as HSV)
-- **CSS** — CSS Color Level 4 `color()` functional notation (e.g., `color(display-p3 0.5 0.2 0.8)`)
+This ADR addresses two sub-decisions:
 
-The `Config.format` section already houses output-shaping options (`output`, `keys`, `layout`, `tokens`). A color format option fits naturally alongside these.
+1. **Where does the setting live?** — placement within `Config`
+2. **Which color formats are supported?** — the enum values and default
 
 ---
 
 ## Decision Drivers
 
-- **Additive change**: Must be a new optional field to avoid a MAJOR bump. Absence preserves existing `ColorValue` object behaviour.
-- **Type ↔ schema symmetry**: The new field must appear in both `Config` / `ResolvedConfig` types and `component.schema.json`.
-- **No runtime logic**: The type/schema package defines the enum values only. Formatting logic belongs in `specs-from-figma`.
-- **Enum casing convention**: String literal unions in config use `SCREAMING_CASE` per the constitution.
-- **Figma parity**: The enum values should cover all formats available in Figma's colour picker UI.
-- **Default preserves current behaviour**: When the config field is absent or set to the default, output must remain unchanged (structured `ColorValue` objects).
+- **Additive change**: Must be a new optional field to avoid a MAJOR bump
+- **Type ↔ schema symmetry**: The new field must appear in both `Config` / `ResolvedConfig` types and `component.schema.json`
+- **No runtime logic**: The type/schema package defines the enum values only. Formatting logic belongs in `specs-from-figma`
+- **Enum casing convention**: String literal unions in config use `SCREAMING_CASE` per the constitution
+- **Figma parity**: The enum values should cover all formats available in Figma's colour picker UI
+- **Least surprise default**: The default should match what users have historically received (hex strings), not introduce a new output shape
+- **Extensibility**: The enum should accommodate future colour formats as MINOR additions
 
 ---
 
 ## Options Considered
 
-### Option A: Add `format.color` with `OBJECT` default *(Selected)*
+### Option A: Add `format.color` under existing `format` section *(Selected)*
 
-Add an optional `color` field to `Config.format` with a string enum covering all Figma formats plus the current structured object as the default.
-
-Enum values: `'OBJECT' | 'HEX' | 'HEXA' | 'RGB' | 'HSLA' | 'HSB' | 'CSS'`
-
-- `OBJECT` — current `ColorValue` object output (default, preserves backwards compatibility)
-- `HEX` — 6-digit hex string `#RRGGBB`
-- `HEXA` — 8-digit hex string `#RRGGBBAA`
-- `RGB` — `rgb(R, G, B)` or `rgba(R, G, B, A)` functional notation
-- `HSLA` — `hsla(H, S%, L%, A)` functional notation
-- `HSB` — `hsb(H, S%, B%)` notation (Figma's native colour model)
-- `CSS` — CSS Color Level 4 `color()` notation
+Add an optional `color` field to `Config.format` alongside the existing `output`, `keys`, `layout`, and `tokens` fields.
 
 **Pros**:
-- Fits naturally into the existing `format` section alongside `output`, `keys`, `layout`, `tokens`
-- `OBJECT` default preserves exact current behaviour — no breaking change
-- Covers all Figma UI formats plus the structured object
-- Follows established pattern: enum string union, optional with default
+- All output-shaping options are co-located under `format`
+- Follows the established pattern: string enum, optional with default, `SCREAMING_CASE` values
+- Consistent with how `format.tokens` controls token serialization shape
 
 **Cons / Trade-offs**:
-- When a non-`OBJECT` format is selected, the output type for color positions changes from `ColorValue` to `string`, which means the TypeScript type for color-bearing properties becomes less precise at compile time (consumers must check `Config.format.color` to know the runtime shape)
+- When a non-`OBJECT` format is selected, the output type for colour positions changes from `ColorValue` to `string` — consumers must check `Config.format.color` to know the runtime shape
 
 ---
 
@@ -85,21 +71,69 @@ A boolean to opt into string output plus a separate notation selector.
 
 ---
 
+## Supported Formats
+
+The enum values fall into three tiers based on origin and priority:
+
+### Tier 1 — Figma UI formats
+
+These match the colour format options in Figma's colour picker, ensuring parity with the design tool:
+
+| Value | Output example | Notes |
+|-------|---------------|-------|
+| `HEX` | `#FF6600` | 6-digit sRGB, no alpha. **Default** — matches v1 behaviour and maximises human readability |
+| `HEXA` | `#FF6600FF` | 8-digit sRGB with alpha channel |
+| `RGB` | `rgb(255, 102, 0)` | CSS `rgb()` functional notation (0–255 integer components) |
+| `RGBA` | `rgba(255, 102, 0, 1)` | CSS `rgba()` functional notation with alpha. This is what Figma labels "CSS" in its UI — despite the name, it uses legacy CSS Color Level 3 `rgba()` syntax, not the Level 4 `color()` function |
+| `HSLA` | `hsla(24, 100%, 50%, 1)` | CSS `hsla()` functional notation |
+| `HSB` | `hsb(24, 100%, 100%)` | Figma's native colour model (also known as HSV). Not a CSS function — consumers targeting CSS should use `HSLA` instead |
+
+### Tier 2 — Modern CSS (CSS Color Level 4)
+
+These provide perceptually uniform colour representations gaining adoption in modern CSS tooling:
+
+| Value | Output example | Notes |
+|-------|---------------|-------|
+| `OKLCH` | `oklch(0.7 0.15 50 / 1)` | Perceptually uniform cylindrical model. Increasingly popular for design systems because lightness, chroma, and hue are independently adjustable without shifting perceived colour |
+| `OKLAB` | `oklab(0.7 0.1 0.1 / 1)` | Perceptually uniform rectangular model. Sibling to OKLCH; better for programmatic colour manipulation (interpolation, mixing) |
+
+### Tier 3 — Structured object
+
+| Value | Output example | Notes |
+|-------|---------------|-------|
+| `OBJECT` | `{ colorSpace: "srgb", components: [1, 0.4, 0], alpha: 1, hex: "#FF6600" }` | Full `ColorValue` object per DTCG Color §4.1. Preserves colour space, component values, and alpha with no lossy conversion. Opt-in for consumers that need structured data |
+
+### Formats deferred
+
+- **CSS `color()` function** — `color(display-p3 0.5 0.2 0.8)` would be the only string format that preserves the exact `colorSpace` from the `ColorValue` object, covering wide-gamut spaces like Display P3 and Rec. 2020. Deferred because OKLCH/OKLAB already address the "modern CSS" need, and `OBJECT` preserves full colour-space fidelity for consumers that require it. Can be added as a MINOR enum extension if wide-gamut string output demand arises.
+
+### Default rationale
+
+`HEX` is the default because:
+
+- **Historical continuity**: Specs v1 output hex by default; v2 has not yet shipped a release with `ColorValue` objects. Hex is what users expect.
+- **Human readability**: `#FF6600` is universally recognised and compact. It appears in every design tool, every browser DevTools pane, and most design system documentation.
+- **Lowest friction**: New users can start without configuring colour format and get usable output immediately.
+- **`OBJECT` is opt-in**: Consumers that need structured colour data (colour-space-aware pipelines, DTCG tooling) can explicitly set `format.color: 'OBJECT'`. This is a power-user feature, not a default.
+
+---
+
 ## Decision
 
 ### Type changes (`types/`)
 
 | File | Change | Bump |
 |------|--------|------|
-| `Config.ts` | Add optional `color` field to `Config.format` | MINOR |
-| `Config.ts` | Add required `color` field to `ResolvedConfig.format` | MINOR |
-| `Config.ts` | Add `color: 'OBJECT'` to `DEFAULT_CONFIG.format` | MINOR |
+| `Config.ts` | Add `ColorFormat` named type | MINOR |
+| `Config.ts` | Add optional `color?: ColorFormat` field to `Config.format` | MINOR |
+| `Config.ts` | Add required `color: ColorFormat` field to `ResolvedConfig.format` | MINOR |
+| `Config.ts` | Add `color: 'HEX'` to `DEFAULT_CONFIG.format` | MINOR |
 | `index.ts` | Export `ColorFormat` type | MINOR |
 
 **New type** (`types/Config.ts`):
 ```yaml
 # New named type
-ColorFormat: "'OBJECT' | 'HEX' | 'HEXA' | 'RGB' | 'HSLA' | 'HSB' | 'CSS'"
+ColorFormat: "'HEX' | 'HEXA' | 'RGB' | 'RGBA' | 'HSLA' | 'HSB' | 'OKLCH' | 'OKLAB' | 'OBJECT'"
 
 # Config.format — before
 format:
@@ -130,7 +164,7 @@ format:
   keys: 'SAFE'
   layout: 'LAYOUT'
   tokens: 'TOKEN'
-  color: 'OBJECT'        # preserves current behaviour
+  color: 'HEX'          # matches historical v1 behaviour
 ```
 
 ### Schema changes (`schema/`)
@@ -144,24 +178,27 @@ format:
 color:
   type: string
   enum:
-    - OBJECT
     - HEX
     - HEXA
     - RGB
+    - RGBA
     - HSLA
     - HSB
-    - CSS
-  default: OBJECT
+    - OKLCH
+    - OKLAB
+    - OBJECT
+  default: HEX
   description: >-
-    Color value output format. OBJECT emits the full ColorValue object
-    (colorSpace, components, alpha, hex). All other values emit a
-    formatted color string. Defaults to OBJECT.
+    Color value output format. HEX (default) emits a 6-digit hex string.
+    OBJECT emits the full ColorValue object (colorSpace, components, alpha, hex).
+    All other values emit a formatted color string in the named notation.
 ```
 
 ### Notes
 
 - The `ColorFormat` named type follows the pattern established by other config enums. While most config values are inline literal unions, a named export is justified here because downstream consumers need to reference this type when implementing format-specific logic.
 - When `format.color` is not `OBJECT`, every property currently typed as `ColorValue` in the output will instead contain a `string`. This affects `backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stop `color`, and shadow `color`. The type/schema package does **not** change these property types — the runtime formatting is a `specs-from-figma` concern. The schema already accommodates string values in `ColorStyleValue` and related definitions.
+- The Figma UI labels its `rgba()` output as "CSS". This ADR uses `RGBA` instead because: (a) `rgba()` is legacy CSS Color Level 3 syntax — calling it "CSS" is misleading now that CSS Color Level 4 exists; (b) `RGBA` precisely describes the output function.
 
 ---
 
@@ -192,8 +229,9 @@ color:
 
 ## Consequences
 
-- Consumers can configure `format.color` to receive flat colour strings instead of `ColorValue` objects, matching their downstream toolchain's expected notation
-- The `OBJECT` default preserves full backwards compatibility — existing integrations are unaffected
-- `specs-from-figma` gains responsibility for colour space conversion logic (e.g., sRGB → HSL) when non-`OBJECT` formats are selected
-- All Figma-native colour formats are supported, achieving parity with the Figma UI colour picker
-- Future colour formats can be added to the enum as a MINOR change
+- Consumers can configure `format.color` to receive colour values in their preferred notation, matching their downstream toolchain's expectations
+- `HEX` default preserves historical Specs v1 behaviour — existing users see no change in output
+- Consumers that need structured DTCG-aligned colour data explicitly opt in via `OBJECT`
+- `specs-from-figma` gains responsibility for colour space conversion logic (e.g., sRGB → HSL, sRGB → OKLCH) when non-`OBJECT` formats are selected
+- All Figma-native colour formats are supported, plus modern CSS perceptually uniform models (OKLCH, OKLAB)
+- Future colour formats (e.g., CSS `color()` function for wide-gamut output) can be added to the enum as a MINOR change

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -2,7 +2,7 @@
 
 **Branch**: `043-custom-color-format-config`
 **Created**: 2026-05-01
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -221,9 +221,9 @@ color:
 
 ## Semver Decision
 
-**Version bump**: `0.20.0 → 0.21.0` (`MINOR`)
+**Version bump**: Included in `0.20.0` (no additional bump)
 
-**Justification**: All changes are additive optional fields on existing types. No existing field is removed, renamed, or has its type signature altered. This is a MINOR bump per constitution §Versioning: "MINOR for additive types or new optional fields."
+**Justification**: All changes are additive optional fields on existing types. No existing field is removed, renamed, or has its type signature altered. This qualifies as MINOR per constitution §Versioning, and `0.20.0` has not yet been published — this change ships as part of the current release.
 
 ---
 

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -214,7 +214,7 @@ color:
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
 | `specs-from-figma` | Low — colour formatting targets the tail end of the processing pipeline where data is emitted, not the core transformation logic | Add a colour formatting step at output emission that reads `resolvedConfig.format.color` and converts `ColorValue` objects to the requested string notation (or passes through for `OBJECT`) |
-| `specs-cli` | Config surface expands; documentation must describe the new option | Add `format.color` to CLI config handling and help output; update documentation to describe available colour formats and their output |
+| `specs-cli` | Config surface expands; initialization must include the new field; documentation must describe the new option | Update config initialization to include `format.color`; add to CLI config handling and help output; update documentation to describe available colour formats and their output |
 | `specs-plugin` | Config UI expands; must also handle `OBJECT` format display in the plugin output viewer | Widen config shape to include `format.color`; add UI control adjacent to existing format options (output, keys, layout, tokens); handle rendering of `OBJECT` format in plugin output display |
 
 ---

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -1,0 +1,199 @@
+# ADR: Custom Color Format Configuration
+
+**Branch**: `043-custom-color-format-config`
+**Created**: 2026-05-01
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+ADR-009 replaced bare hex strings with the structured `ColorValue` object across all color-bearing properties (`backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stops, shadows). `ColorValue` carries `colorSpace`, `components`, `alpha`, and an optional `hex` fallback — a rich, DTCG-aligned representation.
+
+However, many consumers prefer a **flat string** representation of color values rather than the full object. Common use cases include:
+
+- Code generation pipelines that need `#FF6600` or `hsla(24, 100%, 50%, 1)` directly
+- Documentation tools that display human-readable color values
+- Legacy system integration that expects a specific color notation
+
+The previous version of Specs (v1) supported a format toggle between hex and HSLA. Figma's own UI exposes a broader set of color formats:
+
+- **HEX** — `#RRGGBB` (6-digit, no alpha)
+- **HEXA** — `#RRGGBBAA` (8-digit, with alpha)
+- **RGB** — `rgb(R, G, B)` functional notation
+- **HSLA** — `hsla(H, S%, L%, A)` functional notation
+- **HSB** — `hsb(H, S%, B%)` (Figma's native model, also known as HSV)
+- **CSS** — CSS Color Level 4 `color()` functional notation (e.g., `color(display-p3 0.5 0.2 0.8)`)
+
+The `Config.format` section already houses output-shaping options (`output`, `keys`, `layout`, `tokens`). A color format option fits naturally alongside these.
+
+---
+
+## Decision Drivers
+
+- **Additive change**: Must be a new optional field to avoid a MAJOR bump. Absence preserves existing `ColorValue` object behaviour.
+- **Type ↔ schema symmetry**: The new field must appear in both `Config` / `ResolvedConfig` types and `component.schema.json`.
+- **No runtime logic**: The type/schema package defines the enum values only. Formatting logic belongs in `specs-from-figma`.
+- **Enum casing convention**: String literal unions in config use `SCREAMING_CASE` per the constitution.
+- **Figma parity**: The enum values should cover all formats available in Figma's colour picker UI.
+- **Default preserves current behaviour**: When the config field is absent or set to the default, output must remain unchanged (structured `ColorValue` objects).
+
+---
+
+## Options Considered
+
+### Option A: Add `format.color` with `OBJECT` default *(Selected)*
+
+Add an optional `color` field to `Config.format` with a string enum covering all Figma formats plus the current structured object as the default.
+
+Enum values: `'OBJECT' | 'HEX' | 'HEXA' | 'RGB' | 'HSLA' | 'HSB' | 'CSS'`
+
+- `OBJECT` — current `ColorValue` object output (default, preserves backwards compatibility)
+- `HEX` — 6-digit hex string `#RRGGBB`
+- `HEXA` — 8-digit hex string `#RRGGBBAA`
+- `RGB` — `rgb(R, G, B)` or `rgba(R, G, B, A)` functional notation
+- `HSLA` — `hsla(H, S%, L%, A)` functional notation
+- `HSB` — `hsb(H, S%, B%)` notation (Figma's native colour model)
+- `CSS` — CSS Color Level 4 `color()` notation
+
+**Pros**:
+- Fits naturally into the existing `format` section alongside `output`, `keys`, `layout`, `tokens`
+- `OBJECT` default preserves exact current behaviour — no breaking change
+- Covers all Figma UI formats plus the structured object
+- Follows established pattern: enum string union, optional with default
+
+**Cons / Trade-offs**:
+- When a non-`OBJECT` format is selected, the output type for color positions changes from `ColorValue` to `string`, which means the TypeScript type for color-bearing properties becomes less precise at compile time (consumers must check `Config.format.color` to know the runtime shape)
+
+---
+
+### Option B: Add a top-level `colorFormat` field outside `format` *(Rejected)*
+
+Place the field at `Config.colorFormat` rather than `Config.format.color`.
+
+**Rejected because**: All other output-shaping format options live under `Config.format`. Placing this outside breaks the organisational convention and makes the config harder to reason about.
+
+---
+
+### Option C: Boolean `flattenColors` toggle with a separate `colorNotation` field *(Rejected)*
+
+A boolean to opt into string output plus a separate notation selector.
+
+**Rejected because**: Requires two fields where one suffices. The `OBJECT` enum value already serves as the "don't flatten" mode, making a boolean redundant.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Config.ts` | Add optional `color` field to `Config.format` | MINOR |
+| `Config.ts` | Add required `color` field to `ResolvedConfig.format` | MINOR |
+| `Config.ts` | Add `color: 'OBJECT'` to `DEFAULT_CONFIG.format` | MINOR |
+| `index.ts` | Export `ColorFormat` type | MINOR |
+
+**New type** (`types/Config.ts`):
+```yaml
+# New named type
+ColorFormat: "'OBJECT' | 'HEX' | 'HEXA' | 'RGB' | 'HSLA' | 'HSB' | 'CSS'"
+
+# Config.format — before
+format:
+  output?: 'JSON' | 'YAML'
+  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+  layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH'
+  tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM'
+
+# Config.format — after
+format:
+  output?: 'JSON' | 'YAML'
+  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+  layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH'
+  tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM'
+  color?: ColorFormat    # optional — MINOR
+
+# ResolvedConfig.format — after (required, with default)
+format:
+  output: 'JSON' | 'YAML'
+  keys: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+  layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH'
+  tokens: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM'
+  color: ColorFormat     # required in resolved config
+
+# DEFAULT_CONFIG.format — after
+format:
+  output: 'JSON'
+  keys: 'SAFE'
+  layout: 'LAYOUT'
+  tokens: 'TOKEN'
+  color: 'OBJECT'        # preserves current behaviour
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add `color` property to `Config.format` | MINOR |
+
+**New property** (`schema/component.schema.json` — under `#/definitions/Config/properties/format/properties`):
+```yaml
+color:
+  type: string
+  enum:
+    - OBJECT
+    - HEX
+    - HEXA
+    - RGB
+    - HSLA
+    - HSB
+    - CSS
+  default: OBJECT
+  description: >-
+    Color value output format. OBJECT emits the full ColorValue object
+    (colorSpace, components, alpha, hex). All other values emit a
+    formatted color string. Defaults to OBJECT.
+```
+
+### Notes
+
+- The `ColorFormat` named type follows the pattern established by other config enums. While most config values are inline literal unions, a named export is justified here because downstream consumers need to reference this type when implementing format-specific logic.
+- When `format.color` is not `OBJECT`, every property currently typed as `ColorValue` in the output will instead contain a `string`. This affects `backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stop `color`, and shadow `color`. The type/schema package does **not** change these property types — the runtime formatting is a `specs-from-figma` concern. The schema already accommodates string values in `ColorStyleValue` and related definitions.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — one new optional property `color` is added to `Config.format` in both TypeScript types and JSON schema.
+- **Parity check**: `Config.format.color` (type) ↔ `#/definitions/Config/properties/format/properties/color` (schema). Same enum values, same default, same optionality.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Must read `resolvedConfig.format.color` and format `ColorValue` objects into the requested string notation when not `OBJECT` | Implement colour formatting logic for each enum value |
+| `specs-cli` | Passes config to `specs-from-figma`; no CLI-specific logic needed | Recompile against updated types |
+| `specs-plugin` | Passes config to `specs-from-figma`; may expose a UI dropdown for the new option | Recompile; optionally add UI control |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.20.0 → 0.21.0` (`MINOR`)
+
+**Justification**: All changes are additive optional fields on existing types. No existing field is removed, renamed, or has its type signature altered. This is a MINOR bump per constitution §Versioning: "MINOR for additive types or new optional fields."
+
+---
+
+## Consequences
+
+- Consumers can configure `format.color` to receive flat colour strings instead of `ColorValue` objects, matching their downstream toolchain's expected notation
+- The `OBJECT` default preserves full backwards compatibility — existing integrations are unaffected
+- `specs-from-figma` gains responsibility for colour space conversion logic (e.g., sRGB → HSL) when non-`OBJECT` formats are selected
+- All Figma-native colour formats are supported, achieving parity with the Figma UI colour picker
+- Future colour formats can be added to the enum as a MINOR change

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -213,9 +213,9 @@ color:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | Must read `resolvedConfig.format.color` and format `ColorValue` objects into the requested string notation when not `OBJECT` | Implement colour formatting logic for each enum value |
-| `specs-cli` | Passes config to `specs-from-figma`; no CLI-specific logic needed | Recompile against updated types |
-| `specs-plugin` | Passes config to `specs-from-figma`; may expose a UI dropdown for the new option | Recompile; optionally add UI control |
+| `specs-from-figma` | Low — colour formatting targets the tail end of the processing pipeline where data is emitted, not the core transformation logic | Add a colour formatting step at output emission that reads `resolvedConfig.format.color` and converts `ColorValue` objects to the requested string notation (or passes through for `OBJECT`) |
+| `specs-cli` | Config surface expands; documentation must describe the new option | Add `format.color` to CLI config handling and help output; update documentation to describe available colour formats and their output |
+| `specs-plugin` | Config UI expands; must also handle `OBJECT` format display in the plugin output viewer | Widen config shape to include `format.color`; add UI control adjacent to existing format options (output, keys, layout, tokens); handle rendering of `OBJECT` format in plugin output display |
 
 ---
 

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -10,7 +10,7 @@
 
 ## Context
 
-ADR-009 replaced bare hex strings with the structured `ColorValue` object across all color-bearing properties (`backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stops, shadows). `ColorValue` carries `colorSpace`, `components`, `alpha`, and an optional `hex` fallback — a rich, DTCG-aligned representation.
+ADR-009 replaced bare hex strings with the structured `ColorObject` object across all color-bearing properties (`backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stops, shadows). `ColorObject` carries `colorSpace`, `components`, `alpha`, and an optional `hex` fallback — a rich, DTCG-aligned representation.
 
 However, many consumers prefer a **flat string** representation of color values rather than the full object. Common use cases include:
 
@@ -18,7 +18,7 @@ However, many consumers prefer a **flat string** representation of color values 
 - Documentation tools that display human-readable color values
 - Integration with tools that expect a specific color notation
 
-The previous version of Specs (v1) supported a format toggle between hex and HSLA. Specs v2 has not yet shipped a release with the `ColorValue` object — users have received hex strings by default to date. Changing the default away from hex would disrupt existing workflows for no user-requested reason.
+The previous version of Specs (v1) supported a format toggle between hex and HSLA. Specs v2 has not yet shipped a release with the `ColorObject` object — users have received hex strings by default to date. Changing the default away from hex would disrupt existing workflows for no user-requested reason.
 
 This ADR addresses two sub-decisions:
 
@@ -51,7 +51,7 @@ Add an optional `color` field to `Config.format` alongside the existing `output`
 - Consistent with how `format.tokens` controls token serialization shape
 
 **Cons / Trade-offs**:
-- When a non-`OBJECT` format is selected, the output type for colour positions changes from `ColorValue` to `string` — consumers must check `Config.format.color` to know the runtime shape
+- When a non-`OBJECT` format is selected, the output type for colour positions changes from `ColorObject` to `string` — consumers must check `Config.format.color` to know the runtime shape
 
 ---
 
@@ -101,17 +101,17 @@ These provide perceptually uniform colour representations gaining adoption in mo
 
 | Value | Output example | Notes |
 |-------|---------------|-------|
-| `OBJECT` | `{ colorSpace: "srgb", components: [1, 0.4, 0], alpha: 1, hex: "#FF6600" }` | Full `ColorValue` object per DTCG Color §4.1. Preserves colour space, component values, and alpha with no lossy conversion. Opt-in for consumers that need structured data |
+| `OBJECT` | `{ colorSpace: "srgb", components: [1, 0.4, 0], alpha: 1, hex: "#FF6600" }` | Full `ColorObject` object per DTCG Color §4.1. Preserves colour space, component values, and alpha with no lossy conversion. Opt-in for consumers that need structured data |
 
 ### Formats deferred
 
-- **CSS `color()` function** — `color(display-p3 0.5 0.2 0.8)` would be the only string format that preserves the exact `colorSpace` from the `ColorValue` object, covering wide-gamut spaces like Display P3 and Rec. 2020. Deferred because OKLCH/OKLAB already address the "modern CSS" need, and `OBJECT` preserves full colour-space fidelity for consumers that require it. Can be added as a MINOR enum extension if wide-gamut string output demand arises.
+- **CSS `color()` function** — `color(display-p3 0.5 0.2 0.8)` would be the only string format that preserves the exact `colorSpace` from the `ColorObject` object, covering wide-gamut spaces like Display P3 and Rec. 2020. Deferred because OKLCH/OKLAB already address the "modern CSS" need, and `OBJECT` preserves full colour-space fidelity for consumers that require it. Can be added as a MINOR enum extension if wide-gamut string output demand arises.
 
 ### Default rationale
 
 `HEX` is the default because:
 
-- **Historical continuity**: Specs v1 output hex by default; v2 has not yet shipped a release with `ColorValue` objects. Hex is what users expect.
+- **Historical continuity**: Specs v1 output hex by default; v2 has not yet shipped a release with `ColorObject` objects. Hex is what users expect.
 - **Human readability**: `#FF6600` is universally recognised and compact. It appears in every design tool, every browser DevTools pane, and most design system documentation.
 - **Lowest friction**: New users can start without configuring colour format and get usable output immediately.
 - **`OBJECT` is opt-in**: Consumers that need structured colour data (colour-space-aware pipelines, DTCG tooling) can explicitly set `format.color: 'OBJECT'`. This is a power-user feature, not a default.
@@ -129,6 +129,9 @@ These provide perceptually uniform colour representations gaining adoption in mo
 | `Config.ts` | Add required `color: ColorFormat` field to `ResolvedConfig.format` | MINOR |
 | `Config.ts` | Add `color: 'HEX'` to `DEFAULT_CONFIG.format` | MINOR |
 | `index.ts` | Export `ColorFormat` type | MINOR |
+| `Styles.ts` | Widen `ColorStyle` to include `string` arm | MINOR |
+| `Effects.ts` | Widen `Shadow.color` to include `string` arm | MINOR |
+| `Gradient.ts` | Widen `GradientStop.color` to include `string` arm | MINOR |
 
 **New type** (`types/Config.ts`):
 ```yaml
@@ -172,6 +175,7 @@ format:
 | File | Change | Bump |
 |------|--------|------|
 | `component.schema.json` | Add `color` property to `Config.format` | MINOR |
+| `styles.schema.json` | Add `string` arm to `ColorStyleValue`, `Shadow.color`, and `GradientStop.color` | MINOR |
 
 **New property** (`schema/component.schema.json` — under `#/definitions/Config/properties/format/properties`):
 ```yaml
@@ -190,14 +194,14 @@ color:
   default: HEX
   description: >-
     Color value output format. HEX (default) emits a 6-digit hex string.
-    OBJECT emits the full ColorValue object (colorSpace, components, alpha, hex).
+    OBJECT emits the full ColorObject object (colorSpace, components, alpha, hex).
     All other values emit a formatted color string in the named notation.
 ```
 
 ### Notes
 
 - The `ColorFormat` named type follows the pattern established by other config enums. While most config values are inline literal unions, a named export is justified here because downstream consumers need to reference this type when implementing format-specific logic.
-- When `format.color` is not `OBJECT`, every property currently typed as `ColorValue` in the output will instead contain a `string`. This affects `backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stop `color`, and shadow `color`. The type/schema package does **not** change these property types — the runtime formatting is a `specs-from-figma` concern. The schema already accommodates string values in `ColorStyleValue` and related definitions.
+- When `format.color` is not `OBJECT`, every property currently typed as `ColorObject` in the output will instead contain a `string`. This affects `backgroundColor`, `fillColor`, `textColor`, `strokes`, gradient stop `color`, and shadow `color`. To ensure the schema validates both object and string colour values, `string` is added as an arm to `ColorStyle`, `Shadow.color`, `GradientStop.color`, and their schema counterparts (`ColorStyleValue`, `Shadow/properties/color`, `GradientStop/properties/color`).
 - The Figma UI labels its `rgba()` output as "CSS". This ADR uses `RGBA` instead because: (a) `rgba()` is legacy CSS Color Level 3 syntax — calling it "CSS" is misleading now that CSS Color Level 4 exists; (b) `RGBA` precisely describes the output function.
 
 ---
@@ -213,7 +217,7 @@ color:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | Low — colour formatting targets the tail end of the processing pipeline where data is emitted, not the core transformation logic | Add a colour formatting step at output emission that reads `resolvedConfig.format.color` and converts `ColorValue` objects to the requested string notation (or passes through for `OBJECT`) |
+| `specs-from-figma` | Low — colour formatting targets the tail end of the processing pipeline where data is emitted, not the core transformation logic | Add a colour formatting step at output emission that reads `resolvedConfig.format.color` and converts `ColorObject` objects to the requested string notation (or passes through for `OBJECT`) |
 | `specs-cli` | Config surface expands; initialization must include the new field; documentation must describe the new option | Update config initialization to include `format.color`; add to CLI config handling and help output; update documentation to describe available colour formats and their output |
 | `specs-plugin` | Config UI expands; must also handle `OBJECT` format display in the plugin output viewer | Widen config shape to include `format.color`; add UI control adjacent to existing format options (output, keys, layout, tokens); handle rendering of `OBJECT` format in plugin output display |
 

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 043 | Custom Color Format Configuration | |
 | 042 | Composition as a First-Class Type | |
 | 041 | Layout Positioning — Constraint-Based Naming | |
 | 035 | Make Config Properties with Defaults Optional | |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 043 | Custom Color Format Configuration | |
 | 042 | Composition as a First-Class Type | |
 | 041 | Layout Positioning — Constraint-Based Naming | |
 | 035 | Make Config Properties with Defaults Optional | |
@@ -19,6 +18,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 043 | Custom Color Format Configuration | Add `Config.format.color` with 9-format enum (HEX default); rename `ColorValue` → `ColorObject`; widen color types with `string` arm |
 | 041 | Layout Positioning — Constraint-Based Naming | Replace `x`/`y`/`layoutPositioning` with constraint-based `position`, `start`, `end`, `top`, `bottom`, center offsets |
 | 040 | Replace `primaryAxisAlignItems` and `counterAxisAlignItems` with `mainAxisAlignment` and `crossAxisAlignment` | Rename to platform-neutral names; add `MainAxisAlignment` and `CrossAxisAlignment` enums; not token-bindable |
 | 039 | Replace `layoutWrap` and `counterAxisAlignContent` with `wrap` and `wrapAlignment` | Rename to platform-neutral names; add `WrapAlignment` enum (`START \| SPACE_BETWEEN`); not token-bindable |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,13 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Config.format.color` — typed as `ColorFormat` (`'HEX' | 'HEXA' | 'RGB' | 'RGBA' | 'HSLA' | 'HSB' | 'OKLCH' | 'OKLAB' | 'OBJECT'`); controls color value output format; defaults to `HEX`
+
 ### Changed
 
-### Fixed
+### Changed
 
-- `ColorStyle` — replaced bare hex `string` arm with `ColorValue` object per ADR-009; completes the DTCG Color §4.1 alignment started when the `ColorValue` type was added
-- `GradientStop.color` — replaced bare hex `string` arm with `ColorValue` per ADR-009
-- `Shadow.color` — replaced bare hex `string` arm with `ColorValue` per ADR-009
+- `ColorObject` — renamed from `ColorValue` for specificity; the type represents a DTCG Color §4.1 structured object, not a generic "color value"
+- `ColorStyle` — widened to `string | ColorObject | TokenReference | GradientValue | null`; the `string` arm supports formatted color strings when `Config.format.color` is non-`OBJECT`
+- `Shadow.color` — widened to `string | ColorObject | TokenReference`; same `string` arm rationale as `ColorStyle`
+- `GradientStop.color` — widened to `string | ColorObject | TokenReference`; same `string` arm rationale as `ColorStyle`
+
+### Fixed
 
 ### Removed
 

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -13,16 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Changed
-
 - `ColorObject` — renamed from `ColorValue` for specificity; the type represents a DTCG Color §4.1 structured object, not a generic "color value"
 - `ColorStyle` — widened to `string | ColorObject | TokenReference | GradientValue | null`; the `string` arm supports formatted color strings when `Config.format.color` is non-`OBJECT`
 - `Shadow.color` — widened to `string | ColorObject | TokenReference`; same `string` arm rationale as `ColorStyle`
 - `GradientStop.color` — widened to `string | ColorObject | TokenReference`; same `string` arm rationale as `ColorStyle`
-
-### Fixed
-
-### Removed
 
 
 ## [0.19.0] - 2026-04-28

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -861,6 +861,22 @@
               ],
               "default": "TOKEN",
               "description": "Token reference serialization profile. Optional; defaults to TOKEN. CUSTOM delegates projection entirely to the transformer."
+            },
+            "color": {
+              "type": "string",
+              "enum": [
+                "HEX",
+                "HEXA",
+                "RGB",
+                "RGBA",
+                "HSLA",
+                "HSB",
+                "OKLCH",
+                "OKLAB",
+                "OBJECT"
+              ],
+              "default": "HEX",
+              "description": "Color value output format. HEX (default) emits a 6-digit hex string. OBJECT emits the full ColorObject object (colorSpace, components, alpha, hex). All other values emit a formatted color string in the named notation."
             }
           },
           "required": [],

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -119,7 +119,8 @@
         },
         "color": {
           "oneOf": [
-            { "$ref": "#/definitions/ColorValue", "description": "Stop color as a DTCG Color object" },
+            { "type": "string", "description": "Formatted color string when Config.format.color is non-OBJECT" },
+            { "$ref": "#/definitions/ColorObject", "description": "Stop color as a DTCG Color object" },
             { "$ref": "#/definitions/TokenReference", "description": "Stop color as a token reference" }
           ]
         }
@@ -183,7 +184,7 @@
         { "$ref": "#/definitions/AngularGradient" }
       ]
     },
-    "ColorValue": {
+    "ColorObject": {
       "type": "object",
       "description": "Inline resolved color value per DTCG Color Module \u00a74.1. `colorSpace` and `components` are required; `alpha` defaults to 1 (fully opaque) when omitted; `hex` is an optional 6-digit sRGB fallback (#RRGGBB \u2014 no alpha channel in hex). Consumers SHOULD prefer `colorSpace` + `components` for rendering.",
       "properties": {
@@ -224,9 +225,10 @@
       "additionalProperties": false
     },
     "ColorStyleValue": {
-      "description": "Color style value. Covers inline resolved color (DTCG Color \u00a74.1 object), token reference, inline gradient, or null.",
+      "description": "Color style value. Covers formatted color string, inline resolved color object, token reference, inline gradient, or null. The string arm is emitted when Config.format.color is set to a non-OBJECT format.",
       "oneOf": [
-        { "$ref": "#/definitions/ColorValue", "description": "Inline resolved color value with colorSpace, components, optional alpha, and optional 6-digit hex fallback." },
+        { "type": "string", "description": "Formatted color string (e.g. '#FF6600', 'rgba(255,102,0,1)') emitted when Config.format.color is non-OBJECT." },
+        { "$ref": "#/definitions/ColorObject", "description": "Inline resolved color value with colorSpace, components, optional alpha, and optional 6-digit hex fallback." },
         { "$ref": "#/definitions/TokenReference" },
         { "$ref": "#/definitions/GradientValue" },
         { "type": "null" }
@@ -411,7 +413,7 @@
         "offsetY": { "oneOf": [{ "type": "number" }, { "$ref": "#/definitions/TokenReference" }], "description": "Vertical offset in pixels (DTCG)" },
         "blur": { "oneOf": [{ "type": "number" }, { "$ref": "#/definitions/TokenReference" }], "description": "Blur radius in pixels" },
         "spread": { "oneOf": [{ "type": "number" }, { "$ref": "#/definitions/TokenReference" }], "description": "Spread radius in pixels" },
-        "color": { "oneOf": [{ "$ref": "#/definitions/ColorValue", "description": "DTCG Color object" }, { "$ref": "#/definitions/TokenReference" }], "description": "Shadow color" }
+        "color": { "oneOf": [{ "type": "string", "description": "Formatted color string when Config.format.color is non-OBJECT" }, { "$ref": "#/definitions/ColorObject", "description": "DTCG Color object" }, { "$ref": "#/definitions/TokenReference" }], "description": "Shadow color" }
       },
       "required": ["visible", "offsetX", "offsetY", "blur", "spread", "color"],
       "additionalProperties": false

--- a/packages/schema/tests/Config.test-d.ts
+++ b/packages/schema/tests/Config.test-d.ts
@@ -3,7 +3,7 @@
  * These files are intentionally never executed — they are compiled with tsc
  * to assert that the type shape is correct.
  */
-import type { Config, ResolvedConfig } from '../types/index.js';
+import type { Config, ResolvedConfig, ColorFormat } from '../types/index.js';
 import { DEFAULT_CONFIG } from '../types/index.js';
 
 // ─── Helper: minimal valid processing + format + include ──────────────────────
@@ -33,6 +33,7 @@ const fullConfig: Config = {
     keys: 'SAFE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
+    color: 'HEX',
   },
   include: {
     invalidVariants: false,
@@ -167,7 +168,7 @@ const defaultTokensValue: typeof DEFAULT_CONFIG.format.tokens = 'TOKEN';
 
 const resolved: ResolvedConfig = {
   processing: { slotConstraints: false, variantDepth: 9999, details: 'LAYERED', inferNumberProps: false },
-  format: { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT', tokens: 'TOKEN' },
+  format: { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT', tokens: 'TOKEN', color: 'HEX' },
   include: { invalidVariants: false, invalidCombinations: true, emptyVariants: false },
 };
 
@@ -224,3 +225,32 @@ const _inferUndefined: Config['processing']['inferNumberProps'] = undefined;
 // ─── slotConstraints is optional ──────────────────────────────────────────────
 
 const _slotConstraintsUndefined: Config['processing']['slotConstraints'] = undefined;
+
+// ─── format.color is optional on Config ─────────────────────────────────────
+
+const _colorUndefined: Config['format']['color'] = undefined;
+
+// ─── All ColorFormat enum values are valid ──────────────────────────────────
+
+const _cfHex: ColorFormat = 'HEX';
+const _cfHexa: ColorFormat = 'HEXA';
+const _cfRgb: ColorFormat = 'RGB';
+const _cfRgba: ColorFormat = 'RGBA';
+const _cfHsla: ColorFormat = 'HSLA';
+const _cfHsb: ColorFormat = 'HSB';
+const _cfOklch: ColorFormat = 'OKLCH';
+const _cfOklab: ColorFormat = 'OKLAB';
+const _cfObject: ColorFormat = 'OBJECT';
+
+// @ts-expect-error — invalid ColorFormat value
+const _cfBad: ColorFormat = 'CMYK';
+
+// ─── format.color is required on ResolvedConfig ─────────────────────────────
+
+import type { ColorFormat as _CF } from '../types/index.js';
+type _CRequired = ResolvedConfig['format']['color'] extends _CF ? true : never;
+const _cRequired: _CRequired = true;
+
+// ─── DEFAULT_CONFIG.format.color should be 'HEX' ───────────────────────────
+
+const defaultColorValue: typeof DEFAULT_CONFIG.format.color = 'HEX';

--- a/packages/schema/tests/PropBinding.test-d.ts
+++ b/packages/schema/tests/PropBinding.test-d.ts
@@ -69,7 +69,7 @@ const styleBound: Style = { $binding: '#/props/isVisible' };
 const _oldStyle: Style = { $ref: '#/props/isVisible' };
 
 // ─── ColorStyle does NOT accept PropBinding or ReferenceValue ───────────────
-// Color properties are not bindable; only ColorValue | TokenReference | GradientValue | null
+// Color properties are not bindable; only string | ColorObject | TokenReference | GradientValue | null
 
 const colorValue: ColorStyle = { colorSpace: 'srgb', components: [1, 0, 0] };
 const colorNull: ColorStyle = null;

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -5,7 +5,7 @@
  */
 import type {
   Styles, Shadow, Blur, Effects, Typography,
-  TokenReference, ColorStyle, ColorValue, GradientStop, GradientCenter, LinearGradient, RadialGradient,
+  TokenReference, ColorStyle, ColorObject, GradientStop, GradientCenter, LinearGradient, RadialGradient,
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
   MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset,
@@ -13,15 +13,15 @@ import type {
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
 
-// ColorValue arm (DTCG Color §4.1 object)
-const csColorValue: ColorStyle = {
+// ColorObject arm (DTCG Color §4.1 object)
+const csColorObject: ColorStyle = {
   colorSpace: 'srgb',
   components: [1, 0, 0.498],
   alpha: 1,
   hex: '#ff007f',
-} satisfies ColorValue;
+} satisfies ColorObject;
 
-// @ts-expect-error: bare hex string is no longer valid for ColorStyle (ADR-009)
+// String arm is valid — covers formatted color strings (hex, rgba, hsla, etc.) when Config.format.color is non-OBJECT
 const _csHexString: ColorStyle = '#ff007f';
 
 // TokenReference arm
@@ -63,7 +63,7 @@ const withNullBackground: Styles = {
 
 // ─── Styles.fillColor (glyph fill) ───────────────────────────────────────
 
-// ColorValue arm
+// ColorObject arm
 const withFillColor: Styles = { fillColor: { colorSpace: 'srgb', components: [1, 0, 0.498], hex: '#ff007f' } };
 
 // TokenReference arm
@@ -89,9 +89,8 @@ const withNullFillColor: Styles = { fillColor: null };
 // fillColor is optional — omitting it is valid
 const withNoFillColor: Styles = {};
 
-// @ts-expect-error: bare hex strings are no longer valid for color fields (ADR-009)
+// String arms are valid — covers formatted color strings when Config.format.color is non-OBJECT
 const _withBgHexString: Styles = { backgroundColor: '#ff007f' };
-// @ts-expect-error: bare hex strings are no longer valid for color fields (ADR-009)
 const _withTextColorHexString: Styles = { textColor: '#000000' };
 
 // ─── Shadow ────────────────────────────────────────────────────────────────

--- a/packages/schema/types/Config.ts
+++ b/packages/schema/types/Config.ts
@@ -1,4 +1,20 @@
 /**
+ * Color value output format.
+ *
+ * Controls how `ColorObject` objects are serialized in the spec output.
+ * `HEX` (default) emits a 6-digit hex string. `OBJECT` emits the full
+ * `ColorObject` object. All other values emit a formatted color string
+ * in the named notation.
+ *
+ * Tier 1 — Figma UI formats: `HEX`, `HEXA`, `RGB`, `RGBA`, `HSLA`, `HSB`
+ * Tier 2 — Modern CSS (Level 4): `OKLCH`, `OKLAB`
+ * Tier 3 — Structured object: `OBJECT`
+ *
+ * @since 0.20.0
+ */
+export type ColorFormat = 'HEX' | 'HEXA' | 'RGB' | 'RGBA' | 'HSLA' | 'HSB' | 'OKLCH' | 'OKLAB' | 'OBJECT';
+
+/**
  * Model configuration used to generate the component spec.
  * Full structure matches the transformer's configuration options.
  *
@@ -39,6 +55,8 @@ export interface Config {
     layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /** Token reference serialization profile. Optional; defaults to TOKEN. */
     tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
+    /** Color value output format. Optional; defaults to HEX. @since 0.20.0 */
+    color?: ColorFormat;
   };
   include: {
     /** Include invalid variants. Optional; defaults to false. */
@@ -93,6 +111,8 @@ export interface ResolvedConfig {
     layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /** Token reference serialization profile. */
     tokens: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
+    /** Color value output format. */
+    color: ColorFormat;
   };
   include: {
     /** Include invalid variants. */
@@ -117,6 +137,7 @@ export interface ResolvedConfig {
  * - format.keys: SAFE prevents corruption of special characters while maintaining readability
  * - format.layout: LAYOUT provides tree structure with layout properties
  * - format.tokens: TOKEN provides platform-neutral token references with $token path and $type
+ * - format.color: HEX matches historical v1 behaviour and maximises human readability
  * - include.invalidVariants: false excludes variants that can't be instantiated
  * - include.invalidCombinations: true helps designers identify property conflicts
  * - include.emptyVariants: false reduces output size by excluding semantically empty layered variants
@@ -133,6 +154,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
     keys: 'SAFE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
+    color: 'HEX',
   },
   include: {
     invalidVariants: false,

--- a/packages/schema/types/Effects.ts
+++ b/packages/schema/types/Effects.ts
@@ -1,4 +1,4 @@
-import { TokenReference, ColorValue } from "./Styles.js";
+import { TokenReference, ColorObject } from "./Styles.js";
 
 /**
  * A single evaluated shadow (drop or inner).
@@ -19,7 +19,8 @@ export interface Shadow {
   offsetY: number | TokenReference;
   blur: number | TokenReference;
   spread: number | TokenReference;
-  color: ColorValue | TokenReference;
+  /** Shadow color — DTCG Color object, token reference, or formatted string when `Config.format.color` is non-`OBJECT`. */
+  color: string | ColorObject | TokenReference;
 }
 
 /**

--- a/packages/schema/types/Gradient.ts
+++ b/packages/schema/types/Gradient.ts
@@ -1,4 +1,4 @@
-import { TokenReference, ColorValue } from "./Styles.js";
+import { TokenReference, ColorObject } from "./Styles.js";
 
 /**
  * A single stop in a gradient definition.
@@ -6,8 +6,8 @@ import { TokenReference, ColorValue } from "./Styles.js";
 export interface GradientStop {
   /** Position along the gradient vector, normalised 0–1. */
   position: number;
-  /** Stop color as a DTCG Color §4.1 object or a token reference. */
-  color: ColorValue | TokenReference;
+  /** Stop color — DTCG Color object, token reference, or formatted string when `Config.format.color` is non-`OBJECT`. */
+  color: string | ColorObject | TokenReference;
 }
 
 /**

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -119,10 +119,10 @@ export type Style = string | boolean | number | null | TokenReference | PropBind
  * The `colorSpace` field is typed as `string` (not a literal union) to avoid drift
  * with the schema enum — the schema provides the validation constraint.
  *
- * Mirrors `ColorValue` in `schema/styles.schema.json`.
+ * Mirrors `ColorObject` in `schema/styles.schema.json`.
  * @since 0.11.0
  */
-export interface ColorValue { /** Candidate */
+export interface ColorObject { /** Candidate */
   /** Color space identifier per DTCG Color §4.2 (e.g. 'srgb', 'oklch', 'display-p3'). */
   colorSpace: string;
   /** Ordered component values for the given color space. Each element is a number or the 'none' keyword. */
@@ -138,8 +138,11 @@ export interface ColorValue { /** Candidate */
  * Mirrors `ColorStyleValue` in `schema/styles.schema.json`.
  * Used for `backgroundColor`, `fillColor`, `textColor`, and `strokes` — the four properties
  * whose values are always colour-semantics and may carry gradient data.
+ *
+ * The `string` arm covers formatted colour strings (e.g. `#FF6600`, `rgba(...)`)
+ * emitted when `Config.format.color` is set to a non-`OBJECT` format.
  */
-export type ColorStyle = ColorValue | TokenReference | GradientValue | null;
+export type ColorStyle = string | ColorObject | TokenReference | GradientValue | null;
 
 /**
  * Inline typography properties grouped into a composite object.

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -21,11 +21,11 @@ export type { Children } from './Children.js';
 
 // Configuration types
 export type { PropConfigurations } from './PropConfigurations.js';
-export type { Config, ResolvedConfig } from './Config.js';
+export type { Config, ResolvedConfig, ColorFormat } from './Config.js';
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorValue, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 

--- a/site/src/content/docs/config/color.md
+++ b/site/src/content/docs/config/color.md
@@ -1,0 +1,36 @@
+---
+title: "Color"
+description: "Control how color values are formatted in the spec output"
+---
+
+Color value output format.
+
+## Options
+
+- **Default**: `HEX`
+- **Values**:
+  - `HEX` - 6-digit hex string (`#FF6600`). Default — matches historical behaviour and maximises human readability
+  - `HEXA` - 8-digit hex string with alpha (`#FF6600FF`)
+  - `RGB` - CSS `rgb()` functional notation (`rgb(255, 102, 0)`)
+  - `RGBA` - CSS `rgba()` functional notation with alpha (`rgba(255, 102, 0, 1)`). This is what Figma labels "CSS" in its colour picker
+  - `HSLA` - CSS `hsla()` functional notation (`hsla(24, 100%, 50%, 1)`)
+  - `HSB` - Figma's native colour model (`hsb(24, 100%, 100%)`), also known as HSV. Not a CSS function
+  - `OKLCH` - CSS Color Level 4 perceptually uniform cylindrical model (`oklch(0.7 0.15 50 / 1)`)
+  - `OKLAB` - CSS Color Level 4 perceptually uniform rectangular model (`oklab(0.7 0.1 0.1 / 1)`)
+  - `OBJECT` - Full `ColorObject` with `colorSpace`, `components`, `alpha`, and optional `hex`. Preserves colour space fidelity with no lossy conversion
+
+## Path
+
+`config.format.color`
+
+### Example
+
+```yaml
+config:
+  format:
+    color: HEX  # Default — 6-digit hex strings
+```
+
+## See Also
+
+- [Config schema reference](/specs/schema/config/) - Full configuration documentation

--- a/site/src/content/docs/schema/config.md
+++ b/site/src/content/docs/schema/config.md
@@ -25,6 +25,7 @@ Controls how specs are generated. See the [feature guides](/specs/features/) for
 | `keys` | `'SAFE' \| 'CAMEL' \| 'SNAKE' \| 'KEBAB' \| 'PASCAL' \| 'TRAIN'` | `'SAFE'` | Key casing style |
 | `layout` | `'LAYOUT' \| 'PARENT_CHILDREN' \| 'BOTH'` | `'LAYOUT'` | Element hierarchy representation |
 | `tokens` | `'TOKEN' \| 'TOKEN_NAME' \| 'TOKEN_FIGMA_EXTENSIONS' \| 'FIGMA_NAME' \| 'CUSTOM'` | `'TOKEN'` | Token reference output format |
+| `color` | `ColorFormat` | `'HEX'` | Color value output format — `HEX`, `HEXA`, `RGB`, `RGBA`, `HSLA`, `HSB`, `OKLCH`, `OKLAB`, or `OBJECT` |
 
 ## `include`
 
@@ -51,6 +52,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     keys: 'SAFE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
+    color: 'HEX',
   },
   include: {
     invalidVariants: false,


### PR DESCRIPTION
## Summary

- Adds `Config.format.color` typed as `ColorFormat` — 9-value enum (`HEX` | `HEXA` | `RGB` | `RGBA` | `HSLA` | `HSB` | `OKLCH` | `OKLAB` | `OBJECT`) with `HEX` default
- Renames `ColorValue` to `ColorObject` for specificity
- Widens `ColorStyle`, `Shadow.color`, and `GradientStop.color` with `string` arm to support formatted color output

Closes #N/A — ADR-only change, no issue tracking.

## Validation Gates

- [x] TSC build compilation (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON schema validation (4/4 passed)
- [x] Type-level test compilation (`tsc --noEmit --strict tests/*.test-d.ts`)

## Files Changed

**Types**: Config.ts, Styles.ts, Effects.ts, Gradient.ts, index.ts
**Schema**: component.schema.json, styles.schema.json
**Tests**: Config.test-d.ts, Styles.test-d.ts, PropBinding.test-d.ts
**Docs**: config.md, config/color.md (new)
**ADR**: 043-custom-color-format-config.md (ACCEPTED), INDEX.md
**Changelog**: CHANGELOG.md (0.20.0 Unreleased)

🤖 Generated with [Claude Code](https://claude.com/claude-code)