### PR TITLE
feat(cli): ADR 043 color format config + fix doc URLs

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `config.format.color` — validates and normalizes the new `ColorFormat` option (`HEX`, `HEXA`, `RGB`, `RGBA`, `HSLA`, `HSB`, `OKLCH`, `OKLAB`, `OBJECT`); defaults to `HEX`. Config template updated with inline docs. (ADR 043)
+
 ### Changed
+
+### Fixed
+
+- Config template URLs now point to the doc site (`directededges.github.io/specs/config/...`) instead of 404ing GitHub raw paths (#43)
 
 ### Removed
 

--- a/packages/cli/src/Config/ConfigLoader.ts
+++ b/packages/cli/src/Config/ConfigLoader.ts
@@ -194,6 +194,7 @@ export class ConfigLoader {
     const validOutputs = ['JSON', 'YAML'];
     const validLayouts = ['LAYOUT', 'PARENT_CHILDREN', 'BOTH'];
     const validTokens = ['TOKEN', 'TOKEN_NAME', 'TOKEN_FIGMA_EXTENSIONS', 'FIGMA_NAME', 'CUSTOM'];
+    const validColors = ['HEX', 'HEXA', 'RGB', 'RGBA', 'HSLA', 'HSB', 'OKLCH', 'OKLAB', 'OBJECT'];
 
     // Normalize format values to uppercase before validation
     // (YAML configs commonly use lowercase; schema constants are uppercase)
@@ -202,6 +203,9 @@ export class ConfigLoader {
     corrected.format.layout = corrected.format.layout?.toUpperCase() ?? '';
     if (corrected.format.tokens) {
       corrected.format.tokens = corrected.format.tokens.toUpperCase();
+    }
+    if (corrected.format.color) {
+      corrected.format.color = corrected.format.color.toUpperCase();
     }
 
     // Validate format
@@ -216,6 +220,9 @@ export class ConfigLoader {
     }
     if (corrected.format.tokens && !validTokens.includes(corrected.format.tokens)) {
       corrected.format.tokens = DEFAULT_CONFIG.format.tokens;
+    }
+    if (!validColors.includes(corrected.format.color)) {
+      corrected.format.color = DEFAULT_CONFIG.format.color;
     }
 
     // Strip EOLed include properties — subcomponent inclusion is now

--- a/packages/cli/src/Config/ConfigTemplates.ts
+++ b/packages/cli/src/Config/ConfigTemplates.ts
@@ -15,7 +15,7 @@ export function generateConfigTemplate(): string {
   return `# Specs CLI Configuration
 #
 # This file configures how Specs fetches and processes Figma component data.
-# See: https://github.com/DirectedEdges/specs/blob/main/docs/cli/configuration.md
+# See: https://directededges.github.io/specs/config/
 
 # ─── 'fetch'ed Sources (CLI only) ─────────────────────────────────────────────
 # Where Figma data is fetched from and stored locally.
@@ -50,7 +50,7 @@ output:
   useSubfolders: false
 
 # ─── Configuration options (same as the Figma plugin) ──────────────────────────────
-# See: https://github.com/DirectedEdges/specs/blob/main/docs/cli/configuration.md
+# See: https://directededges.github.io/specs/config/
 
 config:
 
@@ -59,22 +59,26 @@ config:
     output: JSON
 
     # Key name transformation: SAFE, CAMEL, SNAKE, KEBAB, PASCAL, TRAIN
-    # See: https://github.com/DirectedEdges/specs/blob/main/docs/guides/key-formatting.md
+    # See: https://directededges.github.io/specs/config/keys/
     keys: SAFE
 
     # Layout representation: LAYOUT, PARENT_CHILDREN, or BOTH
-    # See: https://github.com/DirectedEdges/specs/blob/main/docs/guides/data-layout.md
+    # See: https://directededges.github.io/specs/config/layout/
     layout: LAYOUT
 
     # Token reference format: TOKEN, TOKEN_NAME, TOKEN_FIGMA_EXTENSIONS, FIGMA_NAME, or CUSTOM
-    # See: https://github.com/DirectedEdges/specs/blob/main/docs/guides/token-format.md
+    # See: https://directededges.github.io/specs/config/tokens/
     # Requires a license key to resolve token references in output.
     tokens: TOKEN
+
+    # Color value format: HEX, HEXA, RGB, RGBA, HSLA, HSB, OKLCH, OKLAB, or OBJECT
+    # See: https://directededges.github.io/specs/config/color/
+    color: HEX
 
   processing:
     # Subcomponent discovery configuration.
     # Presence of this block enables subcomponent detection; remove to disable.
-    # See: https://github.com/DirectedEdges/specs/blob/main/docs/guides/subcomponent-scoping.md
+    # See: https://directededges.github.io/specs/config/subcomponents/
     subcomponents:
       # Where to search: NESTED (component anatomy only) or PAGE (also search Figma page)
       # scope: NESTED
@@ -100,11 +104,11 @@ config:
     slotConstraints: false
 
     # Maximum variant property depth to process: 1, 2, 3, or 9999 (unlimited)
-    # See: https://github.com/DirectedEdges/specs/blob/main/docs/guides/variant-depth.md
+    # See: https://directededges.github.io/specs/config/variant-depth/
     variantDepth: 9999
 
     # Detail level for variant data: FULL or LAYERED
-    # See: https://github.com/DirectedEdges/specs/blob/main/docs/cli/configuration.md#details
+    # See: https://directededges.github.io/specs/config/details/
     details: LAYERED
 
     # Infer number props: when true, TEXT code-only props whose values parse as

--- a/packages/cli/tests/unit/commands/InitCommand.test.ts
+++ b/packages/cli/tests/unit/commands/InitCommand.test.ts
@@ -44,7 +44,7 @@ describe('InitCommand', () => {
     it('should include inline documentation', () => {
       const template = generateConfigTemplate();
       expect(template).toContain('# Specs CLI Configuration');
-      expect(template).toContain('docs/cli/configuration.md');
+      expect(template).toContain('directededges.github.io/specs/config/');
     });
 
     it('should mention defaults in comments', () => {
@@ -159,8 +159,8 @@ describe('InitCommand', () => {
     it('should have all required documentation URLs', () => {
       const template = generateConfigTemplate();
       const requiredUrls = [
-        'docs/cli/configuration.md',
-        'github.com/DirectedEdges/specs',
+        'directededges.github.io/specs/config/',
+        'directededges.github.io/specs/',
       ];
 
       requiredUrls.forEach(url => {

--- a/packages/cli/tests/unit/config/ConfigLoader.test.ts
+++ b/packages/cli/tests/unit/config/ConfigLoader.test.ts
@@ -216,6 +216,34 @@ sources:
       expect(config.config.format.tokens).toBe('TOKEN'); // Default
     });
 
+    it('should validate format.color and use default for invalid values', () => {
+      const configPath = path.join(testDir, 'specs.config.yaml');
+      fs.writeFileSync(configPath, 'config:\n  format:\n    color: INVALID');
+
+      const config = configLoader.load();
+      expect(config.config.format.color).toBe('HEX'); // Default
+    });
+
+    it('should accept all valid format.color values', () => {
+      const validValues = ['HEX', 'HEXA', 'RGB', 'RGBA', 'HSLA', 'HSB', 'OKLCH', 'OKLAB', 'OBJECT'];
+
+      validValues.forEach(value => {
+        const configPath = path.join(testDir, 'specs.config.yaml');
+        fs.writeFileSync(configPath, `config:\n  format:\n    color: ${value}`);
+
+        const config = configLoader.load();
+        expect(config.config.format.color).toBe(value);
+      });
+    });
+
+    it('should normalize lowercase format.color to uppercase', () => {
+      const configPath = path.join(testDir, 'specs.config.yaml');
+      fs.writeFileSync(configPath, 'config:\n  format:\n    color: oklch');
+
+      const config = configLoader.load();
+      expect(config.config.format.color).toBe('OKLCH');
+    });
+
     it('should preserve valid glyphNamePattern string', () => {
       const configPath = path.join(testDir, 'specs.config.yaml');
       fs.writeFileSync(configPath, 'config:\n  processing:\n    glyphNamePattern: "DS Icon Glyph /"');

--- a/packages/cli/tests/unit/config/ConfigTemplates.test.ts
+++ b/packages/cli/tests/unit/config/ConfigTemplates.test.ts
@@ -25,13 +25,13 @@ describe('ConfigTemplates', () => {
       const template = generateConfigTemplate();
       expect(template).toContain('#');
       expect(template).toContain('Specs CLI Configuration');
-      expect(template).toContain('docs/cli/configuration.md');
+      expect(template).toContain('directededges.github.io/specs/config/');
     });
 
     it('should include doc URL references', () => {
       const template = generateConfigTemplate();
-      expect(template).toContain('docs/cli/configuration.md');
-      expect(template).toContain('github.com/DirectedEdges/specs');
+      expect(template).toContain('directededges.github.io/specs/config/');
+      expect(template).toContain('directededges.github.io/specs/');
     });
 
     it('should include Figma sources section', () => {


### PR DESCRIPTION
## Summary

- Adds `config.format.color` validation and normalization to ConfigLoader (same pattern as keys/output/layout/tokens)
- Updates config template with `color: HEX` entry and inline docs
- Fixes all template doc URLs from 404ing GitHub raw paths to the doc site (`directededges.github.io/specs/config/...`) — Closes #43

## Test plan

- [x] 3 new ConfigLoader tests: invalid→default, all 9 valid values, lowercase normalization
- [x] Updated ConfigTemplates and InitCommand test assertions for new URLs
- [x] All 169 tests pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)