### PR TITLE
docs: rewrite applyCustomTokens guide

### DIFF
--- a/site/src/content/docs/cli/commands/apply-custom-tokens.md
+++ b/site/src/content/docs/cli/commands/apply-custom-tokens.md
@@ -1,7 +1,29 @@
 ---
 title: "applyCustomTokens"
+description: "Inject your team's token shapes into fetched Figma data so generated specs use your format, not ours"
 ---
-Inject `$custom` token objects from a mapping file into fetched variables and styles JSON files.
+
+## The Problem
+
+Specs generates token references in a fixed shape — `{ $token, $type }` or one of the other [built-in profiles](/specs/guides/token-format/). But many teams already have a token system with its own naming conventions and output shapes: Style Dictionary aliases, JSON schema references, platform-specific formats, or custom structures built for their toolchain.
+
+You can't make Specs guess your format. You need a way to say: _"For this Figma variable, output **this exact object** instead."_
+
+## The Solution
+
+`applyCustomTokens` lets you inject a `$custom` object onto each variable and style in your fetched data files. When you set `format.tokens: CUSTOM` in your config, Specs uses those objects **verbatim** as the token reference value in generated output — no transformation, no reformatting. Your object becomes the property value.
+
+### Where It Fits in the Pipeline
+
+The command runs **between `fetch` and `generate`** — it modifies the raw data files that `fetch` downloaded, before `generate` reads them:
+
+```
+specs fetch                              ← Downloads raw Figma data
+specs applyCustomTokens mapping.json     ← Injects $custom onto matched entries
+specs generate                           ← Reads $custom when format.tokens: CUSTOM
+```
+
+No changes to `fetch` or `generate` are needed. The augmented files are transparent to both commands.
 
 ## Usage
 
@@ -9,101 +31,195 @@ Inject `$custom` token objects from a mapping file into fetched variables and st
 specs applyCustomTokens <mapping> [options]
 ```
 
-## Arguments
+### Arguments
 
-### `<mapping>`
-Path to a JSON mapping file. Each key is a Figma variable or style ID, and the value must contain a `$custom` property (a non-null object). Other properties in the mapping entries are ignored.
+#### `<mapping>`
 
-**Mapping file format:**
+Path to a JSON mapping file. Keys are Figma variable or style IDs; each entry must contain a `$custom` property (a non-null object). Other properties on the entry are ignored.
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `-v, --variables <path>` | Path to a variables JSON file. Overrides config-based discovery |
+| `-s, --styles <path>` | Path to a styles JSON file. Overrides config-based discovery |
+| `--config <path>` | Use a specific config file instead of auto-discovery |
+
+When `-v` and `-s` are omitted, the command auto-discovers data files from `specs.config.yaml` using `dataDirectory` and `sources` — the same resolution that `generate` uses.
+
+## The Mapping File
+
+The mapping file is a JSON file you create and maintain. Each key is a Figma ID (`VariableID:*` for variables, `S:*` for styles), and each value must include a `$custom` object — the exact shape you want in the output:
+
 ```json
 {
+  // Variable: map a Figma variable to a Style Dictionary alias
   "VariableID:4350:72": {
+    "$custom": {
+      "name": "color-text-primary",
+      "value": "{color.text.primary}"
+    },
+    "note": "This property is ignored — only $custom is read"
+  },
+
+  // Variable: map to a JSON schema reference format
+  "VariableID:4350:85": {
     "$custom": {
       "$token": "tokens/$brand#/color/$theme/outline",
       "$type": { "$ref": "foundations#/definitions/color" }
-    },
-    "figmaVariable": "Color.Outline"
+    }
+  },
+
+  // Style: map a published Figma style
+  "S:abc123def456,": {
+    "$custom": {
+      "typography": "body.medium",
+      "platform": "web"
+    }
   }
 }
 ```
 
-## Options
+The `$custom` value can be **any JSON object** — Specs doesn't validate its contents beyond requiring it to be a non-null object. Your downstream consumers define the shape.
 
-### `-v, --variables <path>`
-Path to a variables JSON file. Overrides config-based file discovery.
+> **Where do the Figma IDs come from?** Inspect your fetched `*.variables.json` or `*.styles.json` files — the IDs are the keys in the `meta.variables` and `meta.styles` objects.
 
-### `-s, --styles <path>`
-Path to a styles JSON file. Overrides config-based file discovery.
+## What Happens to the Data
 
-### `--config <path>`
-Use a specific config file instead of auto-discovery.
+The command injects `$custom` onto matching entries in the fetched JSON files. Here's a before/after for a variable:
 
-## Config Integration
+**Before** (raw fetched data):
+```json
+{
+  "meta": {
+    "variables": {
+      "VariableID:4350:72": {
+        "name": "Text/Primary",
+        "resolvedType": "COLOR",
+        "variableCollectionId": "VariableCollectionId:100:0",
+        "valuesByMode": { "200:0": { "r": 0.1, "g": 0.1, "b": 0.1, "a": 1 } }
+      }
+    }
+  }
+}
+```
 
-When `-v` and `-s` are not provided, the command auto-discovers data files using `specs.config.yaml`:
+**After** (`applyCustomTokens` has run):
+```json
+{
+  "meta": {
+    "variables": {
+      "VariableID:4350:72": {
+        "name": "Text/Primary",
+        "resolvedType": "COLOR",
+        "variableCollectionId": "VariableCollectionId:100:0",
+        "valuesByMode": { "200:0": { "r": 0.1, "g": 0.1, "b": 0.1, "a": 1 } },
+        "$custom": {
+          "name": "color-text-primary",
+          "value": "{color.text.primary}"
+        }
+      }
+    }
+  }
+}
+```
 
-1. Reads `dataDirectory` for the data folder path
-2. Reads `sources` entries to locate `{alias}.variables.json` and `{alias}.styles.json` files
+Everything else is preserved — only `$custom` is added (or overwritten if it already exists).
 
-## Behavior
+## Impact on Generated Output
 
-- Reads the mapping file and extracts entries with `$custom` properties
-- For each variables/styles file, matches Figma IDs and injects the `$custom` object
-- Files are modified in place (overwritten with augmented data)
-- Running twice is idempotent: existing `$custom` values are overwritten with the latest mapping
-- Last occurrence wins if a mapping ID appears in multiple entries
+When `generate` runs with `format.tokens: CUSTOM`, every token reference that has a `$custom` object uses it verbatim. References without `$custom` fall back to the `TOKEN_FIGMA_EXTENSIONS` format.
 
-> **Important:** Injecting `$custom` tokens only augments the raw data files. To include custom tokens in `generate` output, you must set `format.tokens` to `CUSTOM` in your `specs.config.yaml`:
->
-> ```yaml
-> format:
->   tokens: CUSTOM
-> ```
->
-> Without this setting, `generate` will use the default token format and the injected `$custom` objects will be ignored.
+**Config:**
+```yaml
+# specs.config.yaml
+model:
+  format:
+    tokens: CUSTOM
+```
 
-## Status Summary
+**Generated output** (YAML shown):
+```yaml
+elements:
+  label:
+    styles:
+      # This variable had $custom injected — uses your object verbatim
+      color:
+        name: color-text-primary
+        value: "{color.text.primary}"
 
-- **Empty mapping** (no `$custom` entries): `No custom tokens found in mapping file. No files were modified.`
-- **Successful augmentation**: Reports count of matched variables and styles
-- **Unmatched IDs**: Reports count of mapping entries that didn't match any variable or style
+      # This variable had NO $custom — falls back to TOKEN_FIGMA_EXTENSIONS
+      borderColor:
+        $token: DS Color.Border.Default
+        $type: color
+        $extensions:
+          com.figma:
+            id: "VariableID:789:012"
+            rawValue: "#e0e0e0"
+            name: Border/Default
+            collectionName: DS Color
+```
 
-## Error Scenarios
+This applies uniformly to all reference sites — including gradient stop colors and any other property bound to a Figma variable or style.
 
-- **Mapping file not found**: Error with file path
-- **Malformed JSON**: Error identifying the file
-- **Invalid `$custom` value** (not a non-null object): Error identifying the specific entry
-- **No data files found**: Error suggesting `-v`/`-s` flags or config setup
+> **Without `format.tokens: CUSTOM`**, the `$custom` objects sit inert in the data files. Other token profiles (`TOKEN`, `TOKEN_NAME`, etc.) ignore `$custom` entirely.
 
-## Examples
+## Full Pipeline Example
 
 ```bash
-# Using explicit file paths
-specs applyCustomTokens data/token-mappings.json \
-  -v data/library.variables.json \
-  -s data/library.styles.json
-
-# Using config-based discovery (reads specs.config.yaml)
-specs applyCustomTokens data/token-mappings.json
-
-# Full pipeline: fetch, augment, then generate specs
-# Requires format.tokens: CUSTOM in specs.config.yaml
+# Step 1: Fetch raw data from Figma
 specs fetch
+
+# Step 2: Inject your custom token shapes
 specs applyCustomTokens data/token-mappings.json
+
+# Step 3: Generate specs — your $custom objects appear in the output
 specs generate
 ```
 
+Or with explicit file paths instead of config discovery:
+
+```bash
+specs applyCustomTokens data/token-mappings.json \
+  -v data/library.variables.json \
+  -s data/library.styles.json
+```
+
+## Behavior Details
+
+- **Idempotent**: Running the command multiple times with the same mapping produces identical output. Existing `$custom` values are overwritten.
+- **Non-destructive**: Only the `$custom` property is modified — all other data on each entry is preserved.
+- **Mixed mapping**: A single mapping file can contain both variable IDs and style IDs. The command augments variables and styles files in a single invocation.
+- **Empty `$custom` objects**: An empty `{}` is treated as absent — the `CUSTOM` profile will fall back to `TOKEN_FIGMA_EXTENSIONS` for that reference.
+
+## Status Summary
+
+After running, the command reports what it did:
+
+- **No matches**: `No custom tokens found in mapping file. No files were modified.`
+- **Matches found**: Reports count of variables augmented, styles augmented, and unmatched mapping entries
+
+## Error Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Mapping file not found | Error with file path |
+| Malformed JSON | Error identifying the file |
+| `$custom` value is not a non-null object (string, array, number, null) | Error identifying the invalid entry |
+| No data files found (no config, no flags) | Error suggesting `-v`/`-s` flags or config setup |
+
 ## Branch-Fetched Data
 
-If your data files were fetched from a Figma branch (using a branch file key in `sources`), variable and style IDs in those files may differ from the IDs on main. Your mapping file must use the IDs that appear in the branch data — not the main file's IDs.
+If your data files were fetched from a Figma branch (using a branch file key in `sources`), variable and style IDs may differ from the IDs on main. Your mapping file must use the IDs that appear in the branch data.
 
-To verify which IDs are present, inspect the fetched `*.variables.json` or `*.styles.json` files directly. If you maintain separate mapping files per branch, keep them alongside the branch data.
+Inspect the fetched files directly to verify which IDs are present. If you maintain separate mapping files per branch, keep them alongside the branch data.
 
-See [Fetching Figma Branches](/specs/cli/commands/fetch.md/#fetching-figma-branches) for more details.
+See [Fetching Figma Branches](/specs/cli/commands/fetch/#fetching-figma-branches) for details.
 
 ---
 
 **See Also:**
-- [Configuration Reference](/specs/config/) - dataDirectory and sources setup
-- [Generate Command](/specs/cli/commands/generate/) - Processing augmented data with `format.tokens: CUSTOM`
-- [Fetch Command](/specs/cli/commands/fetch/) - Fetching raw data before augmentation
+- [Token Format Guide](/specs/guides/token-format/) — all five token profiles compared
+- [Configuration Reference](/specs/config/) — `dataDirectory` and `sources` setup
+- [Generate Command](/specs/cli/commands/generate/) — processing augmented data
+- [Fetch Command](/specs/cli/commands/fetch/) — fetching raw data before augmentation

--- a/site/src/content/docs/guides/token-format.md
+++ b/site/src/content/docs/guides/token-format.md
@@ -70,15 +70,15 @@ Variables include the collection name as a prefix; named styles use the style na
 
 #### `CUSTOM`
 
-Delegates serialization to a custom token mapping. If a variable or style has a `$custom` metadata object (injected via the `applyCustomTokens` CLI command), that object is used verbatim as the property value. References without `$custom` fall back to the `TOKEN_FIGMA_EXTENSIONS` shape.
+Uses your own token shapes instead of Specs' built-in formats. Before generating, you run the [`applyCustomTokens`](/specs/cli/commands/apply-custom-tokens/) command to inject a `$custom` object onto each variable and style in your fetched data. When `CUSTOM` is active, that object becomes the property value verbatim. References without `$custom` fall back to the `TOKEN_FIGMA_EXTENSIONS` shape.
 
 ```yaml
-# With $custom mapping applied
+# This variable had $custom injected — your object, verbatim
 backgroundColor:
   name: color-text-primary
   value: "{color.text.primary}"
 
-# Without $custom — falls back to TOKEN_FIGMA_EXTENSIONS
+# This variable had no $custom — falls back to TOKEN_FIGMA_EXTENSIONS
 borderColor:
   $token: DS Color.Border.Default
   $type: color
@@ -123,17 +123,15 @@ model:
 
 ### Using CUSTOM
 
-The `CUSTOM` profile requires a preparatory step:
+The `CUSTOM` profile requires an extra step between `fetch` and `generate`:
 
 ```bash
-# 1. Inject custom token mappings into fetched data
-specs applyCustomTokens mapping.json
-
-# 2. Generate specs — CUSTOM profile uses the injected $custom objects
-specs generate data/library.file.json -c Button
+specs fetch                              # 1. Download raw Figma data
+specs applyCustomTokens mapping.json     # 2. Inject $custom objects into the data
+specs generate                           # 3. Generate — uses $custom objects verbatim
 ```
 
-See the [applyCustomTokens command](/specs/cli/commands/apply-custom-tokens/) for details on the mapping format.
+See the [`applyCustomTokens` command](/specs/cli/commands/apply-custom-tokens/) for the full mapping file format, data impact examples, and pipeline details.
 
 ## Further Reading
 


### PR DESCRIPTION
## Summary
- Rewrites `applyCustomTokens` docs with problem/solution framing — why teams need it and what it does
- Adds pipeline diagram showing where the command fits (fetch → applyCustomTokens → generate)
- Adds before/after examples of the fetched data and generated output impact
- Well-commented mapping file example covering variables, styles, and ignored properties
- Updates CUSTOM profile section in token-format guide for consistency

## Test plan
- [x] `astro build` passes (68 pages, no errors)
- [ ] Visual review of rendered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)