### PR TITLE
Feature: Duplicate layer disambiguation + provenance

### DIFF
--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -430,13 +430,13 @@ The following cases stress-test the algorithm against common component structure
 |---------|-----------|-------------|
 | **Alert/Banner** (`[Icon, Content, Icon]`) | Two `Icon` siblings flanking a unique `Content` anchor | `Content` is the anchor. Leading icon = before-content, trailing icon = after-content. Correct even when `has-close=false` removes the trailing icon. |
 | **Breadcrumb** (`[Link, Sep, Link, Sep, Link]`) | Interleaved `Link` + `Separator` pairs | Each `Separator` is an anchor (unique per occurrence since the Links are the duplicates). The current-page `Link` (always last) stays matched to its adjacent separator. |
-| **Form fields** (`[Field, Field, Field, Submit]`) | Repeated `Field` with a unique `Submit` anchor at the bottom | `Submit` anchors the right edge. Fields match right-to-left from `Submit`, keeping the field nearest to submit stable as new fields are added above. |
-| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in **different subtrees** | Not sibling duplicates — each `Icon` is scoped to its own parent (`Header` vs `Footer`). Disambiguation per-parent handles this natively. No cross-subtree matching needed. |
+| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in **different subtrees** | **Parent containment** is the strongest disambiguation signal — each `Icon` is scoped to its parent (`Header` vs `Footer`) and receives a distinct key by ancestry alone. No sibling-level heuristic needed. See *Disambiguation hierarchy* below. |
 
 ##### Medium confidence — correct for typical usage, fragile under reordering
 
 | Pattern | Structure | Risk |
 |---------|-----------|------|
+| **Form fields** (`[Field, Field, Field, Submit]`) | Repeated `Field` with a unique `Submit` anchor at the bottom | Anchor-adjacent matches right-to-left from `Submit`, keeping the field *nearest* Submit stable. But new optional fields are typically inserted *just before* Submit (e.g., VA: `[Name, Email, Submit]`, VB: `[Name, Email, Phone, Submit]`). This shifts the "nearest to Submit" identity to the new field, mismatching the original fields. **Left-to-right positional would be more accurate here**, but the algorithm can't know growth direction. Correct when fields are appended at the top; **breaks** when inserted before Submit. |
 | **Star rating** (`[Star, Star, Star, Star, Star]`) | Homogeneous duplicates, no anchors | Falls back to left-to-right positional. Correct when `count` variants remove from the right (the dominant pattern). **Breaks** if a designer reverses layer order for RTL layout. |
 | **Navigation tabs** (`[Tab, Tab, Tab]`) | Homogeneous duplicates, no anchors | Same as stars — positional fallback. Correct for `count` variants. **Breaks** if `selected` is implemented by moving the active tab to position 0. |
 | **Stepper** (`[Step, Step, Step]`) | Homogeneous duplicates if no unique connector/label between steps | Falls back to positional. Correct when steps grow from the right. **Breaks** if a designer inserts steps in the middle of an existing sequence. |
@@ -448,6 +448,18 @@ The following cases stress-test the algorithm against common component structure
 | **Semantic reordering** | VA: `[icon-A, icon-B]`, VB: `[icon-B, icon-A]` — both named `Icon`, swapped | Positional matching assigns `icon` and `icon2` based on position. A becomes icon in VA but icon2 in VB. **No positional scheme can detect semantic identity swaps** without external metadata. |
 | **Accordion nested** | `[Header, Chevron, Content, Header, Chevron, Content]` at multiple nesting depths | After flattening, `Header` appears 2× as siblings even though they belong to different `Section` parents. **Mitigation**: per-parent scoping already handles this — each `Section`'s children are disambiguated independently. |
 | **Table column reordering** | VA: `[Cell-checkbox, Cell-name, Cell-actions]`, VB: `[Cell-name, Cell-checkbox, Cell-actions]` — all named `Cell` | If only `Cell-actions` (last) is an anchor, the other two cells are in the before-anchor segment and matched right-to-left. Reordering swaps their suffixes. **Acceptable**: column reordering is uncommon in variant sets; when it occurs, the resulting diff is larger but not lossy. |
+
+#### Disambiguation hierarchy
+
+The algorithm applies three disambiguation signals in order of strength:
+
+1. **Parent containment** (strongest) — Elements with the same name in different subtrees are already distinct. An `Icon` inside `Header` and an `Icon` inside `Footer` are separate scopes — their keys are disambiguated by ancestry, not by suffix. This is the first and most reliable signal because it reflects the designer's structural intent: grouping elements under named parents is an explicit organizational choice.
+
+2. **Anchor-adjacent matching** (strong) — Within a single parent, unique-named siblings serve as stable landmarks. Duplicates are matched by proximity to these anchors. Effective when the parent contains a mix of unique and repeated names.
+
+3. **Positional fallback** (weakest) — When no anchors exist within a parent (all siblings share the same name), fall back to left-to-right order. Correct only when growth happens at the trailing edge.
+
+Most real components benefit from levels 1 and 2. Homogeneous sibling groups (level 3 only) are the minority case — and even there, the output is lossless; only diff granularity degrades.
 
 #### Error risk scale
 
@@ -476,7 +488,7 @@ The two-pass approach adds one lightweight traversal over all variants:
 
 **Anchor itself is absent in some variants**: If `label` appears in variant A but not variant B, it cannot serve as an anchor. Only names present in **every variant that contains them** qualify. In practice, this means: if an anchor is optional (absent in some variants), its segments are merged with adjacent segments in variants where it's missing.
 
-**Nested duplicates**: Disambiguation is scoped to each parent independently. A parent named `header` with children `[icon, icon]` and a sibling parent `footer` with children `[icon, icon]` are separate scopes. The `icon` in `header` and the `icon` in `footer` are already distinct by ancestry — they have different keys in the flattened anatomy because the traversal encounters them in different subtrees. This is the primary defense against the "same name, different purpose" scenario (Context §2) — containment path, not suffix matching, is what distinguishes them.
+**Nested duplicates**: Disambiguation is scoped to each parent independently (see *Disambiguation hierarchy*, level 1). A parent named `header` with children `[icon, icon]` and a sibling parent `footer` with children `[icon, icon]` are separate scopes. The `icon` in `header` and the `icon` in `footer` are already distinct by ancestry — they have different keys in the flattened anatomy because the traversal encounters them in different subtrees. Parent containment is the primary defense against the "same name, different purpose" scenario (Context §2) — the designer's grouping structure, not suffix matching, is what distinguishes them.
 
 **Anchor ordering inconsistency**: If anchors themselves appear in different orders across variants (e.g., VA has `[label, description]` but VB has `[description, label]`), the segment boundaries diverge and anchor-relative matching degrades. This is treated as a design inconsistency — the algorithm falls back to absolute position for affected segments and emits a diagnostic warning.
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -542,24 +542,29 @@ Once elements have stable, anchor-relative disambiguated keys:
 
 **4. Floating elements across variants**
 
-An element with a **unique name** that appears at different hierarchy positions in different variants (e.g., `label` as a child of `header` in variant A, child of `content` in variant B) is treated as **the same element** — its disambiguated key matches regardless of ancestry. The layout diff captures the structural change; the element diff captures style changes. This is existing behavior and works because a unique name needs no scope-based disambiguation.
+Cross-variant matching is **always by flat key** — the parent is irrelevant. This is critical to preserve and is consistent with how the existing `Anatomy = Record<string, AnatomyElement>` model works today.
 
-This same principle applies to containers: when a uniquely-named parent node moves between ancestors across variants, it retains its identity via its key. Children scoped within that container are matched by the container's key, not its ancestry path (see *Disambiguation hierarchy*, ancestry containment limitation).
+An element that appears at different hierarchy positions in different variants (e.g., `Icon` as a child of `Header` in variant A, child of `Footer` in variant B, child of `Sidebar` in variant C) is the **same element** as long as its disambiguated key matches. The layout diff captures the structural change; the element diff captures style changes. This holds regardless of how many variants exist or how many different parents the element moves through — 96 variants with one `Icon` each, every time under a different parent, all resolve to key `icon` and are tracked as one element.
 
-**Duplicate-named elements that change parents lose identity.** When a non-unique element moves between scopes across variants, per-parent disambiguation treats it as a different element in each scope:
+This distinction is important: **ancestry containment scopes the within-variant disambiguation** (which sibling gets `icon` vs `icon2`), but **cross-variant matching uses the flat key only**. These are two separate steps:
+
+1. **Within-variant disambiguation** — Per-parent scope, anchor-adjacent matching, and positional fallback assign unique keys within each variant. This is where ancestry matters.
+2. **Cross-variant matching** — The flat anatomy key is used to match elements across variants. An element keyed as `icon` in V1 matches an element keyed as `icon` in V2, regardless of which parent it's under in each variant. This is where ancestry is irrelevant.
 
 ```yaml
-# V1: L1 > L2 > L3 > L4 > Icon    (scoped to L4 → "icon" within L4)
-#     L1 > L5 > L6 > Icon          (scoped to L6 → "icon" within L6)
+# V1: Header > [Icon, Label, Icon]   → icon, label, icon2  (within Header)
+# V2: Footer > [Icon, Label, Icon]   → icon, label, icon2  (within Footer)
 #
-# V2: L1 > Icon                    (scoped to L1 → "icon" within L1)
+# Cross-variant matching (flat key):
+#   V1 "icon"  ↔ V2 "icon"    ← same element (parents differ, key matches)
+#   V1 "icon2" ↔ V2 "icon2"   ← same element
+#   V1 "label" ↔ V2 "label"   ← same element
 #
-# V2's Icon is a direct child of L1. Neither V1 Icon shares that scope.
-# Result: V2's Icon is treated as a NEW element — matched to neither.
-# V1's L4 Icon and L6 Icon appear as "removed in V2."
+# The layout diff shows: elements moved from Header to Footer.
+# The element diffs show: style changes (if any) between variants.
 ```
 
-This is a **correct behavior given available information** — the algorithm cannot determine whether V2's Icon is V1's Icon A promoted up the tree (L4 removed) or a genuinely new element. Without external metadata (e.g., a designer annotation saying "this is the same icon"), scope change is indistinguishable from replacement. The resulting diff is larger than ideal (remove + add instead of move) but never lossy — every element is represented in every variant.
+The risk in cross-variant matching is not parent changes — it's **suffix instability**. If V1's disambiguation assigns `icon` to the first Icon and `icon2` to the second, but V2's disambiguation assigns them differently (because anchors shifted, or sibling order changed), the flat keys diverge and the element is mismatched. This is exactly what the global two-pass registry (§2) is designed to prevent — by surveying all variants before assigning any suffixes, the same logical element receives the same key everywhere.
 
 **5. Implementation sequencing**
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -130,7 +130,7 @@ Disambiguate names in `specs-from-figma` using suffixes but add no schema metada
 
 | File | Change | Bump |
 |------|--------|------|
-| `Anatomy.ts` | Add optional `$extensions` to `AnatomyElement` with `com.figma` namespace containing `originalName` and `matchMethod` | MINOR |
+| `Anatomy.ts` | Add optional `$extensions` to `AnatomyElement` with `com.figma` namespace containing `originalName` | MINOR |
 
 **Example — new shape** (`types/Anatomy.ts`):
 ```yaml
@@ -148,24 +148,11 @@ AnatomyElement:
   $extensions?:
     com.figma?:
       originalName?: string         # Present only when key differs from Figma layer name
-      matchMethod?: MatchMethod     # How this element's cross-variant identity was determined
 ```
 
-**`MatchMethod`** — a string literal union describing the heuristic used to assign this element's key:
+`$extensions` is present only when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
 
-```yaml
-MatchMethod:
-  | 'unique'            # No disambiguation needed — name was already unique
-  | 'anchor-adjacent'   # Matched via proximity to a unique-named anchor sibling
-  | 'positional'        # No anchors available — matched by absolute position within parent
-```
-
-`matchMethod` is present on **every** anatomy element when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
-
-**Why `matchMethod` matters**: The disambiguation algorithm knows its own confidence level at every step. Discarding that signal forces consumers to treat all element keys as equally reliable. Preserving it enables:
-- **LLM consumers** to reason about reliability: "This element was matched positionally — its identity across variants is less stable than anchor-adjacent matches. Treat its diff with appropriate skepticism."
-- **Documentation tools** to flag low-confidence elements for designer review
-- **Diagnostic UIs** (plugin, CLI) to surface warnings where heuristic quality is lowest
+> **Future ADR**: A subsequent ADR will evaluate whether to add a **provenance signal** (e.g., `matchMethod`) to `$extensions["com.figma"]` indicating the heuristic used for cross-variant matching. This is a separable decision — disambiguation and collision-safe suffixing do not depend on it.
 
 **Example — spec output with disambiguation** (collision-safe):
 ```yaml
@@ -184,45 +171,30 @@ MatchMethod:
 anatomy:
   root:
     type: container
-    $extensions:
-      com.figma:
-        matchMethod: unique
   checkbox:
     type: instance
     instanceOf: Checkbox
-    $extensions:
-      com.figma:
-        matchMethod: positional         # No anchors among the checkboxes
   checkbox2:
     type: instance
     instanceOf: Checkbox
     $extensions:
       com.figma:
         originalName: checkbox
-        matchMethod: positional
   checkbox3:
     type: instance
     instanceOf: Checkbox
     $extensions:
       com.figma:
         originalName: checkbox
-        matchMethod: positional
   icon2:
-    type: glyph
-    $extensions:
-      com.figma:
-        matchMethod: unique             # "icon2" IS the original name
+    type: glyph                         # "icon2" IS the original Figma name
   icon:
     type: glyph
-    $extensions:
-      com.figma:
-        matchMethod: anchor-adjacent    # Adjacent to "icon2" anchor
   icon3:
     type: glyph
     $extensions:
       com.figma:
         originalName: icon
-        matchMethod: anchor-adjacent    # Farther from anchor, but still anchor-relative
 
 # Elements section — uses the same disambiguated keys
 elements:
@@ -254,7 +226,7 @@ layout:
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition with `com.figma` sub-object containing `originalName` and `matchMethod` | MINOR |
+| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition with `com.figma` sub-object containing `originalName` | MINOR |
 
 **Example — new property** (under `#/definitions/AnatomyElement/properties`):
 ```yaml
@@ -272,15 +244,6 @@ $extensions:
             disambiguation. Present only when the element key was modified
             to resolve a duplicate name conflict. When absent, the key IS
             the original layer name.
-        matchMethod:
-          type: string
-          enum: [unique, anchor-adjacent, positional]
-          description: >
-            The heuristic used to determine this element's cross-variant
-            identity. "unique" = no disambiguation needed. "anchor-adjacent"
-            = matched via proximity to a unique-named anchor sibling.
-            "positional" = no anchors available, matched by absolute
-            position within parent (lowest confidence).
       additionalProperties: false
   additionalProperties: true
   # not in required[] — optional field
@@ -288,22 +251,19 @@ $extensions:
 
 ### Notes
 
-- **`$extensions` follows the established provenance pattern**: `TokenReference`, `BooleanProp`, `StringProp`, `EnumProp`, and `SlotProp` all use `$extensions["com.figma"]` for Figma extraction metadata. Placing `originalName` and `matchMethod` here is consistent with the ecosystem convention.
-- **`$extensions` presence is conditional on duplicates**: When a component has **no** duplicate names, `$extensions` is omitted entirely from all anatomy elements — zero overhead for the common case. When **any** duplicate group exists, all elements in the component receive `$extensions` with at least `matchMethod`, because a consumer viewing the spec needs to know which elements are unique and which were disambiguated. `originalName` is only present on elements whose key differs from their Figma layer name.
+- **`$extensions` follows the established provenance pattern**: `TokenReference`, `BooleanProp`, `StringProp`, `EnumProp`, and `SlotProp` all use `$extensions["com.figma"]` for Figma extraction metadata. Placing `originalName` here is consistent with the ecosystem convention.
+- **`$extensions` presence is conditional on disambiguation**: `$extensions["com.figma"].originalName` is present **only** on elements whose key differs from their Figma layer name. When a component has no duplicate names, no `$extensions` appear anywhere — zero overhead for the common case.
 - **`originalName` stores the formatted key version** of the original name (after `formatKey` is applied), not the raw Figma name with original casing. This ensures consumers can compare `originalName` against other keys using the same format.
-- **`Elements` and `Layout` do not need `$extensions`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` and `matchMethod` there.
+- **`Elements` and `Layout` do not need `$extensions`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` there.
 - **The suffix format** (`name`, `name2`, `name3` with collision skipping) is a processing convention, not a schema constraint. The schema only guarantees unique keys and the `$extensions` field for traceability. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
-- **`matchMethod` as provenance signal**: The disambiguation algorithm is deterministic, but its heuristic quality varies by context (see Adversarial cases and Error risk scale in §2). Embedding the match method directly in the output makes spec data **self-documenting** — any consumer (human, LLM, or tool) can assess reliability without re-running the algorithm. This follows the principle that a deterministic script should expose what it *can* evaluate (structural relationships, anchor density) rather than force consumers to infer it.
 
 ---
 
 ## Type ↔ Schema Impact
 
-- **Symmetric**: Yes — one optional `$extensions` object with two properties added to both `AnatomyElement` type and schema definition.
+- **Symmetric**: Yes — one optional `$extensions` object with one property added to both `AnatomyElement` type and schema definition.
 - **Parity check**:
   - `AnatomyElement.$extensions["com.figma"].originalName` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/originalName` (schema)
-  - `AnatomyElement.$extensions["com.figma"].matchMethod` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/matchMethod` (schema)
-  - `MatchMethod` string literal union (type) ↔ `enum: [unique, anchor-adjacent, positional]` (schema)
 
 ---
 
@@ -541,7 +501,7 @@ The work spans two repos and should proceed in this order:
 1. **`specs-schema`**: Add `$extensions` to `AnatomyElement` type and schema. Publish as `0.22.0` (MINOR). This is a trivial, low-risk change.
 2. **`specs-from-figma`**: Implement the global registry, anchor-adjacent matching, and collision-safe suffix assignment. This is the bulk of the work. Split into sub-milestones:
    - **Phase A — Survey infrastructure**: Implement the two-pass survey (name counting, anchor identification) without changing output. Add logging/diagnostics that report which components have duplicate names and what anchors were identified. This is observability-only — no output changes.
-   - **Phase B — Disambiguation**: Apply suffix assignment. All `Record`-keyed structures (`Anatomy._items`, `Elements._items`, `Layout.serialize()`) receive disambiguated keys. Add `$extensions["com.figma"].originalName` to anatomy output. This changes output for components with duplicate names.
+   - **Phase B — Disambiguation**: Apply suffix assignment. All `Record`-keyed structures (`Anatomy._items`, `Elements._items`, `Layout.serialize()`) receive disambiguated keys. Add `$extensions["com.figma"].originalName` to anatomy elements whose key differs from their Figma layer name. This changes output for components with duplicate names.
    - **Phase C — Parity testing**: Run the parity test suite (`specs-testing`) against ground-truth fixtures to validate that disambiguated output is correct and that components with unique names produce identical output.
 3. **`specs-plugin-2`**: Recompile against new schema types. Optionally surface disambiguation warnings in the plugin UI.
 4. **`specs-cli`**: Recompile. No behavioral changes required.
@@ -589,5 +549,4 @@ Parity tests in `specs-testing`:
 - Variant differencing operates on complete element sets, producing accurate diffs
 - The disambiguation suffix format (`name`, `name3`, `name4` with collision skipping) becomes a de facto convention in spec output, though it is not enforced by the schema — suffix numbers may be non-contiguous
 - `specs-from-figma` requires significant architectural changes in traversal, element detection, and variant differencing — this is the primary implementation cost
-- The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata on anatomy (e.g., node IDs, layer visibility) without additional schema changes
-- **Provenance as a design principle**: `matchMethod` establishes a precedent — deterministic processing steps should embed their confidence signals in the output. This transforms spec data from "here are the results" to "here are the results, and here's how much you should trust each one." Future processing steps (e.g., prop inference, subcomponent detection) could follow the same pattern: expose the heuristic method alongside the result, enabling consumers — particularly LLMs — to reason about data quality without needing access to the source Figma file or the processing algorithm
+- The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata on anatomy (e.g., match method confidence signals, node IDs, layer visibility) without additional schema changes — a subsequent ADR will evaluate this

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -453,7 +453,7 @@ The following cases stress-test the algorithm against common component structure
 
 The algorithm applies three disambiguation signals in order of strength:
 
-1. **Ancestry containment** (strongest) — Elements with the same name in different subtrees are already distinct. An `Icon` inside `Card > Header > Actions` and an `Icon` inside `Card > Footer > Links` are separate scopes — their keys are disambiguated by the full ancestry path, not by suffix. This is the most reliable signal because it reflects the designer's structural intent: grouping elements under named containers is an explicit organizational choice.
+1. **Ancestry containment** (strongest **when tree structure is stable**) — Elements with the same name in different subtrees are already distinct. An `Icon` inside `Card > Header > Actions` and an `Icon` inside `Card > Footer > Links` are separate scopes — their keys are disambiguated by the full ancestry path, not by suffix. This is the most reliable signal because it reflects the designer's structural intent: grouping elements under named containers is an explicit organizational choice.
 
    The containment signal extends through the **full ancestry chain**, not just the immediate parent. Every named ancestor contributes to the scope. This means disambiguation must proceed **top-down** — resolve each depth level before descending to its children:
 
@@ -473,6 +473,25 @@ The algorithm applies three disambiguation signals in order of strength:
    ```
 
    Top-down resolution is a natural fit for depth-first traversal: parents are visited before children, so by the time the algorithm reaches a child scope, its parent's disambiguated key is already assigned.
+
+   **Limitation — tree restructuring across variants**: Ancestry containment assumes the tree structure is stable across variants. When a container moves between parents across variants, ancestry paths diverge and the containment signal becomes ambiguous:
+
+   ```yaml
+   # V1: L1 > L2 > L3 > L4 > Icon    (Icon A)
+   #     L1 > L5 > L6 > Icon          (Icon B)
+   #
+   # V2: L1 > L2 > L3 > L6 > Icon    (which V1 Icon does this match?)
+   #
+   # Immediate parent says Icon B (both under L6).
+   # Longest ancestry prefix says Icon A (shares L1 > L2 > L3).
+   # The signals conflict.
+   ```
+
+   This reveals that ancestry doesn't eliminate the cross-variant matching problem — it **moves it up the tree**. Before you can scope children within a parent, you need to know which parent in V1 corresponds to which parent in V2. When containers themselves migrate between ancestors, the algorithm faces the same identity question at the container level.
+
+   **Resolution rule — match containers by name, not path**: Containers are matched across variants by their **disambiguated key**, regardless of where they sit in the tree. If `L6` has a unique name, it's the same container whether it's under `L5` or `L3`. Children scoped within `L6` in V1 match children scoped within `L6` in V2. The layout diff captures the structural change (L6 moved); the element diff captures style changes within it. This is consistent with how the existing anatomy model works — the flat `Anatomy = Record<string, AnatomyElement>` keys elements by name, not by path, so elements that move between parents already retain their identity as long as the key matches.
+
+   In practice, tree restructuring across variants is uncommon — most component variants change leaf-level visibility and properties, not container hierarchy. When it does occur, name-based container matching produces correct results for the common case (a container moved to a different parent) and acceptable degradation for the rare case (a container replaced by a different container with the same name).
 
 2. **Anchor-adjacent matching** (strong) — Within a single parent, unique-named siblings serve as stable landmarks. Duplicates are matched by proximity to these anchors. Effective when the parent contains a mix of unique and repeated names.
 
@@ -524,6 +543,8 @@ Once elements have stable, anchor-relative disambiguated keys:
 **4. Floating elements across variants**
 
 An element that appears at different hierarchy positions in different variants (e.g., `label` as a child of `header` in variant A, child of `content` in variant B) is treated as **the same element** if its disambiguated key matches. The layout diff captures the structural change; the element diff captures style changes. This is existing behavior — disambiguation doesn't change it, but it does ensure the element isn't silently dropped if another element shares its name.
+
+This same principle applies to containers: when a parent node moves between ancestors across variants, it retains its identity via its disambiguated key (see *Disambiguation hierarchy*, ancestry containment limitation). Children scoped within that container are matched by the container's key, not its ancestry path.
 
 **5. Implementation sequencing**
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -430,7 +430,7 @@ The following cases stress-test the algorithm against common component structure
 |---------|-----------|-------------|
 | **Alert/Banner** (`[Icon, Content, Icon]`) | Two `Icon` siblings flanking a unique `Content` anchor | `Content` is the anchor. Leading icon = before-content, trailing icon = after-content. Correct even when `has-close=false` removes the trailing icon. |
 | **Breadcrumb** (`[Link, Sep, Link, Sep, Link]`) | Interleaved `Link` + `Separator` pairs | Each `Separator` is an anchor (unique per occurrence since the Links are the duplicates). The current-page `Link` (always last) stays matched to its adjacent separator. |
-| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in **different subtrees** | **Parent containment** is the strongest disambiguation signal — each `Icon` is scoped to its parent (`Header` vs `Footer`) and receives a distinct key by ancestry alone. No sibling-level heuristic needed. See *Disambiguation hierarchy* below. |
+| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in **different subtrees** | **Ancestry containment** is the strongest disambiguation signal — each `Icon` is scoped by its full containment path (`Header` vs `Footer`) and receives a distinct key without any sibling-level heuristic. See *Disambiguation hierarchy* below. |
 
 ##### Medium confidence — correct for typical usage, fragile under reordering
 
@@ -453,7 +453,26 @@ The following cases stress-test the algorithm against common component structure
 
 The algorithm applies three disambiguation signals in order of strength:
 
-1. **Parent containment** (strongest) — Elements with the same name in different subtrees are already distinct. An `Icon` inside `Header` and an `Icon` inside `Footer` are separate scopes — their keys are disambiguated by ancestry, not by suffix. This is the first and most reliable signal because it reflects the designer's structural intent: grouping elements under named parents is an explicit organizational choice.
+1. **Ancestry containment** (strongest) — Elements with the same name in different subtrees are already distinct. An `Icon` inside `Card > Header > Actions` and an `Icon` inside `Card > Footer > Links` are separate scopes — their keys are disambiguated by the full ancestry path, not by suffix. This is the most reliable signal because it reflects the designer's structural intent: grouping elements under named containers is an explicit organizational choice.
+
+   The containment signal extends through the **full ancestry chain**, not just the immediate parent. Every named ancestor contributes to the scope. This means disambiguation must proceed **top-down** — resolve each depth level before descending to its children:
+
+   ```yaml
+   # Same-named parents are themselves duplicates:
+   #   Section, Section (siblings at depth 1)
+   #
+   # Step 1 — disambiguate depth 1:
+   #   section, section2
+   #
+   # Step 2 — each disambiguated parent scopes its children independently:
+   #   section  > [icon, label, icon]  → icon, label, icon2  (scoped to section)
+   #   section2 > [icon, label, icon]  → icon, label, icon2  (scoped to section2)
+   #
+   # These are four distinct icons — ancestry separates section/section2,
+   # then sibling disambiguation separates icon/icon2 within each.
+   ```
+
+   Top-down resolution is a natural fit for depth-first traversal: parents are visited before children, so by the time the algorithm reaches a child scope, its parent's disambiguated key is already assigned.
 
 2. **Anchor-adjacent matching** (strong) — Within a single parent, unique-named siblings serve as stable landmarks. Duplicates are matched by proximity to these anchors. Effective when the parent contains a mix of unique and repeated names.
 
@@ -488,7 +507,7 @@ The two-pass approach adds one lightweight traversal over all variants:
 
 **Anchor itself is absent in some variants**: If `label` appears in variant A but not variant B, it cannot serve as an anchor. Only names present in **every variant that contains them** qualify. In practice, this means: if an anchor is optional (absent in some variants), its segments are merged with adjacent segments in variants where it's missing.
 
-**Nested duplicates**: Disambiguation is scoped to each parent independently (see *Disambiguation hierarchy*, level 1). A parent named `header` with children `[icon, icon]` and a sibling parent `footer` with children `[icon, icon]` are separate scopes. The `icon` in `header` and the `icon` in `footer` are already distinct by ancestry — they have different keys in the flattened anatomy because the traversal encounters them in different subtrees. Parent containment is the primary defense against the "same name, different purpose" scenario (Context §2) — the designer's grouping structure, not suffix matching, is what distinguishes them.
+**Nested duplicates**: Disambiguation is scoped by the full ancestry path (see *Disambiguation hierarchy*, level 1). A container `header` with children `[icon, icon]` and a sibling container `footer` with children `[icon, icon]` are separate scopes — the Icons are distinguished by containment, not suffix. When the containers themselves are duplicates (e.g., two `Section` siblings), top-down resolution disambiguates parents first (`section`, `section2`), then scopes child disambiguation independently within each. This recursive descent is the primary defense against the "same name, different purpose" scenario (Context §2) — the designer's grouping structure, at every depth, is what distinguishes elements.
 
 **Anchor ordering inconsistency**: If anchors themselves appear in different orders across variants (e.g., VA has `[label, description]` but VB has `[description, label]`), the segment boundaries diverge and anchor-relative matching degrades. This is treated as a design inconsistency — the algorithm falls back to absolute position for affected segments and emits a diagnostic warning.
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -130,7 +130,7 @@ Disambiguate names in `specs-from-figma` using suffixes but add no schema metada
 
 | File | Change | Bump |
 |------|--------|------|
-| `Anatomy.ts` | Add optional `$extensions` to `AnatomyElement` with `com.figma` namespace containing `originalName` | MINOR |
+| `Anatomy.ts` | Add optional `$extensions` to `AnatomyElement` with `com.figma` namespace containing `originalName` and `matchMethod` | MINOR |
 
 **Example — new shape** (`types/Anatomy.ts`):
 ```yaml
@@ -147,8 +147,25 @@ AnatomyElement:
   instanceOf?: string | SubcomponentRef
   $extensions?:
     com.figma?:
-      originalName?: string   # Present only when key differs from Figma layer name
+      originalName?: string         # Present only when key differs from Figma layer name
+      matchMethod?: MatchMethod     # How this element's cross-variant identity was determined
 ```
+
+**`MatchMethod`** — a string literal union describing the heuristic used to assign this element's key:
+
+```yaml
+MatchMethod:
+  | 'unique'            # No disambiguation needed — name was already unique
+  | 'anchor-adjacent'   # Matched via proximity to a unique-named anchor sibling
+  | 'positional'        # No anchors available — matched by absolute position within parent
+```
+
+`matchMethod` is present on **every** anatomy element when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
+
+**Why `matchMethod` matters**: The disambiguation algorithm knows its own confidence level at every step. Discarding that signal forces consumers to treat all element keys as equally reliable. Preserving it enables:
+- **LLM consumers** to reason about reliability: "This element was matched positionally — its identity across variants is less stable than anchor-adjacent matches. Treat its diff with appropriate skepticism."
+- **Documentation tools** to flag low-confidence elements for designer review
+- **Diagnostic UIs** (plugin, CLI) to surface warnings where heuristic quality is lowest
 
 **Example — spec output with disambiguation** (collision-safe):
 ```yaml
@@ -167,30 +184,45 @@ AnatomyElement:
 anatomy:
   root:
     type: container
+    $extensions:
+      com.figma:
+        matchMethod: unique
   checkbox:
     type: instance
     instanceOf: Checkbox
+    $extensions:
+      com.figma:
+        matchMethod: positional         # No anchors among the checkboxes
   checkbox2:
     type: instance
     instanceOf: Checkbox
     $extensions:
       com.figma:
         originalName: checkbox
+        matchMethod: positional
   checkbox3:
     type: instance
     instanceOf: Checkbox
     $extensions:
       com.figma:
         originalName: checkbox
+        matchMethod: positional
   icon2:
-    type: glyph                    # No $extensions — "icon2" IS the original name
+    type: glyph
+    $extensions:
+      com.figma:
+        matchMethod: unique             # "icon2" IS the original name
   icon:
     type: glyph
+    $extensions:
+      com.figma:
+        matchMethod: anchor-adjacent    # Adjacent to "icon2" anchor
   icon3:
     type: glyph
     $extensions:
       com.figma:
-        originalName: icon         # Was "icon", but "icon2" was taken
+        originalName: icon
+        matchMethod: anchor-adjacent    # Farther from anchor, but still anchor-relative
 
 # Elements section — uses the same disambiguated keys
 elements:
@@ -222,7 +254,7 @@ layout:
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition with `com.figma` sub-object | MINOR |
+| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition with `com.figma` sub-object containing `originalName` and `matchMethod` | MINOR |
 
 **Example — new property** (under `#/definitions/AnatomyElement/properties`):
 ```yaml
@@ -240,6 +272,15 @@ $extensions:
             disambiguation. Present only when the element key was modified
             to resolve a duplicate name conflict. When absent, the key IS
             the original layer name.
+        matchMethod:
+          type: string
+          enum: [unique, anchor-adjacent, positional]
+          description: >
+            The heuristic used to determine this element's cross-variant
+            identity. "unique" = no disambiguation needed. "anchor-adjacent"
+            = matched via proximity to a unique-named anchor sibling.
+            "positional" = no anchors available, matched by absolute
+            position within parent (lowest confidence).
       additionalProperties: false
   additionalProperties: true
   # not in required[] — optional field
@@ -247,18 +288,22 @@ $extensions:
 
 ### Notes
 
-- **`$extensions` follows the established provenance pattern**: `TokenReference`, `BooleanProp`, `StringProp`, `EnumProp`, and `SlotProp` all use `$extensions["com.figma"]` for Figma extraction metadata. Placing `originalName` here is consistent with the ecosystem convention.
-- **`$extensions` is omitted when not needed**: If the key matches the original Figma layer name (the common case), neither `$extensions` nor `originalName` are present. This keeps output compact for components with unique names.
+- **`$extensions` follows the established provenance pattern**: `TokenReference`, `BooleanProp`, `StringProp`, `EnumProp`, and `SlotProp` all use `$extensions["com.figma"]` for Figma extraction metadata. Placing `originalName` and `matchMethod` here is consistent with the ecosystem convention.
+- **`$extensions` presence is conditional on duplicates**: When a component has **no** duplicate names, `$extensions` is omitted entirely from all anatomy elements — zero overhead for the common case. When **any** duplicate group exists, all elements in the component receive `$extensions` with at least `matchMethod`, because a consumer viewing the spec needs to know which elements are unique and which were disambiguated. `originalName` is only present on elements whose key differs from their Figma layer name.
 - **`originalName` stores the formatted key version** of the original name (after `formatKey` is applied), not the raw Figma name with original casing. This ensures consumers can compare `originalName` against other keys using the same format.
-- **`Elements` and `Layout` do not need `$extensions.originalName`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` there.
+- **`Elements` and `Layout` do not need `$extensions`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` and `matchMethod` there.
 - **The suffix format** (`name`, `name2`, `name3` with collision skipping) is a processing convention, not a schema constraint. The schema only guarantees unique keys and the `$extensions` field for traceability. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
+- **`matchMethod` as provenance signal**: The disambiguation algorithm is deterministic, but its heuristic quality varies by context (see Adversarial cases and Error risk scale in §2). Embedding the match method directly in the output makes spec data **self-documenting** — any consumer (human, LLM, or tool) can assess reliability without re-running the algorithm. This follows the principle that a deterministic script should expose what it *can* evaluate (structural relationships, anchor density) rather than force consumers to infer it.
 
 ---
 
 ## Type ↔ Schema Impact
 
-- **Symmetric**: Yes — one optional `$extensions` object added to both `AnatomyElement` type and schema definition.
-- **Parity check**: `AnatomyElement.$extensions["com.figma"].originalName` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/originalName` (schema).
+- **Symmetric**: Yes — one optional `$extensions` object with two properties added to both `AnatomyElement` type and schema definition.
+- **Parity check**:
+  - `AnatomyElement.$extensions["com.figma"].originalName` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/originalName` (schema)
+  - `AnatomyElement.$extensions["com.figma"].matchMethod` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/matchMethod` (schema)
+  - `MatchMethod` string literal union (type) ↔ `enum: [unique, anchor-adjacent, positional]` (schema)
 
 ---
 
@@ -545,3 +590,4 @@ Parity tests in `specs-testing`:
 - The disambiguation suffix format (`name`, `name3`, `name4` with collision skipping) becomes a de facto convention in spec output, though it is not enforced by the schema — suffix numbers may be non-contiguous
 - `specs-from-figma` requires significant architectural changes in traversal, element detection, and variant differencing — this is the primary implementation cost
 - The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata on anatomy (e.g., node IDs, layer visibility) without additional schema changes
+- **Provenance as a design principle**: `matchMethod` establishes a precedent — deterministic processing steps should embed their confidence signals in the output. This transforms spec data from "here are the results" to "here are the results, and here's how much you should trust each one." Future processing steps (e.g., prop inference, subcomponent detection) could follow the same pattern: expose the heuristic method alongside the result, enabling consumers — particularly LLMs — to reason about data quality without needing access to the source Figma file or the processing algorithm

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -71,11 +71,12 @@ The suffix algorithm must be **collision-safe** — it cannot assign a suffix th
 ```
 
 Algorithm:
-1. Collect all original element names in the current scope into a **reserved set**
-2. First occurrence of a name → use as-is
-3. Subsequent occurrences → find the lowest available suffix (`name2`, `name3`, ...) that is **not in the reserved set** and **not already assigned**
-4. Add each assigned disambiguated name to the reserved set to prevent future collisions
-5. Suffixes are assigned by **traversal order within a single variant** (depth-first, matching Figma's layer panel order)
+1. Collect all original element names across all variants into a **reserved set**
+2. For each duplicate name group, identify distinct identities via the global two-pass registry (§2: anchor-adjacent matching across variants)
+3. Rank identities by **cross-variant prevalence** — the identity appearing in the most variants gets the base name; less prevalent identities get ascending suffixes
+4. Ties in prevalence → break by first traversal appearance (depth-first order in the first variant encountered)
+5. Each assigned suffix must be **collision-safe**: find the lowest available suffix (`name2`, `name3`, ...) that is **not in the reserved set** and **not already assigned**
+6. Add each assigned disambiguated name to the reserved set to prevent future collisions
 
 **Pros**:
 - Human-readable keys (`icon`, `icon3` is immediately understandable)
@@ -85,8 +86,8 @@ Algorithm:
 - Simple algorithm — no dependency on node types or hierarchy depth
 
 **Cons / Trade-offs**:
-- Positional sensitivity: if a designer reorders two identically-named layers, their suffixes swap, which changes the keys. This is inherent to any ordering-based scheme.
-- Cross-variant matching relies on traversal-order consistency. If variant A has `[icon, label, icon]` and variant B has `[label, icon]`, the single `icon` in B matches `icon` (the first) in A by name. The second `icon3` in A has no match in B — it appears as a diff. This is correct behavior.
+- Positional sensitivity: if a designer reorders two identically-named layers within the same anchor segment, their suffixes may swap, which changes the keys. This is inherent to any ordering-based tiebreaker.
+- Cross-variant matching depends on the global registry producing stable identities. If variant A has `[icon, label, icon]` and variant B has `[label, icon]`, anchor-adjacent matching correctly identifies the after-label Icon as the persistent element (96 variants > 1 variant) and assigns it the base name. The before-label Icon in A, appearing in fewer variants, gets the suffix. This is correct behavior.
 - Suffix numbers may not be contiguous (e.g., `icon`, `icon3` when `icon2` is reserved by an original layer name). This is intentional — contiguity is sacrificed for collision safety.
 
 ---
@@ -371,12 +372,18 @@ Anchor-adjacent is preferred for three reasons:
 #   VA after-label, adjacent to label (pos 0):   icon  ─┐
 #   VB after-label, adjacent to label (pos 0):   icon  ─┘ SAME element
 
-# Three distinct identities, suffixes assigned by first traversal appearance:
-#   Identity 1 (before-label, adjacent) → first seen VA pos 0 → "icon"
-#   Identity 2 (after-label, adjacent)  → first seen VA pos 2 → "icon2"
-#   Identity 3 (before-label, far)      → first seen VB pos 0 → "icon3"
+# Three distinct identities, suffixes assigned by cross-variant prevalence:
+#   Identity 1 (before-label, adjacent) → appears in VA + VB (2 variants) → "icon"
+#   Identity 2 (after-label, adjacent)  → appears in VA + VB (2 variants) → "icon2" (tie, broken by first traversal)
+#   Identity 3 (before-label, far)      → appears in VB only (1 variant)  → "icon3"
+#
+# In this example prevalence is tied for identities 1 and 2 (both in 2 variants),
+# so the tiebreaker (traversal order) applies. In a real scenario where VA has
+# both icons but VB-V96 have only the after-label icon:
+#   after-label identity → 96 variants → "icon" (base name — most prevalent)
+#   before-label identity → 1 variant  → "icon2"
 
-# Final disambiguation:
+# Final disambiguation (for this 2-variant example):
 #   Variant A: icon, label, icon2
 #   Variant B: icon3, icon, label, icon2
 #
@@ -410,11 +417,11 @@ When multiple anchors exist, they create finer-grained segments. Matching radiat
 #   after-description (left-to-right from description):
 #     VA [→icon]     →  VB [→icon]  → match
 
-# Identities and suffix assignment:
-#   Identity 1 (before-label, adjacent)         → first seen VA pos 0 → "icon"
-#   Identity 2 (after-description, adjacent)    → first seen VA pos 3 → "icon2"
-#   Identity 3 (between-label-desc, adjacent)   → first seen VB pos 3 → "icon3"
-#   Identity 4 (before-label, far)              → first seen VB pos 0 → "icon4"
+# Identities and suffix assignment (by prevalence, then traversal order):
+#   Identity 1 (before-label, adjacent)         → VA + VB (2 variants) → "icon"
+#   Identity 2 (after-description, adjacent)    → VA + VB (2 variants) → "icon2"
+#   Identity 3 (between-label-desc, adjacent)   → VB only (1 variant)  → "icon3"
+#   Identity 4 (before-label, far)              → VB only (1 variant)  → "icon4"
 
 # Variant A: icon, label, description, icon2
 # Variant B: icon4, icon, label, icon3, description, icon2
@@ -564,7 +571,34 @@ This distinction is important: **ancestry containment scopes the within-variant 
 # The element diffs show: style changes (if any) between variants.
 ```
 
-The risk in cross-variant matching is not parent changes — it's **suffix instability**. If V1's disambiguation assigns `icon` to the first Icon and `icon2` to the second, but V2's disambiguation assigns them differently (because anchors shifted, or sibling order changed), the flat keys diverge and the element is mismatched. This is exactly what the global two-pass registry (§2) is designed to prevent — by surveying all variants before assigning any suffixes, the same logical element receives the same key everywhere.
+The risk in cross-variant matching is **suffix instability** — the same logical element receiving different keys in different variants. This can happen when suffix assignment is based on traversal order alone:
+
+```yaml
+# V1:     [Icon₁, Label, Icon₂]  → icon, label, icon2
+# V2-V96: [Label, Icon₂]         → label, icon
+#
+# Traversal-order assignment: V1 assigns "icon" to Icon₁ (first encountered)
+# and "icon2" to Icon₂. V2-V96 assign "icon" to Icon₂ (only one Icon).
+#
+# Cross-variant matching: V2's "icon" matches V1's "icon" — but those are
+# DIFFERENT elements. Icon₂ is "icon2" in V1 and "icon" in V2.
+# Result: 95 wrong comparisons.
+```
+
+The fix: suffix assignment must use **cross-variant prevalence**, not traversal order (see Algorithm, step 3). The global two-pass registry identifies identities first (via anchor-adjacent matching), then assigns the base name to the identity appearing in the **most variants**:
+
+```yaml
+# Identity A (before-label Icon₁) → 1 variant   → "icon2"
+# Identity B (after-label Icon₂)  → 96 variants  → "icon" (base name)
+#
+# V1:     icon2, label, icon    ← Icon₁ gets the suffix
+# V2-V96: label, icon           ← Icon₂ keeps the base name
+#
+# Cross-variant matching: V2's "icon" matches V1's "icon" — CORRECT.
+# The persistent element gets the stable key everywhere.
+```
+
+This ensures that the element appearing in the most variants always gets the base name, and optional/rare elements get suffixes — regardless of which variant is traversed first.
 
 **5. Implementation sequencing**
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -51,25 +51,41 @@ The original EGDS Specs generator solved this with a composite key: **layer name
 
 ## Options Considered
 
-### Option A: Numeric suffix disambiguation + `originalName` metadata *(Selected)*
+### Option A: Collision-safe numeric suffix + `$extensions` metadata *(Selected)*
 
-Disambiguate duplicate names by appending a numeric suffix (`icon`, `icon2`, `icon3`) at traversal time, before any dictionary keying. Add an optional `originalName` field to `AnatomyElement` so consumers can recover the original Figma layer name when disambiguation occurred.
+Disambiguate duplicate names by appending a numeric suffix at traversal time, before any dictionary keying. Store the original Figma layer name under `$extensions["com.figma"].originalName` on `AnatomyElement`, following the existing DTCG extension convention used by `TokenReference` and `PropExtensions`.
 
-The suffix algorithm:
-- First occurrence keeps the bare name: `icon`
-- Subsequent occurrences get ascending suffixes: `icon2`, `icon3`, ...
-- Suffixes are assigned by **traversal order within a single variant** (depth-first, matching Figma's layer panel order)
-- Cross-variant stability: the disambiguation is performed per-variant, then the anatomy merges use the disambiguated keys for matching
+The suffix algorithm must be **collision-safe** — it cannot assign a suffix that conflicts with an existing element name:
+
+```yaml
+# Input layers in traversal order:
+#   icon, icon, icon2
+
+# Naive (WRONG) — second "icon" steals "icon2" from the third element:
+#   icon, icon2, icon2  ← COLLISION
+
+# Collision-safe (CORRECT) — skip occupied names:
+#   icon, icon3, icon2
+```
+
+Algorithm:
+1. Collect all original element names in the current scope into a **reserved set**
+2. First occurrence of a name → use as-is
+3. Subsequent occurrences → find the lowest available suffix (`name2`, `name3`, ...) that is **not in the reserved set** and **not already assigned**
+4. Add each assigned disambiguated name to the reserved set to prevent future collisions
+5. Suffixes are assigned by **traversal order within a single variant** (depth-first, matching Figma's layer panel order)
 
 **Pros**:
-- Human-readable keys (`icon`, `icon2` is immediately understandable)
-- `originalName` preserves the Figma source name for consumers that need it (documentation tools, design token mapping)
-- Additive schema change (MINOR) — `originalName` is optional, existing specs are unaffected
+- Human-readable keys (`icon`, `icon3` is immediately understandable)
+- `$extensions["com.figma"].originalName` follows the established Figma provenance convention — consistent with `TokenReference.$extensions` and `PropExtensions["com.figma"]`
+- Collision-safe — never steals a name that belongs to an existing element
+- Additive schema change (MINOR) — `$extensions` is optional, existing specs are unaffected
 - Simple algorithm — no dependency on node types or hierarchy depth
 
 **Cons / Trade-offs**:
 - Positional sensitivity: if a designer reorders two identically-named layers, their suffixes swap, which changes the keys. This is inherent to any ordering-based scheme.
-- Cross-variant matching relies on traversal-order consistency. If variant A has `[icon, label, icon]` and variant B has `[label, icon]`, the single `icon` in B matches `icon` (the first) in A by name. The second `icon2` in A has no match in B — it appears as a diff. This is correct behavior.
+- Cross-variant matching relies on traversal-order consistency. If variant A has `[icon, label, icon]` and variant B has `[label, icon]`, the single `icon` in B matches `icon` (the first) in A by name. The second `icon3` in A has no match in B — it appears as a diff. This is correct behavior.
+- Suffix numbers may not be contiguous (e.g., `icon`, `icon3` when `icon2` is reserved by an original layer name). This is intentional — contiguity is sacrificed for collision safety.
 
 ---
 
@@ -101,8 +117,8 @@ Use the full hierarchy path as the key: `root/content/icon:0`, `root/header/icon
 Disambiguate names in `specs-from-figma` using suffixes but add no schema metadata.
 
 **Rejected because**:
-- Consumers see `icon2` but can't determine whether it was originally named `icon2` in Figma or disambiguated from `icon`. The `originalName` field makes this distinction explicit and supports round-trip fidelity.
-- Small schema cost (one optional field) for significant traceability gain.
+- Consumers see `icon3` but can't determine whether it was originally named `icon3` in Figma or disambiguated from `icon`. The `$extensions["com.figma"].originalName` field makes this distinction explicit and supports round-trip fidelity.
+- Small schema cost (one optional field within an established extension pattern) for significant traceability gain.
 
 ---
 
@@ -112,7 +128,7 @@ Disambiguate names in `specs-from-figma` using suffixes but add no schema metada
 
 | File | Change | Bump |
 |------|--------|------|
-| `Anatomy.ts` | Add optional `originalName?: string` to `AnatomyElement` | MINOR |
+| `Anatomy.ts` | Add optional `$extensions` to `AnatomyElement` with `com.figma` namespace containing `originalName` | MINOR |
 
 **Example — new shape** (`types/Anatomy.ts`):
 ```yaml
@@ -127,12 +143,25 @@ AnatomyElement:
   type: ElementType | ElementTypeRef
   detectedIn?: string
   instanceOf?: string | SubcomponentRef
-  originalName?: string   # Present only when key differs from Figma layer name
+  $extensions?:
+    com.figma?:
+      originalName?: string   # Present only when key differs from Figma layer name
 ```
 
-**Example — spec output with disambiguation**:
+**Example — spec output with disambiguation** (collision-safe):
 ```yaml
-# Anatomy section of a component with duplicate "Checkbox" layers
+# Input: Figma layers in order: Checkbox, Checkbox, Checkbox, icon2, icon, icon
+# After formatKey (camelCase): checkbox, checkbox, checkbox, icon2, icon, icon
+
+# Collision-safe disambiguation:
+#   "checkbox" → reserved set: {checkbox, icon2, icon}
+#   1st checkbox → "checkbox" (first occurrence, keep as-is)
+#   2nd checkbox → "checkbox2" not reserved → assign "checkbox2"
+#   3rd checkbox → "checkbox3" not reserved → assign "checkbox3"
+#   "icon2" → already in reserved set, first occurrence → "icon2" (keep as-is)
+#   1st icon → "icon" (first occurrence, keep as-is)
+#   2nd icon → "icon2" IS reserved → skip; "icon3" not reserved → assign "icon3"
+
 anatomy:
   root:
     type: container
@@ -142,13 +171,24 @@ anatomy:
   checkbox2:
     type: instance
     instanceOf: Checkbox
-    originalName: checkbox      # Was "Checkbox" in Figma, same as checkbox above
+    $extensions:
+      com.figma:
+        originalName: checkbox
   checkbox3:
     type: instance
     instanceOf: Checkbox
-    originalName: checkbox      # Was "Checkbox" in Figma
-  label:
-    type: text
+    $extensions:
+      com.figma:
+        originalName: checkbox
+  icon2:
+    type: glyph                    # No $extensions — "icon2" IS the original name
+  icon:
+    type: glyph
+  icon3:
+    type: glyph
+    $extensions:
+      com.figma:
+        originalName: icon         # Was "icon", but "icon2" was taken
 
 # Elements section — uses the same disambiguated keys
 elements:
@@ -158,6 +198,12 @@ elements:
     styles: { ... }
   checkbox3:
     styles: { ... }
+  icon2:
+    styles: { ... }
+  icon:
+    styles: { ... }
+  icon3:
+    styles: { ... }
 
 # Layout section — uses disambiguated keys in tree
 layout:
@@ -165,39 +211,52 @@ layout:
     - checkbox
     - checkbox2
     - checkbox3
-    - label
+    - icon2
+    - icon
+    - icon3
 ```
 
 ### Schema changes (`schema/`)
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Add optional `originalName` property to `AnatomyElement` definition | MINOR |
+| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition with `com.figma` sub-object | MINOR |
 
 **Example — new property** (under `#/definitions/AnatomyElement/properties`):
 ```yaml
-originalName:
-  type: string
-  description: >
-    The original Figma layer name before disambiguation. Present only when
-    the element key was modified to resolve a duplicate name conflict.
-    When absent, the key IS the original layer name.
+$extensions:
+  type: object
+  description: "DTCG §5.2.3 platform-specific extensions."
+  properties:
+    com.figma:
+      type: object
+      properties:
+        originalName:
+          type: string
+          description: >
+            The original Figma layer name (after formatKey) before
+            disambiguation. Present only when the element key was modified
+            to resolve a duplicate name conflict. When absent, the key IS
+            the original layer name.
+      additionalProperties: false
+  additionalProperties: true
   # not in required[] — optional field
 ```
 
 ### Notes
 
-- **`originalName` is omitted when not needed**: If the key matches the original Figma layer name (the common case), the field is absent. This keeps output compact for components with unique names.
+- **`$extensions` follows the established provenance pattern**: `TokenReference`, `BooleanProp`, `StringProp`, `EnumProp`, and `SlotProp` all use `$extensions["com.figma"]` for Figma extraction metadata. Placing `originalName` here is consistent with the ecosystem convention.
+- **`$extensions` is omitted when not needed**: If the key matches the original Figma layer name (the common case), neither `$extensions` nor `originalName` are present. This keeps output compact for components with unique names.
 - **`originalName` stores the formatted key version** of the original name (after `formatKey` is applied), not the raw Figma name with original casing. This ensures consumers can compare `originalName` against other keys using the same format.
-- **`Elements` and `Layout` do not need `originalName`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` there.
-- **The suffix format** (`name`, `name2`, `name3`) is a processing convention, not a schema constraint. The schema only guarantees unique keys and the `originalName` field for traceability. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
+- **`Elements` and `Layout` do not need `$extensions.originalName`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` there.
+- **The suffix format** (`name`, `name2`, `name3` with collision skipping) is a processing convention, not a schema constraint. The schema only guarantees unique keys and the `$extensions` field for traceability. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
 
 ---
 
 ## Type ↔ Schema Impact
 
-- **Symmetric**: Yes — one optional field added to both `AnatomyElement` type and schema definition.
-- **Parity check**: `AnatomyElement.originalName` (type) ↔ `#/definitions/AnatomyElement/properties/originalName` (schema).
+- **Symmetric**: Yes — one optional `$extensions` object added to both `AnatomyElement` type and schema definition.
+- **Parity check**: `AnatomyElement.$extensions["com.figma"].originalName` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/originalName` (schema).
 
 ---
 
@@ -224,10 +283,73 @@ Disambiguation must happen at the earliest point: during `Anatomy.traverse()`, b
 
 **2. Cross-variant key stability**
 
-The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants. Two strategies to evaluate:
+The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants so that differencing produces correct diffs. Two strategies are viable:
 
-- **Per-variant disambiguation + anatomy merge**: Each variant is disambiguated independently. The anatomy accumulates elements from all variants using `addNewElementsFromVariant()`. When a disambiguated key from variant B doesn't match any key in the anatomy (built from variant A), it's added as a new element. This works correctly when traversal order is consistent across variants.
-- **Global name registry**: Build a disambiguation registry from all variants before processing any single variant. Analyze all variants to determine the maximum count of each name, then assign stable suffixes. This is more robust but requires a two-pass approach.
+#### Strategy A: Per-variant disambiguation + anatomy merge
+
+Each variant is disambiguated independently using the collision-safe algorithm. The anatomy accumulates elements from all variants using `addNewElementsFromVariant()`. When a disambiguated key from variant B doesn't match any key in the anatomy (built from variant A), it's added as a new element.
+
+```yaml
+# Variant A layers: [icon, label, icon]
+# After disambiguation: icon, label, icon3 (icon2 might be reserved)
+# Anatomy after variant A: {icon, label, icon3}
+
+# Variant B layers: [icon, label]
+# After disambiguation: icon, label (no duplicates)
+# Anatomy merge: icon ✓ exists, label ✓ exists → no new elements
+
+# Variant C layers: [icon, icon, icon, label]
+# After disambiguation: icon, icon3, icon4, label
+# Anatomy merge: icon ✓, icon3 ✓, label ✓, icon4 is NEW → added
+# Final anatomy: {icon, label, icon3, icon4}
+```
+
+**Pros**:
+- Simple — single pass, fits existing processing pipeline
+- Each variant is self-contained; no coordination required
+
+**Cons**:
+- Suffix assignment depends on which variant is processed first (the baseline). If variant A has `[icon, icon]` → `icon, icon2` and variant B has `[icon, icon, icon]` → `icon, icon2, icon3`, the keys align. But if variant A has `[icon, label, icon]` and variant C has `[icon, icon, label]`, the second `icon` gets different suffixes in each (`icon3` vs `icon2` depending on the reserved set), and differencing may see them as different elements.
+- Variant processing order affects the anatomy's key set, which can produce inconsistent diffs.
+
+#### Strategy B: Global name registry (two-pass)
+
+Before processing any variant, scan all variants to build a **global disambiguation registry**:
+
+1. **Pass 1 — Survey**: For each unique name across all variants, record the maximum occurrence count and the set of names that exist as originals (for collision avoidance).
+2. **Pass 2 — Assign**: Using the global reserved set, assign suffixes using the collision-safe algorithm. Because the reserved set is the same for all variants, the same name at the same traversal position always gets the same suffix.
+
+```yaml
+# Survey pass:
+#   "icon" appears: 2× in variant A, 1× in variant B, 3× in variant C → max 3
+#   "icon2" appears: 1× in variant A (as an original name) → reserved
+#   "label" appears: 1× everywhere → max 1
+
+# Global reserved set: {icon, icon2, label}
+# Disambiguation slots for "icon": icon (1st), icon3 (2nd, skip icon2), icon4 (3rd)
+
+# All variants now use the same slot assignments:
+#   Variant A: [icon, icon] → icon, icon3
+#   Variant B: [icon] → icon
+#   Variant C: [icon, icon, icon] → icon, icon3, icon4
+
+# Differencing: "icon3" in A and "icon3" in C are the SAME element (2nd icon)
+```
+
+**Pros**:
+- Deterministic regardless of variant processing order
+- Same traversal position always maps to the same key across all variants
+- Differencing is accurate — no false positives from inconsistent suffixes
+
+**Cons**:
+- Requires two passes over all variants (survey + assign), adding complexity to the processing pipeline
+- The "same traversal position" heuristic assumes designers maintain consistent layer ordering across variants. If variant A has `[icon-decorative, icon-functional]` and variant B has `[icon-functional, icon-decorative]` (swapped order, both named `icon`), they'll get swapped keys. This is an inherent limitation of positional matching without semantic analysis.
+
+#### Recommendation
+
+Strategy B (global registry) is preferred for correctness. The two-pass cost is low — the survey pass only collects name counts, not full element processing. The payoff is deterministic key stability across all variants, which directly impacts the quality of variant diffs.
+
+Strategy A is acceptable as a first implementation if the two-pass approach proves too disruptive to the existing pipeline, with the understanding that edge cases around variant-order-dependent suffixes may produce suboptimal diffs.
 
 **3. Variant differencing accuracy**
 
@@ -253,9 +375,10 @@ An element that appears at different hierarchy positions in different variants (
 ## Consequences
 
 - Spec output represents every element in the Figma source — no silent data loss from duplicate layer names
-- Components with unique layer names (the majority) produce identical output — `originalName` is absent, keys unchanged
-- Consumers can distinguish between an element named `icon2` by the designer and one disambiguated from `icon` by checking for `originalName`
+- Components with unique layer names (the majority) produce identical output — no `$extensions` present, keys unchanged
+- Consumers can distinguish between an element named `icon2` by the designer and one disambiguated from `icon` by checking for `$extensions["com.figma"].originalName`
+- The collision-safe algorithm guarantees no name theft — an original `icon2` layer is never displaced by a disambiguated `icon` duplicate
 - Variant differencing operates on complete element sets, producing accurate diffs
-- The disambiguation suffix format (`name2`, `name3`) becomes a de facto convention in spec output, though it is not enforced by the schema
+- The disambiguation suffix format (`name`, `name3`, `name4` with collision skipping) becomes a de facto convention in spec output, though it is not enforced by the schema — suffix numbers may be non-contiguous
 - `specs-from-figma` requires significant architectural changes in traversal, element detection, and variant differencing — this is the primary implementation cost
-- Future consideration: if numeric suffixes prove insufficient (e.g., designers already use `icon2` as a name), a more sophisticated disambiguation strategy may be needed. The `originalName` field supports any future suffix scheme without schema changes
+- The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata on anatomy (e.g., node IDs, layer visibility) without additional schema changes

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -1,0 +1,261 @@
+# ADR: Duplicate Layer Name Disambiguation
+
+**Branch**: `adr/044-duplicate-layer-disambiguation`
+**Created**: 2026-05-07
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+Three core types in `@directededges/specs-schema` use layer names as dictionary keys:
+
+- `Anatomy = Record<string, AnatomyElement>`
+- `Elements = Record<string, Element>`
+- `Layout` serializes to `{ [nodeName]: LayoutNode[] }`
+
+The schema contract implicitly assumes **unique layer names within a component**. When a Figma component contains duplicate layer names — which is common and valid in Figma — the processing engine has no schema-level affordance to represent them distinctly. This causes silent data loss: duplicate names overwrite each other in every `Record`-keyed structure, and variant differencing produces incorrect results because elements can't be matched across variants.
+
+### Common duplicate-name scenarios
+
+- **Repeating items**: Five layers named `Checkbox` within a container (e.g., a rating control, a multi-select group)
+- **Same name, different purpose**: An `Icon` at the root level (decorative) and another `Icon` nested inside a button (functional) — distinct roles, identical names
+- **Floating elements across variants**: A layer named `Label` that appears at different hierarchy positions in different variants — is it the same element relocated, or a different element with the same name?
+
+### Current failure modes
+
+1. **Anatomy**: `Anatomy.add()` stores elements by name. The second `Checkbox` silently overwrites the first. `addNewElementsFromVariant()` skips names already present, so only the first variant's version is recorded.
+2. **Elements**: `Elements.detect()` and `Elements.set()` use name as the dictionary key. Last-write-wins for siblings; first-write-wins across variants.
+3. **Layout**: `Layout.serialize()` converts the tree to `{ [name]: children[] }` objects. Sibling nodes with the same name collapse into one key.
+4. **Variant differencing**: `Elements.compare()` looks up baseline elements by name. When duplicates were lost during detection, the diff is computed against an incomplete baseline, producing incorrect or missing diffs. `Differencer.establishBaselineParity()` operates on the already-deduplicated `Elements` map, so it never sees the lost duplicates.
+
+### Prior art
+
+The original EGDS Specs generator solved this with a composite key: **layer name + layer type + hierarchy position (including child index within parent)**. This was deterministic and lossless but opinionated — hierarchy position made keys brittle when designers reordered layers.
+
+---
+
+## Decision Drivers
+
+- **Lossless representation**: The spec output must represent every element in the Figma source. Silent data loss is unacceptable.
+- **Deterministic disambiguation**: The same Figma input must always produce the same disambiguated keys. No randomness, no side effects.
+- **Stable variant matching**: Disambiguated keys must be consistent across variants so that differencing produces correct diffs. An element that exists in multiple variants must receive the same key in each.
+- **Additive change**: Prefer a MINOR (additive) schema change over a MAJOR (breaking) one. Existing specs with unique names should be unaffected.
+- **Human-readable keys**: Disambiguated keys should remain meaningful to consumers (designers, developers reading spec output).
+- **Type ↔ schema symmetry**: Any new type must have a corresponding schema definition.
+- **No logic in schema package**: The disambiguation algorithm belongs in `specs-from-figma`, not in `@directededges/specs-schema`. The schema defines the contract; downstream packages implement it.
+
+---
+
+## Options Considered
+
+### Option A: Numeric suffix disambiguation + `originalName` metadata *(Selected)*
+
+Disambiguate duplicate names by appending a numeric suffix (`icon`, `icon2`, `icon3`) at traversal time, before any dictionary keying. Add an optional `originalName` field to `AnatomyElement` so consumers can recover the original Figma layer name when disambiguation occurred.
+
+The suffix algorithm:
+- First occurrence keeps the bare name: `icon`
+- Subsequent occurrences get ascending suffixes: `icon2`, `icon3`, ...
+- Suffixes are assigned by **traversal order within a single variant** (depth-first, matching Figma's layer panel order)
+- Cross-variant stability: the disambiguation is performed per-variant, then the anatomy merges use the disambiguated keys for matching
+
+**Pros**:
+- Human-readable keys (`icon`, `icon2` is immediately understandable)
+- `originalName` preserves the Figma source name for consumers that need it (documentation tools, design token mapping)
+- Additive schema change (MINOR) — `originalName` is optional, existing specs are unaffected
+- Simple algorithm — no dependency on node types or hierarchy depth
+
+**Cons / Trade-offs**:
+- Positional sensitivity: if a designer reorders two identically-named layers, their suffixes swap, which changes the keys. This is inherent to any ordering-based scheme.
+- Cross-variant matching relies on traversal-order consistency. If variant A has `[icon, label, icon]` and variant B has `[label, icon]`, the single `icon` in B matches `icon` (the first) in A by name. The second `icon2` in A has no match in B — it appears as a diff. This is correct behavior.
+
+---
+
+### Option B: Type-aware compound key (`name-type`) *(Rejected)*
+
+Disambiguate by combining layer name + element type: `icon-glyph`, `icon-container`.
+
+**Rejected because**:
+- Two elements can have the same name AND the same type (e.g., two `Frame` layers both named `Content`). This doesn't fully solve the uniqueness problem.
+- Changes the key format for ALL elements, not just duplicates — every key becomes `name-type`, which is a MAJOR breaking change.
+- Violates human-readability: `labelContainer-frame` is worse than `labelContainer`.
+
+---
+
+### Option C: Hierarchy-path key (`parent/child:index`) *(Rejected)*
+
+Use the full hierarchy path as the key: `root/content/icon:0`, `root/header/icon:0`.
+
+**Rejected because**:
+- MAJOR breaking change — completely new key format for all elements.
+- Keys become long and fragile — any hierarchy restructuring changes all descendant keys.
+- Violates human-readability for simple, unique-name components (the common case).
+- Over-engineered for the problem: most components have unique names and need no disambiguation.
+
+---
+
+### Option D: Processing-only fix, no schema change *(Rejected)*
+
+Disambiguate names in `specs-from-figma` using suffixes but add no schema metadata.
+
+**Rejected because**:
+- Consumers see `icon2` but can't determine whether it was originally named `icon2` in Figma or disambiguated from `icon`. The `originalName` field makes this distinction explicit and supports round-trip fidelity.
+- Small schema cost (one optional field) for significant traceability gain.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Anatomy.ts` | Add optional `originalName?: string` to `AnatomyElement` | MINOR |
+
+**Example — new shape** (`types/Anatomy.ts`):
+```yaml
+# Before
+AnatomyElement:
+  type: ElementType | ElementTypeRef
+  detectedIn?: string
+  instanceOf?: string | SubcomponentRef
+
+# After
+AnatomyElement:
+  type: ElementType | ElementTypeRef
+  detectedIn?: string
+  instanceOf?: string | SubcomponentRef
+  originalName?: string   # Present only when key differs from Figma layer name
+```
+
+**Example — spec output with disambiguation**:
+```yaml
+# Anatomy section of a component with duplicate "Checkbox" layers
+anatomy:
+  root:
+    type: container
+  checkbox:
+    type: instance
+    instanceOf: Checkbox
+  checkbox2:
+    type: instance
+    instanceOf: Checkbox
+    originalName: checkbox      # Was "Checkbox" in Figma, same as checkbox above
+  checkbox3:
+    type: instance
+    instanceOf: Checkbox
+    originalName: checkbox      # Was "Checkbox" in Figma
+  label:
+    type: text
+
+# Elements section — uses the same disambiguated keys
+elements:
+  checkbox:
+    styles: { ... }
+  checkbox2:
+    styles: { ... }
+  checkbox3:
+    styles: { ... }
+
+# Layout section — uses disambiguated keys in tree
+layout:
+  - root:
+    - checkbox
+    - checkbox2
+    - checkbox3
+    - label
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add optional `originalName` property to `AnatomyElement` definition | MINOR |
+
+**Example — new property** (under `#/definitions/AnatomyElement/properties`):
+```yaml
+originalName:
+  type: string
+  description: >
+    The original Figma layer name before disambiguation. Present only when
+    the element key was modified to resolve a duplicate name conflict.
+    When absent, the key IS the original layer name.
+  # not in required[] — optional field
+```
+
+### Notes
+
+- **`originalName` is omitted when not needed**: If the key matches the original Figma layer name (the common case), the field is absent. This keeps output compact for components with unique names.
+- **`originalName` stores the formatted key version** of the original name (after `formatKey` is applied), not the raw Figma name with original casing. This ensures consumers can compare `originalName` against other keys using the same format.
+- **`Elements` and `Layout` do not need `originalName`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` there.
+- **The suffix format** (`name`, `name2`, `name3`) is a processing convention, not a schema constraint. The schema only guarantees unique keys and the `originalName` field for traceability. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — one optional field added to both `AnatomyElement` type and schema definition.
+- **Parity check**: `AnatomyElement.originalName` (type) ↔ `#/definitions/AnatomyElement/properties/originalName` (schema).
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | **High** — Must implement disambiguation in traversal, element detection, layout serialization, and variant differencing | See architectural notes below |
+| `specs-cli` | **Low** — Recompile against new types. No behavioral change needed unless CLI renders element names (may want to show `originalName` in diagnostics) | Recompile |
+| `specs-plugin-2` | **Low** — Recompile against new types. Plugin UI may want to surface disambiguation warnings | Recompile |
+
+### Architectural notes for `specs-from-figma`
+
+The following changes are needed in the processing engine. These are described at the architectural level — specific implementation is at the discretion of the package maintainers.
+
+**1. Traversal-time disambiguation**
+
+Disambiguation must happen at the earliest point: during `Anatomy.traverse()`, before nodes enter any `Record`-keyed structure. The algorithm:
+
+- Track seen names per parent scope during depth-first traversal
+- First occurrence of a name → use as-is
+- Subsequent occurrences → append ascending numeric suffix (`name2`, `name3`, ...)
+- Attach the disambiguated name to the node for all downstream consumers (anatomy, elements, layout)
+
+**2. Cross-variant key stability**
+
+The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants. Two strategies to evaluate:
+
+- **Per-variant disambiguation + anatomy merge**: Each variant is disambiguated independently. The anatomy accumulates elements from all variants using `addNewElementsFromVariant()`. When a disambiguated key from variant B doesn't match any key in the anatomy (built from variant A), it's added as a new element. This works correctly when traversal order is consistent across variants.
+- **Global name registry**: Build a disambiguation registry from all variants before processing any single variant. Analyze all variants to determine the maximum count of each name, then assign stable suffixes. This is more robust but requires a two-pass approach.
+
+**3. Variant differencing accuracy**
+
+Once elements have stable disambiguated keys:
+- `Elements.compare()` matches by disambiguated key — no change to comparison logic needed
+- `Differencer.establishBaselineParity()` sees the full element set (no silent losses) — parity is established correctly
+- Layout diffing compares trees with disambiguated keys — structural differences are detected accurately
+
+**4. Floating elements across variants**
+
+An element that appears at different hierarchy positions in different variants (e.g., `label` as a child of `header` in variant A, child of `content` in variant B) is treated as **the same element** if its disambiguated key matches. The layout diff captures the structural change; the element diff captures style changes. This is existing behavior — disambiguation doesn't change it, but it does ensure the element isn't silently dropped if another element shares its name.
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.21.0` → `0.22.0` (`MINOR`)
+
+**Justification**: The only schema change is an additive optional field (`originalName` on `AnatomyElement`). No existing fields are modified, removed, or renamed. Per constitution III: "additive types or new optional fields → MINOR."
+
+---
+
+## Consequences
+
+- Spec output represents every element in the Figma source — no silent data loss from duplicate layer names
+- Components with unique layer names (the majority) produce identical output — `originalName` is absent, keys unchanged
+- Consumers can distinguish between an element named `icon2` by the designer and one disambiguated from `icon` by checking for `originalName`
+- Variant differencing operates on complete element sets, producing accurate diffs
+- The disambiguation suffix format (`name2`, `name3`) becomes a de facto convention in spec output, though it is not enforced by the schema
+- `specs-from-figma` requires significant architectural changes in traversal, element detection, and variant differencing — this is the primary implementation cost
+- Future consideration: if numeric suffixes prove insufficient (e.g., designers already use `icon2` as a name), a more sophisticated disambiguation strategy may be needed. The `originalName` field supports any future suffix scheme without schema changes

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -314,7 +314,34 @@ For each group of duplicates sharing a name within a parent, split occurrences i
 - **After-anchor** segments: match left-to-right (from anchor side inward)
 - **Between two anchors**: match inward from both sides (nearest anchor wins)
 
-This reflects designer intent: when a repeated element is added to a group, existing elements near landmarks retain their identity. New elements appear at the edges of segments, farther from anchors.
+##### Why anchor-adjacent over left-to-right positional?
+
+Two matching directions are plausible:
+
+- **Left-to-right positional**: 1st duplicate → `icon`, 2nd → `icon2`, 3rd → `icon3`. Simple, but assigns identity based on absolute position with no awareness of surrounding context.
+- **Anchor-adjacent**: match from the nearest unique landmark inward. Assigns identity based on structural relationship to stable reference points.
+
+Anchor-adjacent is preferred for three reasons:
+
+**1. Terminal elements have distinct semantic roles in real UI patterns.** A breadcrumb trail's last `Link` is always the current page. A table row's last `Cell` is typically the actions column. A form's bottom element is the submit button. Left-to-right positional matching assigns the base name to the first element and pushes new suffixes rightward — but when a variant adds items, the *last* element (often semantically distinct) drifts to a different suffix. Anchor-adjacent matching anchors terminal elements to their adjacent landmark and keeps their suffix stable.
+
+```yaml
+# Breadcrumb: last Link = current page
+# VA: [Link, Separator, Link, Separator, Link]
+# VB: [Link, Separator, Link, Separator, Link, Separator, Link]
+#
+# Left-to-right: VA Link₃ = "link3", VB Link₃ = "link3" ← same suffix, but
+#   VA link3 is "current page", VB link3 is a middle link. Mismatch.
+#
+# Anchor-adjacent (Separator as anchor, last Link as right-edge identity):
+#   VA's last Link and VB's last Link both get the same suffix. Correct match.
+```
+
+**2. Right-edge growth is the dominant pattern.** Across star ratings, steppers, form fields, navigation tabs, accordion sections, and breadcrumbs, new repeated elements are added at the trailing edge. Anchor-adjacent matching keeps existing elements (near anchors) stable and assigns fresh suffixes to newly appended elements at the far edge of each segment.
+
+**3. Anchor-adjacent degrades gracefully to positional.** When no anchors exist (e.g., five `Star` layers with no unique siblings), anchor-adjacent falls back to left-to-right positional — the only option. When anchors do exist, anchor-adjacent strictly improves on positional by using contextual information. There is no case where positional produces better matches than anchor-adjacent given the same anchor set.
+
+##### Worked example
 
 ```yaml
 # Segments divided by anchor "label":
@@ -344,15 +371,13 @@ This reflects designer intent: when a repeated element is added to a group, exis
 # Final disambiguation:
 #   Variant A: icon, label, icon2
 #   Variant B: icon3, icon, label, icon2
-#                          ^^^^^
-#                          anchor
 #
 # "icon" (adjacent to label, left side) is the SAME element in both variants.
 # "icon2" (adjacent to label, right side) is the SAME element in both variants.
 # "icon3" appears only in VB — new element, correctly surfaced as a variant diff.
 ```
 
-#### Multi-anchor example
+##### Multi-anchor example
 
 When multiple anchors exist, they create finer-grained segments. Matching radiates inward from the nearest anchor:
 
@@ -387,15 +412,67 @@ When multiple anchors exist, they create finer-grained segments. Matching radiat
 # Variant B: icon4, icon, label, icon3, description, icon2
 ```
 
+#### Adversarial cases from real UI patterns
+
+The following cases stress-test the algorithm against common component structures. Each is categorized by **confidence level** — how reliably the algorithm produces correct matches.
+
+##### High confidence — algorithm matches designer intent
+
+| Pattern | Structure | Why it works |
+|---------|-----------|-------------|
+| **Alert/Banner** (`[Icon, Content, Icon]`) | Two `Icon` siblings flanking a unique `Content` anchor | `Content` is the anchor. Leading icon = before-content, trailing icon = after-content. Correct even when `has-close=false` removes the trailing icon. |
+| **Breadcrumb** (`[Link, Sep, Link, Sep, Link]`) | Interleaved `Link` + `Separator` pairs | Each `Separator` is an anchor (unique per occurrence since the Links are the duplicates). The current-page `Link` (always last) stays matched to its adjacent separator. |
+| **Form fields** (`[Field, Field, Field, Submit]`) | Repeated `Field` with a unique `Submit` anchor at the bottom | `Submit` anchors the right edge. Fields match right-to-left from `Submit`, keeping the field nearest to submit stable as new fields are added above. |
+| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in **different subtrees** | Not sibling duplicates — each `Icon` is scoped to its own parent (`Header` vs `Footer`). Disambiguation per-parent handles this natively. No cross-subtree matching needed. |
+
+##### Medium confidence — correct for typical usage, fragile under reordering
+
+| Pattern | Structure | Risk |
+|---------|-----------|------|
+| **Star rating** (`[Star, Star, Star, Star, Star]`) | Homogeneous duplicates, no anchors | Falls back to left-to-right positional. Correct when `count` variants remove from the right (the dominant pattern). **Breaks** if a designer reverses layer order for RTL layout. |
+| **Navigation tabs** (`[Tab, Tab, Tab]`) | Homogeneous duplicates, no anchors | Same as stars — positional fallback. Correct for `count` variants. **Breaks** if `selected` is implemented by moving the active tab to position 0. |
+| **Stepper** (`[Step, Step, Step]`) | Homogeneous duplicates if no unique connector/label between steps | Falls back to positional. Correct when steps grow from the right. **Breaks** if a designer inserts steps in the middle of an existing sequence. |
+
+##### Low confidence — algorithm produces a result but may mismatch
+
+| Pattern | Scenario | What goes wrong |
+|---------|----------|----------------|
+| **Semantic reordering** | VA: `[icon-A, icon-B]`, VB: `[icon-B, icon-A]` — both named `Icon`, swapped | Positional matching assigns `icon` and `icon2` based on position. A becomes icon in VA but icon2 in VB. **No positional scheme can detect semantic identity swaps** without external metadata. |
+| **Accordion nested** | `[Header, Chevron, Content, Header, Chevron, Content]` at multiple nesting depths | After flattening, `Header` appears 2× as siblings even though they belong to different `Section` parents. **Mitigation**: per-parent scoping already handles this — each `Section`'s children are disambiguated independently. |
+| **Table column reordering** | VA: `[Cell-checkbox, Cell-name, Cell-actions]`, VB: `[Cell-name, Cell-checkbox, Cell-actions]` — all named `Cell` | If only `Cell-actions` (last) is an anchor, the other two cells are in the before-anchor segment and matched right-to-left. Reordering swaps their suffixes. **Acceptable**: column reordering is uncommon in variant sets; when it occurs, the resulting diff is larger but not lossy. |
+
+#### Error risk scale
+
+The algorithm's matching quality depends on the **anchor density** — the ratio of unique-named siblings to total siblings within a parent:
+
+| Anchor density | Matching quality | Example |
+|----------------|-----------------|---------|
+| **High** (>50% unique) | Excellent — most duplicates are sandwiched between anchors | `[Icon, Label, Input, Icon, HelperText]` — 3 anchors, 2 duplicate Icons |
+| **Medium** (1+ anchor, <50%) | Good — terminal elements match well; interior may be positional | `[Cell, Cell, Cell, Actions]` — 1 anchor, 3 duplicate Cells |
+| **Zero** (no anchors) | Positional fallback — correct for right-edge growth only | `[Star, Star, Star, Star, Star]` — 0 anchors |
+
+**Error tolerance**: Mismatched keys produce **larger variant diffs** (element appears as "removed in VA, added in VB" instead of "changed between VA and VB") but never produce **data loss**. The output is always lossless — every element is represented. The only cost of a mismatch is suboptimal diff granularity: a style change on a mismatched element shows as a full element diff rather than a targeted property diff. This is an acceptable degradation for low-confidence cases.
+
+#### Performance considerations
+
+The two-pass approach adds one lightweight traversal over all variants:
+
+- **Pass 1 (survey)**: Iterate each variant's children within each parent, collecting name counts and identifying anchors. This is a name-counting pass only — no element processing, no style detection, no property extraction. Cost: O(V × N) where V = variant count, N = average children per parent.
+- **Pass 2 (assign)**: Segment children by anchors, match across variants within each segment. Cost: O(V × N × A) where A = anchor count per parent. In practice, A is small (typically 1–5).
+- **Total overhead**: Negligible relative to the existing processing pipeline, which performs Figma API calls, style extraction, and variant differencing. The survey pass touches only node names — no I/O, no async operations.
+- **Worst case**: A component with hundreds of variants and deep nesting. Even here, the survey pass is bounded by the total node count across all variants, which is already traversed during the existing `Anatomy.traverse()` call. The added cost is a second traversal of the same nodes collecting only names.
+
 #### Edge cases and fallbacks
 
-**No anchors available**: If all siblings within a parent are duplicates (e.g., `[icon, icon, icon]` with no unique names), fall back to **left-to-right absolute position within parent** — 1st → `icon`, 2nd → `icon2`, 3rd → `icon3`. This is the weakest heuristic but the only option when no context is available. Positional matching here means a designer reordering layers changes suffix assignment — an accepted trade-off when no anchors exist to provide stability.
+**No anchors available**: If all siblings within a parent are duplicates (e.g., `[Star, Star, Star, Star, Star]` with no unique names), fall back to **left-to-right absolute position within parent** — 1st → `star`, 2nd → `star2`, 3rd → `star3`. This is the weakest heuristic but the only option when no context is available. Positional matching here means a designer reordering layers changes suffix assignment — an accepted trade-off when no anchors exist to provide stability.
 
 **Anchor itself is absent in some variants**: If `label` appears in variant A but not variant B, it cannot serve as an anchor. Only names present in **every variant that contains them** qualify. In practice, this means: if an anchor is optional (absent in some variants), its segments are merged with adjacent segments in variants where it's missing.
 
-**Nested duplicates**: Disambiguation is scoped to each parent independently. A parent named `header` with children `[icon, icon]` and a sibling parent `footer` with children `[icon, icon]` are separate scopes. The `icon` in `header` and the `icon` in `footer` are already distinct by ancestry — they have different keys in the flattened anatomy because the traversal encounters them in different subtrees.
+**Nested duplicates**: Disambiguation is scoped to each parent independently. A parent named `header` with children `[icon, icon]` and a sibling parent `footer` with children `[icon, icon]` are separate scopes. The `icon` in `header` and the `icon` in `footer` are already distinct by ancestry — they have different keys in the flattened anatomy because the traversal encounters them in different subtrees. This is the primary defense against the "same name, different purpose" scenario (Context §2) — containment path, not suffix matching, is what distinguishes them.
 
-**Anchor ordering inconsistency**: If anchors themselves appear in different orders across variants (e.g., VA has `[label, description]` but VB has `[description, label]`), the segment boundaries diverge and anchor-relative matching degrades. This is treated as a design inconsistency — the algorithm falls back to absolute position for affected segments and may emit a diagnostic warning.
+**Anchor ordering inconsistency**: If anchors themselves appear in different orders across variants (e.g., VA has `[label, description]` but VB has `[description, label]`), the segment boundaries diverge and anchor-relative matching degrades. This is treated as a design inconsistency — the algorithm falls back to absolute position for affected segments and emits a diagnostic warning.
+
+**formatKey collisions**: Two distinct Figma names could format to the same key (e.g., `My Icon` and `myIcon` both → `myIcon` in camelCase). This is treated as a duplicate even though the original names differ. The `$extensions["com.figma"].originalName` field records the formatted key of the dominant name; the collision is surfaced in the same way as a true duplicate.
 
 **3. Variant differencing accuracy**
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -10,7 +10,7 @@
 
 ## Context
 
-> **Scope**: This ADR addresses a **two-part problem** spanning both the schema contract (`@directededges/specs-schema`) and the processing architecture (`specs-from-figma`). Part 1 (Decision) defines the schema change — a small additive type. Part 2 (Downstream Impact → Architectural notes) defines the disambiguation algorithm, cross-variant matching heuristics, and adversarial analysis that make the schema change useful. **Reviewers should evaluate both parts** — the schema change alone is trivial; the processing architecture is where the complexity lives.
+> **Scope**: This ADR addresses a **two-part problem** spanning both the schema contract (`@directededges/specs-schema`) and the processing architecture (`specs-from-figma`). Part 1 (Decision) defines the schema change — a small additive type. Part 2 (Downstream Impact → Architectural notes) defines the disambiguation algorithm. **Reviewers should evaluate both parts** — the schema change alone is trivial; the processing architecture is where the complexity lives.
 
 Three core types in `@directededges/specs-schema` use layer names as dictionary keys:
 
@@ -55,7 +55,7 @@ The original EGDS Specs generator solved this with a composite key: **layer name
 
 ### Option A: Collision-safe numeric suffix + `$extensions` metadata *(Selected)*
 
-Disambiguate duplicate names by appending a numeric suffix at traversal time, before any dictionary keying. Store the original Figma layer name under `$extensions["com.figma"].originalName` on `AnatomyElement`, following the existing DTCG extension convention used by `TokenReference` and `PropExtensions`.
+Disambiguate duplicate names by appending a numeric suffix, determined by an ordered heuristic chain during a disambiguation phase that is separate from initial evaluation. Store the original Figma layer name under `$extensions["com.figma"].originalName` on `AnatomyElement`, following the existing DTCG extension convention used by `TokenReference` and `PropExtensions`.
 
 The suffix algorithm must be **collision-safe** — it cannot assign a suffix that conflicts with an existing element name:
 
@@ -70,25 +70,15 @@ The suffix algorithm must be **collision-safe** — it cannot assign a suffix th
 #   icon, icon3, icon2
 ```
 
-Algorithm:
-1. Collect all original element names across all variants into a **reserved set**
-2. For each duplicate name group, identify distinct identities via the global two-pass registry (§2: anchor-adjacent matching across variants)
-3. Rank identities by **cross-variant prevalence** — the identity appearing in the most variants gets the base name; less prevalent identities get ascending suffixes
-4. Ties in prevalence → break by first traversal appearance (depth-first order in the first variant encountered)
-5. Each assigned suffix must be **collision-safe**: find the lowest available suffix (`name2`, `name3`, ...) that is **not in the reserved set** and **not already assigned**
-6. Add each assigned disambiguated name to the reserved set to prevent future collisions
-
 **Pros**:
 - Human-readable keys (`icon`, `icon3` is immediately understandable)
 - `$extensions["com.figma"].originalName` follows the established Figma provenance convention — consistent with `TokenReference.$extensions` and `PropExtensions["com.figma"]`
 - Collision-safe — never steals a name that belongs to an existing element
 - Additive schema change (MINOR) — `$extensions` is optional, existing specs are unaffected
-- Simple algorithm — no dependency on node types or hierarchy depth
 
 **Cons / Trade-offs**:
-- Positional sensitivity: if a designer reorders two identically-named layers within the same anchor segment, their suffixes may swap, which changes the keys. This is inherent to any ordering-based tiebreaker.
-- Cross-variant matching depends on the global registry producing stable identities. If variant A has `[icon, label, icon]` and variant B has `[label, icon]`, anchor-adjacent matching correctly identifies the after-label Icon as the persistent element (96 variants > 1 variant) and assigns it the base name. The before-label Icon in A, appearing in fewer variants, gets the suffix. This is correct behavior.
-- Suffix numbers may not be contiguous (e.g., `icon`, `icon3` when `icon2` is reserved by an original layer name). This is intentional — contiguity is sacrificed for collision safety.
+- Key stability depends on the heuristic chain producing consistent identities across variants. When the chain reaches the weakest check (sibling index), reordering layers changes suffixes.
+- Suffix numbers may not be contiguous (e.g., `icon`, `icon3` when `icon2` is reserved by an original layer name). Intentional — contiguity is sacrificed for collision safety.
 
 ---
 
@@ -153,7 +143,7 @@ AnatomyElement:
 
 `$extensions` is present only when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
 
-> **Future ADR**: A subsequent ADR will evaluate whether to add a **provenance signal** (e.g., `matchMethod`) to `$extensions["com.figma"]` indicating the heuristic used for cross-variant matching. This is a separable decision — disambiguation and collision-safe suffixing do not depend on it.
+> **Future ADR**: A subsequent ADR (045) evaluates whether to add a **provenance signal** (e.g., `matchMethod`) to `$extensions["com.figma"]` indicating which heuristic resolved each element's cross-variant identity. This is a separable decision — disambiguation and collision-safe suffixing do not depend on it.
 
 **Example — spec output with disambiguation** (collision-safe):
 ```yaml
@@ -162,11 +152,11 @@ AnatomyElement:
 
 # Collision-safe disambiguation:
 #   "checkbox" → reserved set: {checkbox, icon2, icon}
-#   1st checkbox → "checkbox" (first occurrence, keep as-is)
+#   1st checkbox → "checkbox" (base name — most prevalent or first)
 #   2nd checkbox → "checkbox2" not reserved → assign "checkbox2"
 #   3rd checkbox → "checkbox3" not reserved → assign "checkbox3"
-#   "icon2" → already in reserved set, first occurrence → "icon2" (keep as-is)
-#   1st icon → "icon" (first occurrence, keep as-is)
+#   "icon2" → already in reserved set, original name → "icon2" (keep as-is)
+#   1st icon → "icon" (base name)
 #   2nd icon → "icon2" IS reserved → skip; "icon3" not reserved → assign "icon3"
 
 anatomy:
@@ -272,7 +262,7 @@ $extensions:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | **High** — Must implement disambiguation in traversal, element detection, layout serialization, and variant differencing | See architectural notes below |
+| `specs-from-figma` | **High** — Must implement two-phase disambiguation in traversal, element detection, layout serialization, and variant differencing | See architectural notes below |
 | `specs-cli` | **Low** — Recompile against new types. No behavioral change needed unless CLI renders element names (may want to show `originalName` in diagnostics) | Recompile |
 | `specs-plugin-2` | **Low** — Recompile against new types. Plugin UI may want to surface disambiguation warnings | Recompile |
 
@@ -280,77 +270,128 @@ $extensions:
 
 The following changes are needed in the processing engine. These are described at the architectural level — specific implementation is at the discretion of the package maintainers.
 
-**1. Disambiguation insertion point**
+#### 1. Two-phase architecture: Evaluation → Disambiguation
 
-Disambiguation must happen at the earliest point in the pipeline: during or immediately after `Anatomy.traverse()`, before nodes enter any `Record`-keyed structure. The disambiguated name replaces the raw Figma layer name for all downstream consumers — anatomy registration, element detection, layout serialization, and variant differencing all operate on the disambiguated key.
+Disambiguation separates **signal collection** from **identity resolution**:
 
-The disambiguation itself is not a simple per-node decision. It requires cross-variant coordination (see §2 below) because the same logical element must receive the same key in every variant. This means the traversal must either:
-- Run a lightweight survey pass across all variants **before** the main traversal, or
-- Defer name assignment until all variants have been traversed and then apply names retroactively
+- **Evaluation** (Phase 1) records raw facts about each element during traversal — no matching logic, no key assignment
+- **Disambiguation** (Phase 2) consumes those facts through an ordered heuristic chain to assign unique keys
 
-The survey-first approach is preferred because it avoids retroactive renaming of already-registered elements.
+This separation means the evaluation phase stays simple (observe and record), the heuristic chain is explicit and independently testable, and signals are reusable for diagnostics and provenance (ADR-045).
 
-**2. Cross-variant key stability — global registry with anchor-adjacent matching**
+#### 2. Phase 1 — Signal collection during traversal
 
-The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants so that differencing produces correct diffs. Pure positional matching (1st icon → `icon`, 2nd icon → `icon2`) fails when variants have different element counts or ordering, because the "2nd icon" in one variant may not be the same element as the "2nd icon" in another.
+During anatomy traversal, each element in each variant logs:
 
-The solution is a **two-pass global registry** enhanced with **anchor-relative positioning** — using unique-named siblings as stable reference points to match duplicate elements across variants.
+| Signal | Description | Example |
+|--------|-------------|---------|
+| `layerName` | Figma layer name (after formatKey) | `icon` |
+| `layerType` | Figma node type | `INSTANCE` |
+| `ancestors` | Full ancestry chain, root to parent (name + type per level) | `[{name: "card", type: "FRAME"}, {name: "header", type: "FRAME"}]` |
+| `siblingIndex` | Position among same-name+type siblings within parent | `2` (2nd `INSTANCE` named `icon` in this parent) |
+| `nearestAnchor` | Closest unique-named sibling, if any | `{name: "label", direction: "right", distance: 1}` |
 
-#### Pass 1 — Survey and anchor identification
+Signals are stored per element per variant. No disambiguation decisions are made during this phase — the log is a pure record of what was observed.
 
-Scan all variants within each parent scope to build:
-1. A **global reserved set**: all original element names across all variants (for collision-safe suffix assignment)
-2. An **anchor set**: element names that appear **exactly once** within a given parent in **every variant that contains them**. These are stable reference points — they don't move relative to their duplicated neighbors.
-3. For each duplicate name, a **maximum occurrence count** across all variants
+The cost is lightweight: a few extra properties per node, all derived from data already available during traversal. Signals are discarded after Phase 2 completes (unless surfaced via ADR-045 provenance).
 
-```yaml
-# Variant A siblings: [icon, label, icon]
-# Variant B siblings: [icon, icon, label, icon]
+#### 3. Phase 2 — Ordered heuristic chain
 
-# Anchors within this parent:
-#   "label" — appears exactly 1× in VA, 1× in VB → ✓ anchor
-#   "icon" — appears 2× in VA, 3× in VB → ✗ not an anchor
+For elements sharing a name within a variant, apply checks in order. Each check runs **only on elements still ambiguous** after the previous check:
 
-# Global reserved set: {icon, label}
-# Max "icon" count: 3 (from variant B)
-```
-
-#### Pass 2 — Anchor-adjacent identity assignment
-
-For each group of duplicates sharing a name within a parent, split occurrences into **segments** bounded by anchors. Within each segment, match duplicates **from the anchor boundary inward** — elements closest to the anchor have the strongest identity signal and are matched first:
-
-- **Before-anchor** segments: match right-to-left (from anchor side inward)
-- **After-anchor** segments: match left-to-right (from anchor side inward)
-- **Between two anchors**: match inward from both sides (nearest anchor wins)
-
-##### Why anchor-adjacent over left-to-right positional?
-
-Two matching directions are plausible:
-
-- **Left-to-right positional**: 1st duplicate → `icon`, 2nd → `icon2`, 3rd → `icon3`. Simple, but assigns identity based on absolute position with no awareness of surrounding context.
-- **Anchor-adjacent**: match from the nearest unique landmark inward. Assigns identity based on structural relationship to stable reference points.
-
-Anchor-adjacent is preferred for three reasons:
-
-**1. Terminal elements have distinct semantic roles in real UI patterns.** A breadcrumb trail's last `Link` is always the current page. A table row's last `Cell` is typically the actions column. A form's bottom element is the submit button. Left-to-right positional matching assigns the base name to the first element and pushes new suffixes rightward — but when a variant adds items, the *last* element (often semantically distinct) drifts to a different suffix. Anchor-adjacent matching anchors terminal elements to their adjacent landmark and keeps their suffix stable.
+| # | Check | Resolves when... | Confidence |
+|---|-------|-------------------|------------|
+| 1 | **Layer name** | Name is unique across the variant | Highest |
+| 2 | **+ layer type** | Adding node type narrows to unique identity | High |
+| 3 | **+ ancestry chain** | Elements have different ancestor paths (walk up one level at a time) | High |
+| 4 | **+ nearest anchor neighbor** | A unique-named sibling nearby stabilizes identity | Medium |
+| 5 | **+ sibling index** | Position among same-name+type siblings within parent | Lowest |
 
 ```yaml
-# Breadcrumb: last Link = current page
-# VA: [Link, Separator, Link, Separator, Link]
-# VB: [Link, Separator, Link, Separator, Link, Separator, Link]
-#
-# Left-to-right: VA Link₃ = "link3", VB Link₃ = "link3" ← same suffix, but
-#   VA link3 is "current page", VB link3 is a middle link. Mismatch.
-#
-# Anchor-adjacent (Separator as anchor, last Link as right-edge identity):
-#   VA's last Link and VB's last Link both get the same suffix. Correct match.
+# Which check resolves each case?
+
+# [Icon(INSTANCE), Label, Icon(FRAME)]
+#   → Check 2: name+type distinguishes INSTANCE from FRAME
+
+# Header > [Icon, Icon], Footer > [Icon]
+#   → Check 3: ancestry distinguishes Header vs Footer icons
+#   → Header's two Icons continue to checks 4–5
+
+# [Icon, Label, Icon]  (same type, same parent)
+#   → Check 4: one Icon is left-of-Label, one is right-of-Label
+
+# [Star, Star, Star, Star, Star]  (homogeneous, no anchors)
+#   → Check 5: positional index is the only signal
 ```
 
-**2. Right-edge growth is the dominant pattern.** Across star ratings, steppers, form fields, navigation tabs, accordion sections, and breadcrumbs, new repeated elements are added at the trailing edge. Anchor-adjacent matching keeps existing elements (near anchors) stable and assigns fresh suffixes to newly appended elements at the far edge of each segment.
+**Check 4 vs Check 5 — why ordered, not competing**: They solve different failure modes. Anchor neighbors are resilient to insertion/deletion (the anchor stays put even when new siblings appear). Sibling index is fragile to insertion/deletion (indices shift) but always available. Anchor first, index as fallback.
 
-**3. Anchor-adjacent degrades gracefully to positional.** When no anchors exist (e.g., five `Star` layers with no unique siblings), anchor-adjacent falls back to left-to-right positional — the only option. When anchors do exist, anchor-adjacent strictly improves on positional by using contextual information. There is no case where positional produces better matches than anchor-adjacent given the same anchor set.
+```yaml
+# Insertion resilience:
+#   V1: [icon, icon, button]
+#   V2: [icon, checkbox, icon, button]
+#
+# Check 5 (sibling index): V1 icon(2) and V2 icon(2) match by index.
+#   But did checkbox get inserted between them or before both? Index can't tell.
+#
+# Check 4 (anchor neighbor): V1's 2nd icon is adjacent to "button" (unique).
+#   V2's 2nd icon is also adjacent to "button". Anchored match — insertion-proof.
+```
 
-##### Worked example
+#### 4. Ancestry — top-down resolution
+
+When two elements share a name and exist in different subtrees, the ancestry chain (Check 3) distinguishes them without sibling-level heuristics. Resolution proceeds **top-down** — disambiguate each depth level before descending to its children:
+
+```yaml
+# Same-named parents:
+#   Section > [icon, label, icon],  Section > [icon, label, icon]
+#
+# Step 1 — disambiguate depth 1:
+#   section, section2
+#
+# Step 2 — each disambiguated parent scopes its children:
+#   section  > [icon, label, icon]  → icon, label, icon2
+#   section2 > [icon, label, icon]  → icon, label, icon2
+#
+# Four distinct icons — ancestry separates section/section2,
+# then checks 4–5 separate icon/icon2 within each.
+```
+
+Top-down resolution is a natural fit for depth-first traversal: parents are visited before children, so by the time the algorithm reaches a child scope, its parent's disambiguated key is already assigned.
+
+**Container matching across variants**: Containers are matched by their **disambiguated key**, not by path. If `header` has a unique name, it's the same container whether it sits under `card` or `sidebar`. Children scoped within `header` in V1 match children within `header` in V2. The layout diff captures the structural change; the element diff captures style changes.
+
+#### 5. Cross-variant key stability
+
+The heuristic chain resolves within-variant disambiguation. **Cross-variant matching uses the flat anatomy key only** — an element keyed as `icon` in V1 matches `icon` in V2, regardless of which parent it's under. This is consistent with how `Anatomy = Record<string, AnatomyElement>` works today.
+
+The risk is **suffix instability**: the same logical element receiving different keys in different variants. The fix is **prevalence-based naming** — the identity appearing in the most variants gets the base name:
+
+```yaml
+# V1:     [Icon₁, Label, Icon₂]   (2 icons)
+# V2-V96: [Label, Icon₂]          (1 icon — the after-label one)
+#
+# Traversal-order assignment would give Icon₁ the base name in V1,
+# but Icon₂ gets it in V2-V96. Result: 95 wrong comparisons.
+#
+# Prevalence-based:
+#   Icon₂ (after-label) → 96 variants → "icon" (base name)
+#   Icon₁ (before-label) → 1 variant  → "icon2"
+#
+# V1:     icon2, label, icon
+# V2-V96: label, icon
+# Cross-variant: V2's "icon" matches V1's "icon" — correct.
+```
+
+**Suffix assignment algorithm**:
+1. Collect all original names into a **reserved set**
+2. Identify distinct identities via the heuristic chain across all variants
+3. Rank by **cross-variant prevalence** — most variants gets base name
+4. Ties → break by first traversal appearance
+5. Assign collision-safe suffixes (skip reserved names)
+6. Add each assigned name to the reserved set
+
+#### 6. Worked example — anchor-adjacent matching (Check 4)
 
 ```yaml
 # Segments divided by anchor "label":
@@ -365,276 +406,100 @@ Anchor-adjacent is preferred for three reasons:
 
 # Anchor-adjacent matching (before-label = right-to-left from anchor):
 #   VA before-label, adjacent to label (pos 0):  icon  ─┐
-#   VB before-label, adjacent to label (pos 1):  icon  ─┘ SAME element
-#   VB before-label, far from label (pos 0):     icon  → NEW element
-#
+#   VB before-label, adjacent to label (pos 1):  icon  ─┘ SAME identity
+#   VB before-label, far from label (pos 0):     icon  → NEW identity
+
 # Anchor-adjacent matching (after-label = left-to-right from anchor):
 #   VA after-label, adjacent to label (pos 0):   icon  ─┐
-#   VB after-label, adjacent to label (pos 0):   icon  ─┘ SAME element
+#   VB after-label, adjacent to label (pos 0):   icon  ─┘ SAME identity
 
-# Three distinct identities, suffixes assigned by cross-variant prevalence:
-#   Identity 1 (before-label, adjacent) → appears in VA + VB (2 variants) → "icon"
-#   Identity 2 (after-label, adjacent)  → appears in VA + VB (2 variants) → "icon2" (tie, broken by first traversal)
-#   Identity 3 (before-label, far)      → appears in VB only (1 variant)  → "icon3"
+# Three distinct identities, suffixes by prevalence:
+#   Identity 1 (before-label, adjacent) → VA + VB → "icon"
+#   Identity 2 (after-label, adjacent)  → VA + VB → "icon2" (tie, first traversal)
+#   Identity 3 (before-label, far)      → VB only → "icon3"
 #
-# In this example prevalence is tied for identities 1 and 2 (both in 2 variants),
-# so the tiebreaker (traversal order) applies. In a real scenario where VA has
-# both icons but VB-V96 have only the after-label icon:
-#   after-label identity → 96 variants → "icon" (base name — most prevalent)
-#   before-label identity → 1 variant  → "icon2"
-
-# Final disambiguation (for this 2-variant example):
-#   Variant A: icon, label, icon2
-#   Variant B: icon3, icon, label, icon2
-#
-# "icon" (adjacent to label, left side) is the SAME element in both variants.
-# "icon2" (adjacent to label, right side) is the SAME element in both variants.
-# "icon3" appears only in VB — new element, correctly surfaced as a variant diff.
+# Variant A: icon, label, icon2
+# Variant B: icon3, icon, label, icon2
 ```
 
-##### Multi-anchor example
-
-When multiple anchors exist, they create finer-grained segments. Matching radiates inward from the nearest anchor:
+With multiple anchors, segments get finer-grained:
 
 ```yaml
 # Variant A: [icon, label, description, icon]
 # Variant B: [icon, icon, label, icon, description, icon]
-
+#
 # Anchors: "label" and "description" (both unique in all variants)
 # Segments: BEFORE-label, BETWEEN-label-description, AFTER-description
-
+#
 # VA segments: [icon], [], [icon]
 # VB segments: [icon, icon], [icon], [icon]
-
-# Anchor-adjacent matching:
-#   before-label (right-to-left from label):
-#     VA [icon←]     →  VB [icon, icon←]  → adjacent icons match
-#     VB pos 0 icon  →  NEW (far from label)
 #
-#   between-label-description (match from nearest anchor):
-#     VA []          →  VB [icon]  → VB only → NEW
+# Matching per segment (from nearest anchor inward):
+#   before-label:          VA 1 icon,  VB 2 icons → adjacent match + 1 new
+#   between-label-desc:    VA 0 icons, VB 1 icon  → VB only, new
+#   after-description:     VA 1 icon,  VB 1 icon  → match
 #
-#   after-description (left-to-right from description):
-#     VA [→icon]     →  VB [→icon]  → match
-
-# Identities and suffix assignment (by prevalence, then traversal order):
-#   Identity 1 (before-label, adjacent)         → VA + VB (2 variants) → "icon"
-#   Identity 2 (after-description, adjacent)    → VA + VB (2 variants) → "icon2"
-#   Identity 3 (between-label-desc, adjacent)   → VB only (1 variant)  → "icon3"
-#   Identity 4 (before-label, far)              → VB only (1 variant)  → "icon4"
-
-# Variant A: icon, label, description, icon2
-# Variant B: icon4, icon, label, icon3, description, icon2
+# Result:
+#   Variant A: icon, label, description, icon2
+#   Variant B: icon4, icon, label, icon3, description, icon2
 ```
 
-#### Adversarial cases from real UI patterns
-
-The following cases stress-test the algorithm against common component structures. Each is categorized by **confidence level** — how reliably the algorithm produces correct matches.
+#### 7. Adversarial cases
 
 ##### High confidence — algorithm matches designer intent
 
 | Pattern | Structure | Why it works |
 |---------|-----------|-------------|
-| **Alert/Banner** (`[Icon, Content, Icon]`) | Two `Icon` siblings flanking a unique `Content` anchor | `Content` is the anchor. Leading icon = before-content, trailing icon = after-content. Correct even when `has-close=false` removes the trailing icon. |
-| **Breadcrumb** (`[Link, Sep, Link, Sep, Link]`) | Interleaved `Link` + `Separator` pairs | Each `Separator` is an anchor (unique per occurrence since the Links are the duplicates). The current-page `Link` (always last) stays matched to its adjacent separator. |
-| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in **different subtrees** | **Ancestry containment** is the strongest disambiguation signal — each `Icon` is scoped by its full containment path (`Header` vs `Footer`) and receives a distinct key without any sibling-level heuristic. See *Disambiguation hierarchy* below. |
+| **Alert/Banner** (`[Icon, Content, Icon]`) | Two `Icon` siblings flanking unique `Content` | Check 4: leading icon = before-Content, trailing icon = after-Content. Correct even when `has-close=false` removes the trailing icon. |
+| **Breadcrumb** (`[Link, Sep, Link, Sep, Link]`) | Interleaved `Link` + `Separator` pairs | Check 4: each `Separator` is an anchor. The current-page `Link` (always last) stays matched to its adjacent separator. |
+| **Card icons** (`Header > [Icon], Footer > [Icon]`) | Duplicates in different subtrees | Check 3: ancestry distinguishes `Header > Icon` from `Footer > Icon`. |
 
-##### Medium confidence — correct for typical usage, fragile under reordering
+##### Medium confidence — correct for typical usage
 
 | Pattern | Structure | Risk |
 |---------|-----------|------|
-| **Form fields** (`[Field, Field, Field, Submit]`) | Repeated `Field` with a unique `Submit` anchor at the bottom | Anchor-adjacent matches right-to-left from `Submit`, keeping the field *nearest* Submit stable. But new optional fields are typically inserted *just before* Submit (e.g., VA: `[Name, Email, Submit]`, VB: `[Name, Email, Phone, Submit]`). This shifts the "nearest to Submit" identity to the new field, mismatching the original fields. **Left-to-right positional would be more accurate here**, but the algorithm can't know growth direction. Correct when fields are appended at the top; **breaks** when inserted before Submit. |
-| **Star rating** (`[Star, Star, Star, Star, Star]`) | Homogeneous duplicates, no anchors | Falls back to left-to-right positional. Correct when `count` variants remove from the right (the dominant pattern). **Breaks** if a designer reverses layer order for RTL layout. |
-| **Navigation tabs** (`[Tab, Tab, Tab]`) | Homogeneous duplicates, no anchors | Same as stars — positional fallback. Correct for `count` variants. **Breaks** if `selected` is implemented by moving the active tab to position 0. |
-| **Stepper** (`[Step, Step, Step]`) | Homogeneous duplicates if no unique connector/label between steps | Falls back to positional. Correct when steps grow from the right. **Breaks** if a designer inserts steps in the middle of an existing sequence. |
+| **Form fields** (`[Field, ..., Submit]`) | Repeated `Field` with unique `Submit` anchor | Check 4 matches right-to-left from Submit. Correct when fields append at top. Breaks when inserted just before Submit (shifts the "nearest" identity). |
+| **Star rating** (`[Star × 5]`) | Homogeneous duplicates, no anchors | Check 5 (positional fallback). Correct when count variants remove from the right. Breaks on layer reordering. |
 
-##### Low confidence — algorithm produces a result but may mismatch
+##### Low confidence — may mismatch
 
 | Pattern | Scenario | What goes wrong |
 |---------|----------|----------------|
-| **Semantic reordering** | VA: `[icon-A, icon-B]`, VB: `[icon-B, icon-A]` — both named `Icon`, swapped | Positional matching assigns `icon` and `icon2` based on position. A becomes icon in VA but icon2 in VB. **No positional scheme can detect semantic identity swaps** without external metadata. |
-| **Accordion nested** | `[Header, Chevron, Content, Header, Chevron, Content]` at multiple nesting depths | After flattening, `Header` appears 2× as siblings even though they belong to different `Section` parents. **Mitigation**: per-parent scoping already handles this — each `Section`'s children are disambiguated independently. |
-| **Table column reordering** | VA: `[Cell-checkbox, Cell-name, Cell-actions]`, VB: `[Cell-name, Cell-checkbox, Cell-actions]` — all named `Cell` | If only `Cell-actions` (last) is an anchor, the other two cells are in the before-anchor segment and matched right-to-left. Reordering swaps their suffixes. **Acceptable**: column reordering is uncommon in variant sets; when it occurs, the resulting diff is larger but not lossy. |
+| **Semantic swap** | VA: `[icon-A, icon-B]`, VB: `[icon-B, icon-A]` — both named `Icon`, swapped | No check can detect semantic identity swaps without external metadata. |
+| **Column reorder** | All named `Cell`, only last is anchored | Reordering before the anchor swaps suffixes. Acceptable: output is still lossless, only diff granularity degrades. |
 
-#### Disambiguation hierarchy
+#### 8. Error tolerance
 
-The algorithm applies three disambiguation signals in order of strength:
+Mismatched keys produce **larger variant diffs** (element appears as "removed in VA, added in VB" instead of "changed between VA and VB") but never produce **data loss**. Every element is always represented. The only cost of a mismatch is suboptimal diff granularity.
 
-1. **Ancestry containment** (strongest **when tree structure is stable**) — Elements with the same name in different subtrees are already distinct. An `Icon` inside `Card > Header > Actions` and an `Icon` inside `Card > Footer > Links` are separate scopes — their keys are disambiguated by the full ancestry path, not by suffix. This is the most reliable signal because it reflects the designer's structural intent: grouping elements under named containers is an explicit organizational choice.
+#### 9. Edge cases
 
-   The containment signal extends through the **full ancestry chain**, not just the immediate parent. Every named ancestor contributes to the scope. This means disambiguation must proceed **top-down** — resolve each depth level before descending to its children:
+- **No anchors**: All siblings share the same name → Check 5 (positional). Weakest but always available.
+- **Anchor absent in some variants**: Only names present in every variant that contains them qualify as anchors. If an anchor is optional, its segments merge in variants where it's absent.
+- **formatKey collisions**: `My Icon` and `myIcon` both → `myIcon` in camelCase. Treated as a duplicate. `originalName` records the formatted key of the dominant name.
+- **Anchor ordering inconsistency**: If anchors appear in different orders across variants, segment boundaries diverge. Falls back to positional for affected segments.
 
-   ```yaml
-   # Same-named parents are themselves duplicates:
-   #   Section, Section (siblings at depth 1)
-   #
-   # Step 1 — disambiguate depth 1:
-   #   section, section2
-   #
-   # Step 2 — each disambiguated parent scopes its children independently:
-   #   section  > [icon, label, icon]  → icon, label, icon2  (scoped to section)
-   #   section2 > [icon, label, icon]  → icon, label, icon2  (scoped to section2)
-   #
-   # These are four distinct icons — ancestry separates section/section2,
-   # then sibling disambiguation separates icon/icon2 within each.
-   ```
+#### 10. Implementation sequencing
 
-   Top-down resolution is a natural fit for depth-first traversal: parents are visited before children, so by the time the algorithm reaches a child scope, its parent's disambiguated key is already assigned.
+1. **`specs-schema`**: Add `$extensions` to `AnatomyElement` type and schema. Publish as `0.22.0` (MINOR).
+2. **`specs-from-figma`**:
+   - **Phase A — Signal collection**: Implement evaluation logging during traversal. No output changes — observability only.
+   - **Phase B — Heuristic chain + suffix assignment**: Apply the ordered checks, assign collision-safe suffixes. All `Record`-keyed structures receive disambiguated keys. Add `$extensions["com.figma"].originalName`.
+   - **Phase C — Parity testing**: Validate against ground-truth fixtures. Components with unique names must produce identical output.
+3. **`specs-plugin-2`** / **`specs-cli`**: Recompile against new schema types.
 
-   **Limitation — tree restructuring across variants**: Ancestry containment assumes the tree structure is stable across variants. When a container moves between parents across variants, ancestry paths diverge and the containment signal becomes ambiguous:
-
-   ```yaml
-   # V1: L1 > L2 > L3 > L4 > Icon    (Icon A)
-   #     L1 > L5 > L6 > Icon          (Icon B)
-   #
-   # V2: L1 > L2 > L3 > L6 > Icon    (which V1 Icon does this match?)
-   #
-   # Immediate parent says Icon B (both under L6).
-   # Longest ancestry prefix says Icon A (shares L1 > L2 > L3).
-   # The signals conflict.
-   ```
-
-   This reveals that ancestry doesn't eliminate the cross-variant matching problem — it **moves it up the tree**. Before you can scope children within a parent, you need to know which parent in V1 corresponds to which parent in V2. When containers themselves migrate between ancestors, the algorithm faces the same identity question at the container level.
-
-   **Resolution rule — match containers by name, not path**: Containers are matched across variants by their **disambiguated key**, regardless of where they sit in the tree. If `L6` has a unique name, it's the same container whether it's under `L5` or `L3`. Children scoped within `L6` in V1 match children scoped within `L6` in V2. The layout diff captures the structural change (L6 moved); the element diff captures style changes within it. This is consistent with how the existing anatomy model works — the flat `Anatomy = Record<string, AnatomyElement>` keys elements by name, not by path, so elements that move between parents already retain their identity as long as the key matches.
-
-   In practice, tree restructuring across variants is uncommon — most component variants change leaf-level visibility and properties, not container hierarchy. When it does occur, name-based container matching produces correct results for the common case (a container moved to a different parent) and acceptable degradation for the rare case (a container replaced by a different container with the same name).
-
-2. **Anchor-adjacent matching** (strong) — Within a single parent, unique-named siblings serve as stable landmarks. Duplicates are matched by proximity to these anchors. Effective when the parent contains a mix of unique and repeated names.
-
-3. **Positional fallback** (weakest) — When no anchors exist within a parent (all siblings share the same name), fall back to left-to-right order. Correct only when growth happens at the trailing edge.
-
-Most real components benefit from levels 1 and 2. Homogeneous sibling groups (level 3 only) are the minority case — and even there, the output is lossless; only diff granularity degrades.
-
-#### Error risk scale
-
-The algorithm's matching quality depends on the **anchor density** — the ratio of unique-named siblings to total siblings within a parent:
-
-| Anchor density | Matching quality | Example |
-|----------------|-----------------|---------|
-| **High** (>50% unique) | Excellent — most duplicates are sandwiched between anchors | `[Icon, Label, Input, Icon, HelperText]` — 3 anchors, 2 duplicate Icons |
-| **Medium** (1+ anchor, <50%) | Good — terminal elements match well; interior may be positional | `[Cell, Cell, Cell, Actions]` — 1 anchor, 3 duplicate Cells |
-| **Zero** (no anchors) | Positional fallback — correct for right-edge growth only | `[Star, Star, Star, Star, Star]` — 0 anchors |
-
-**Error tolerance**: Mismatched keys produce **larger variant diffs** (element appears as "removed in VA, added in VB" instead of "changed between VA and VB") but never produce **data loss**. The output is always lossless — every element is represented. The only cost of a mismatch is suboptimal diff granularity: a style change on a mismatched element shows as a full element diff rather than a targeted property diff. This is an acceptable degradation for low-confidence cases.
-
-#### Performance considerations
-
-The two-pass approach adds one lightweight traversal over all variants:
-
-- **Pass 1 (survey)**: Iterate each variant's children within each parent, collecting name counts and identifying anchors. This is a name-counting pass only — no element processing, no style detection, no property extraction. Cost: O(V × N) where V = variant count, N = average children per parent.
-- **Pass 2 (assign)**: Segment children by anchors, match across variants within each segment. Cost: O(V × N × A) where A = anchor count per parent. In practice, A is small (typically 1–5).
-- **Total overhead**: Negligible relative to the existing processing pipeline, which performs Figma API calls, style extraction, and variant differencing. The survey pass touches only node names — no I/O, no async operations.
-- **Worst case**: A component with hundreds of variants and deep nesting. Even here, the survey pass is bounded by the total node count across all variants, which is already traversed during the existing `Anatomy.traverse()` call. The added cost is a second traversal of the same nodes collecting only names.
-
-#### Edge cases and fallbacks
-
-**No anchors available**: If all siblings within a parent are duplicates (e.g., `[Star, Star, Star, Star, Star]` with no unique names), fall back to **left-to-right absolute position within parent** — 1st → `star`, 2nd → `star2`, 3rd → `star3`. This is the weakest heuristic but the only option when no context is available. Positional matching here means a designer reordering layers changes suffix assignment — an accepted trade-off when no anchors exist to provide stability.
-
-**Anchor itself is absent in some variants**: If `label` appears in variant A but not variant B, it cannot serve as an anchor. Only names present in **every variant that contains them** qualify. In practice, this means: if an anchor is optional (absent in some variants), its segments are merged with adjacent segments in variants where it's missing.
-
-**Nested duplicates**: Disambiguation is scoped by the full ancestry path (see *Disambiguation hierarchy*, level 1). A container `header` with children `[icon, icon]` and a sibling container `footer` with children `[icon, icon]` are separate scopes — the Icons are distinguished by containment, not suffix. When the containers themselves are duplicates (e.g., two `Section` siblings), top-down resolution disambiguates parents first (`section`, `section2`), then scopes child disambiguation independently within each. This recursive descent is the primary defense against the "same name, different purpose" scenario (Context §2) — the designer's grouping structure, at every depth, is what distinguishes elements.
-
-**Anchor ordering inconsistency**: If anchors themselves appear in different orders across variants (e.g., VA has `[label, description]` but VB has `[description, label]`), the segment boundaries diverge and anchor-relative matching degrades. This is treated as a design inconsistency — the algorithm falls back to absolute position for affected segments and emits a diagnostic warning.
-
-**formatKey collisions**: Two distinct Figma names could format to the same key (e.g., `My Icon` and `myIcon` both → `myIcon` in camelCase). This is treated as a duplicate even though the original names differ. The `$extensions["com.figma"].originalName` field records the formatted key of the dominant name; the collision is surfaced in the same way as a true duplicate.
-
-**3. Variant differencing accuracy**
-
-Once elements have stable, anchor-relative disambiguated keys:
-- `Elements.compare()` matches by disambiguated key — no change to comparison logic needed. Because anchor-relative matching ensures the same logical element gets the same key across variants, diffs correctly identify which elements changed vs. which are new/removed.
-- `Differencer.establishBaselineParity()` sees the full element set (no silent losses) — parity is established correctly
-- Layout diffing compares trees with disambiguated keys — structural differences are detected accurately
-- Elements that exist in some variants but not others (e.g., `icon3` appears only in variant B) surface as expected variant diffs, not as mismatched keys
-
-**4. Floating elements across variants**
-
-Cross-variant matching is **always by flat key** — the parent is irrelevant. This is critical to preserve and is consistent with how the existing `Anatomy = Record<string, AnatomyElement>` model works today.
-
-An element that appears at different hierarchy positions in different variants (e.g., `Icon` as a child of `Header` in variant A, child of `Footer` in variant B, child of `Sidebar` in variant C) is the **same element** as long as its disambiguated key matches. The layout diff captures the structural change; the element diff captures style changes. This holds regardless of how many variants exist or how many different parents the element moves through — 96 variants with one `Icon` each, every time under a different parent, all resolve to key `icon` and are tracked as one element.
-
-This distinction is important: **ancestry containment scopes the within-variant disambiguation** (which sibling gets `icon` vs `icon2`), but **cross-variant matching uses the flat key only**. These are two separate steps:
-
-1. **Within-variant disambiguation** — Per-parent scope, anchor-adjacent matching, and positional fallback assign unique keys within each variant. This is where ancestry matters.
-2. **Cross-variant matching** — The flat anatomy key is used to match elements across variants. An element keyed as `icon` in V1 matches an element keyed as `icon` in V2, regardless of which parent it's under in each variant. This is where ancestry is irrelevant.
-
-```yaml
-# V1: Header > [Icon, Label, Icon]   → icon, label, icon2  (within Header)
-# V2: Footer > [Icon, Label, Icon]   → icon, label, icon2  (within Footer)
-#
-# Cross-variant matching (flat key):
-#   V1 "icon"  ↔ V2 "icon"    ← same element (parents differ, key matches)
-#   V1 "icon2" ↔ V2 "icon2"   ← same element
-#   V1 "label" ↔ V2 "label"   ← same element
-#
-# The layout diff shows: elements moved from Header to Footer.
-# The element diffs show: style changes (if any) between variants.
-```
-
-The risk in cross-variant matching is **suffix instability** — the same logical element receiving different keys in different variants. This can happen when suffix assignment is based on traversal order alone:
-
-```yaml
-# V1:     [Icon₁, Label, Icon₂]  → icon, label, icon2
-# V2-V96: [Label, Icon₂]         → label, icon
-#
-# Traversal-order assignment: V1 assigns "icon" to Icon₁ (first encountered)
-# and "icon2" to Icon₂. V2-V96 assign "icon" to Icon₂ (only one Icon).
-#
-# Cross-variant matching: V2's "icon" matches V1's "icon" — but those are
-# DIFFERENT elements. Icon₂ is "icon2" in V1 and "icon" in V2.
-# Result: 95 wrong comparisons.
-```
-
-The fix: suffix assignment must use **cross-variant prevalence**, not traversal order (see Algorithm, step 3). The global two-pass registry identifies identities first (via anchor-adjacent matching), then assigns the base name to the identity appearing in the **most variants**:
-
-```yaml
-# Identity A (before-label Icon₁) → 1 variant   → "icon2"
-# Identity B (after-label Icon₂)  → 96 variants  → "icon" (base name)
-#
-# V1:     icon2, label, icon    ← Icon₁ gets the suffix
-# V2-V96: label, icon           ← Icon₂ keeps the base name
-#
-# Cross-variant matching: V2's "icon" matches V1's "icon" — CORRECT.
-# The persistent element gets the stable key everywhere.
-```
-
-This ensures that the element appearing in the most variants always gets the base name, and optional/rare elements get suffixes — regardless of which variant is traversed first.
-
-**5. Implementation sequencing**
-
-The work spans two repos and should proceed in this order:
-
-1. **`specs-schema`**: Add `$extensions` to `AnatomyElement` type and schema. Publish as `0.22.0` (MINOR). This is a trivial, low-risk change.
-2. **`specs-from-figma`**: Implement the global registry, anchor-adjacent matching, and collision-safe suffix assignment. This is the bulk of the work. Split into sub-milestones:
-   - **Phase A — Survey infrastructure**: Implement the two-pass survey (name counting, anchor identification) without changing output. Add logging/diagnostics that report which components have duplicate names and what anchors were identified. This is observability-only — no output changes.
-   - **Phase B — Disambiguation**: Apply suffix assignment. All `Record`-keyed structures (`Anatomy._items`, `Elements._items`, `Layout.serialize()`) receive disambiguated keys. Add `$extensions["com.figma"].originalName` to anatomy elements whose key differs from their Figma layer name. This changes output for components with duplicate names.
-   - **Phase C — Parity testing**: Run the parity test suite (`specs-testing`) against ground-truth fixtures to validate that disambiguated output is correct and that components with unique names produce identical output.
-3. **`specs-plugin-2`**: Recompile against new schema types. Optionally surface disambiguation warnings in the plugin UI.
-4. **`specs-cli`**: Recompile. No behavioral changes required.
-
-**6. Testing strategy**
-
-Validation requires both **unit tests** (in `specs-from-figma`) and **parity tests** (in `specs-testing`).
+#### 11. Testing strategy
 
 Unit tests in `specs-from-figma`:
-- **Collision-safe suffix**: Input `[icon, icon, icon2]` → output `[icon, icon3, icon2]`. Verify `icon2` is not stolen.
-- **Anchor identification**: Given variants with known layer structures, verify the correct anchor set is computed.
-- **Anchor-adjacent matching**: Given two variants with different duplicate counts, verify segment assignment and identity matching produce expected keys.
-- **No-anchor fallback**: Homogeneous duplicates `[star, star, star]` → positional `[star, star2, star3]`.
-- **Cross-variant stability**: Process the same component multiple times with different variant ordering — output must be identical regardless of processing order.
-- **Passthrough for unique names**: Components with no duplicate names produce identical output to the current (pre-disambiguation) engine. Zero `$extensions` fields in output.
+- **Collision-safe suffix**: Input `[icon, icon, icon2]` → output `[icon, icon3, icon2]`
+- **Heuristic chain levels**: Test cases that resolve at each check level (name, type, ancestry, anchor, index)
+- **Cross-variant prevalence**: 96-variant scenario — persistent element gets base name
+- **Passthrough**: Components with unique names produce identical output, zero `$extensions`
 
 Parity tests in `specs-testing`:
-- Add Figma test fixtures containing deliberate duplicate names (repeating instances, same-name-different-subtree, floating elements).
-- Verify plugin (`specs-plugin-2`) and CLI (`specs-cli`) produce identical output for these fixtures.
-- Regression: existing fixtures with unique names must produce byte-identical output.
-
-**7. Rollout impact**
-
-- **Components with unique names** (the vast majority): **No output change.** Disambiguation produces no suffixes, no `$extensions` fields. Output is identical to pre-ADR behavior.
-- **Components with duplicate names**: Output changes — previously lost elements now appear in anatomy, elements, and layout. This is a correctness improvement, not a regression, but consumers parsing spec output may see new keys they didn't expect.
-- **No feature flag needed**: The disambiguation algorithm is deterministic and always-on. There is no "old mode" worth preserving — the old behavior was silent data loss.
-- **Breaking change for downstream parsers?**: No. The schema change is additive (new optional `$extensions`). The key format change (new suffixed keys) only affects components that previously had data loss — those consumers were already receiving incorrect output.
+- Figma fixtures with deliberate duplicate names (repeating instances, different-subtree, floating elements)
+- Plugin and CLI produce identical output for disambiguation fixtures
+- Existing fixtures with unique names produce byte-identical output
 
 ---
 
@@ -653,6 +518,6 @@ Parity tests in `specs-testing`:
 - Consumers can distinguish between an element named `icon2` by the designer and one disambiguated from `icon` by checking for `$extensions["com.figma"].originalName`
 - The collision-safe algorithm guarantees no name theft — an original `icon2` layer is never displaced by a disambiguated `icon` duplicate
 - Variant differencing operates on complete element sets, producing accurate diffs
-- The disambiguation suffix format (`name`, `name3`, `name4` with collision skipping) becomes a de facto convention in spec output, though it is not enforced by the schema — suffix numbers may be non-contiguous
-- `specs-from-figma` requires significant architectural changes in traversal, element detection, and variant differencing — this is the primary implementation cost
-- The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata on anatomy (e.g., match method confidence signals, node IDs, layer visibility) without additional schema changes — a subsequent ADR will evaluate this
+- **Evaluation/disambiguation separation** makes the algorithm testable at two levels: "did we collect the right signals?" and "did we resolve correctly given these signals?"
+- The ordered heuristic chain (name → type → ancestry → anchor → index) provides explicit, auditable disambiguation with graceful degradation
+- The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata (ADR-045 evaluates a `matchMethod` signal indicating which heuristic resolved each element)

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -10,6 +10,8 @@
 
 ## Context
 
+> **Scope**: This ADR addresses a **two-part problem** spanning both the schema contract (`@directededges/specs-schema`) and the processing architecture (`specs-from-figma`). Part 1 (Decision) defines the schema change — a small additive type. Part 2 (Downstream Impact → Architectural notes) defines the disambiguation algorithm, cross-variant matching heuristics, and adversarial analysis that make the schema change useful. **Reviewers should evaluate both parts** — the schema change alone is trivial; the processing architecture is where the complexity lives.
+
 Three core types in `@directededges/specs-schema` use layer names as dictionary keys:
 
 - `Anatomy = Record<string, AnatomyElement>`
@@ -272,16 +274,17 @@ $extensions:
 
 The following changes are needed in the processing engine. These are described at the architectural level — specific implementation is at the discretion of the package maintainers.
 
-**1. Traversal-time disambiguation**
+**1. Disambiguation insertion point**
 
-Disambiguation must happen at the earliest point: during `Anatomy.traverse()`, before nodes enter any `Record`-keyed structure. The algorithm:
+Disambiguation must happen at the earliest point in the pipeline: during or immediately after `Anatomy.traverse()`, before nodes enter any `Record`-keyed structure. The disambiguated name replaces the raw Figma layer name for all downstream consumers — anatomy registration, element detection, layout serialization, and variant differencing all operate on the disambiguated key.
 
-- Track seen names per parent scope during depth-first traversal
-- First occurrence of a name → use as-is
-- Subsequent occurrences → append ascending numeric suffix (`name2`, `name3`, ...)
-- Attach the disambiguated name to the node for all downstream consumers (anatomy, elements, layout)
+The disambiguation itself is not a simple per-node decision. It requires cross-variant coordination (see §2 below) because the same logical element must receive the same key in every variant. This means the traversal must either:
+- Run a lightweight survey pass across all variants **before** the main traversal, or
+- Defer name assignment until all variants have been traversed and then apply names retroactively
 
-**2. Cross-variant key stability — global registry with anchor-relative matching**
+The survey-first approach is preferred because it avoids retroactive renaming of already-registered elements.
+
+**2. Cross-variant key stability — global registry with anchor-adjacent matching**
 
 The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants so that differencing produces correct diffs. Pure positional matching (1st icon → `icon`, 2nd icon → `icon2`) fails when variants have different element counts or ordering, because the "2nd icon" in one variant may not be the same element as the "2nd icon" in another.
 
@@ -485,6 +488,42 @@ Once elements have stable, anchor-relative disambiguated keys:
 **4. Floating elements across variants**
 
 An element that appears at different hierarchy positions in different variants (e.g., `label` as a child of `header` in variant A, child of `content` in variant B) is treated as **the same element** if its disambiguated key matches. The layout diff captures the structural change; the element diff captures style changes. This is existing behavior — disambiguation doesn't change it, but it does ensure the element isn't silently dropped if another element shares its name.
+
+**5. Implementation sequencing**
+
+The work spans two repos and should proceed in this order:
+
+1. **`specs-schema`**: Add `$extensions` to `AnatomyElement` type and schema. Publish as `0.22.0` (MINOR). This is a trivial, low-risk change.
+2. **`specs-from-figma`**: Implement the global registry, anchor-adjacent matching, and collision-safe suffix assignment. This is the bulk of the work. Split into sub-milestones:
+   - **Phase A — Survey infrastructure**: Implement the two-pass survey (name counting, anchor identification) without changing output. Add logging/diagnostics that report which components have duplicate names and what anchors were identified. This is observability-only — no output changes.
+   - **Phase B — Disambiguation**: Apply suffix assignment. All `Record`-keyed structures (`Anatomy._items`, `Elements._items`, `Layout.serialize()`) receive disambiguated keys. Add `$extensions["com.figma"].originalName` to anatomy output. This changes output for components with duplicate names.
+   - **Phase C — Parity testing**: Run the parity test suite (`specs-testing`) against ground-truth fixtures to validate that disambiguated output is correct and that components with unique names produce identical output.
+3. **`specs-plugin-2`**: Recompile against new schema types. Optionally surface disambiguation warnings in the plugin UI.
+4. **`specs-cli`**: Recompile. No behavioral changes required.
+
+**6. Testing strategy**
+
+Validation requires both **unit tests** (in `specs-from-figma`) and **parity tests** (in `specs-testing`).
+
+Unit tests in `specs-from-figma`:
+- **Collision-safe suffix**: Input `[icon, icon, icon2]` → output `[icon, icon3, icon2]`. Verify `icon2` is not stolen.
+- **Anchor identification**: Given variants with known layer structures, verify the correct anchor set is computed.
+- **Anchor-adjacent matching**: Given two variants with different duplicate counts, verify segment assignment and identity matching produce expected keys.
+- **No-anchor fallback**: Homogeneous duplicates `[star, star, star]` → positional `[star, star2, star3]`.
+- **Cross-variant stability**: Process the same component multiple times with different variant ordering — output must be identical regardless of processing order.
+- **Passthrough for unique names**: Components with no duplicate names produce identical output to the current (pre-disambiguation) engine. Zero `$extensions` fields in output.
+
+Parity tests in `specs-testing`:
+- Add Figma test fixtures containing deliberate duplicate names (repeating instances, same-name-different-subtree, floating elements).
+- Verify plugin (`specs-plugin-2`) and CLI (`specs-cli`) produce identical output for these fixtures.
+- Regression: existing fixtures with unique names must produce byte-identical output.
+
+**7. Rollout impact**
+
+- **Components with unique names** (the vast majority): **No output change.** Disambiguation produces no suffixes, no `$extensions` fields. Output is identical to pre-ADR behavior.
+- **Components with duplicate names**: Output changes — previously lost elements now appear in anatomy, elements, and layout. This is a correctness improvement, not a regression, but consumers parsing spec output may see new keys they didn't expect.
+- **No feature flag needed**: The disambiguation algorithm is deterministic and always-on. There is no "old mode" worth preserving — the old behavior was silent data loss.
+- **Breaking change for downstream parsers?**: No. The schema change is additive (new optional `$extensions`). The key format change (new suffixed keys) only affects components that previously had data loss — those consumers were already receiving incorrect output.
 
 ---
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -542,9 +542,24 @@ Once elements have stable, anchor-relative disambiguated keys:
 
 **4. Floating elements across variants**
 
-An element that appears at different hierarchy positions in different variants (e.g., `label` as a child of `header` in variant A, child of `content` in variant B) is treated as **the same element** if its disambiguated key matches. The layout diff captures the structural change; the element diff captures style changes. This is existing behavior — disambiguation doesn't change it, but it does ensure the element isn't silently dropped if another element shares its name.
+An element with a **unique name** that appears at different hierarchy positions in different variants (e.g., `label` as a child of `header` in variant A, child of `content` in variant B) is treated as **the same element** — its disambiguated key matches regardless of ancestry. The layout diff captures the structural change; the element diff captures style changes. This is existing behavior and works because a unique name needs no scope-based disambiguation.
 
-This same principle applies to containers: when a parent node moves between ancestors across variants, it retains its identity via its disambiguated key (see *Disambiguation hierarchy*, ancestry containment limitation). Children scoped within that container are matched by the container's key, not its ancestry path.
+This same principle applies to containers: when a uniquely-named parent node moves between ancestors across variants, it retains its identity via its key. Children scoped within that container are matched by the container's key, not its ancestry path (see *Disambiguation hierarchy*, ancestry containment limitation).
+
+**Duplicate-named elements that change parents lose identity.** When a non-unique element moves between scopes across variants, per-parent disambiguation treats it as a different element in each scope:
+
+```yaml
+# V1: L1 > L2 > L3 > L4 > Icon    (scoped to L4 → "icon" within L4)
+#     L1 > L5 > L6 > Icon          (scoped to L6 → "icon" within L6)
+#
+# V2: L1 > Icon                    (scoped to L1 → "icon" within L1)
+#
+# V2's Icon is a direct child of L1. Neither V1 Icon shares that scope.
+# Result: V2's Icon is treated as a NEW element — matched to neither.
+# V1's L4 Icon and L6 Icon appear as "removed in V2."
+```
+
+This is a **correct behavior given available information** — the algorithm cannot determine whether V2's Icon is V1's Icon A promoted up the tree (L4 removed) or a genuinely new element. Without external metadata (e.g., a designer annotation saying "this is the same icon"), scope change is indistinguishable from replacement. The resulting diff is larger than ideal (remove + add instead of move) but never lossy — every element is represented in every variant.
 
 **5. Implementation sequencing**
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -306,44 +306,55 @@ Scan all variants within each parent scope to build:
 # Max "icon" count: 3 (from variant B)
 ```
 
-#### Pass 2 — Anchor-relative identity assignment
+#### Pass 2 — Anchor-adjacent identity assignment
 
-For each group of duplicates sharing a name within a parent, split occurrences into **segments** bounded by anchors. Duplicates in the same segment at the same position within that segment are considered the **same element** across variants.
+For each group of duplicates sharing a name within a parent, split occurrences into **segments** bounded by anchors. Within each segment, match duplicates **from the anchor boundary inward** — elements closest to the anchor have the strongest identity signal and are matched first:
+
+- **Before-anchor** segments: match right-to-left (from anchor side inward)
+- **After-anchor** segments: match left-to-right (from anchor side inward)
+- **Between two anchors**: match inward from both sides (nearest anchor wins)
+
+This reflects designer intent: when a repeated element is added to a group, existing elements near landmarks retain their identity. New elements appear at the edges of segments, farther from anchors.
 
 ```yaml
 # Segments divided by anchor "label":
 #
 # Variant A: [icon, label, icon]
-#   segment BEFORE label: [icon]     → 1 icon
-#   segment AFTER label:  [icon]     → 1 icon
+#   segment BEFORE label: [icon]       → 1 icon
+#   segment AFTER label:  [icon]       → 1 icon
 #
 # Variant B: [icon, icon, label, icon]
 #   segment BEFORE label: [icon, icon] → 2 icons
 #   segment AFTER label:  [icon]       → 1 icon
 
-# Identity matching by segment + position within segment:
-#   "icon, before-label, pos 0" → VA ✓, VB ✓ → SAME element → "icon"
-#   "icon, before-label, pos 1" → VB only     → NEW element  → "icon3"
-#   "icon, after-label, pos 0"  → VA ✓, VB ✓ → SAME element → "icon2"
+# Anchor-adjacent matching (before-label = right-to-left from anchor):
+#   VA before-label, adjacent to label (pos 0):  icon  ─┐
+#   VB before-label, adjacent to label (pos 1):  icon  ─┘ SAME element
+#   VB before-label, far from label (pos 0):     icon  → NEW element
+#
+# Anchor-adjacent matching (after-label = left-to-right from anchor):
+#   VA after-label, adjacent to label (pos 0):   icon  ─┐
+#   VB after-label, adjacent to label (pos 0):   icon  ─┘ SAME element
 
-# Suffix assignment (collision-safe):
-#   Identity 1 (before-label, first) → "icon" (base name, first encountered)
-#   Identity 2 (after-label, first)  → "icon2" (next available, not reserved)
-#   Identity 3 (before-label, second) → "icon3" (next available)
+# Three distinct identities, suffixes assigned by first traversal appearance:
+#   Identity 1 (before-label, adjacent) → first seen VA pos 0 → "icon"
+#   Identity 2 (after-label, adjacent)  → first seen VA pos 2 → "icon2"
+#   Identity 3 (before-label, far)      → first seen VB pos 0 → "icon3"
 
 # Final disambiguation:
 #   Variant A: icon, label, icon2
-#   Variant B: icon, icon3, label, icon2
+#   Variant B: icon3, icon, label, icon2
 #                          ^^^^^
 #                          anchor
 #
-# Differencing: "icon2" in A and "icon2" in B are the SAME element
-# (the icon after label). "icon3" appears only in B → new element diff.
+# "icon" (adjacent to label, left side) is the SAME element in both variants.
+# "icon2" (adjacent to label, right side) is the SAME element in both variants.
+# "icon3" appears only in VB — new element, correctly surfaced as a variant diff.
 ```
 
 #### Multi-anchor example
 
-When multiple anchors exist, they create finer-grained segments:
+When multiple anchors exist, they create finer-grained segments. Matching radiates inward from the nearest anchor:
 
 ```yaml
 # Variant A: [icon, label, description, icon]
@@ -355,19 +366,30 @@ When multiple anchors exist, they create finer-grained segments:
 # VA segments: [icon], [], [icon]
 # VB segments: [icon, icon], [icon], [icon]
 
-# Identity matching:
-#   before-label pos 0    → VA ✓, VB ✓ → "icon"
-#   before-label pos 1    → VB only    → "icon4"
-#   between-label-desc pos 0 → VB only → "icon3"
-#   after-description pos 0  → VA ✓, VB ✓ → "icon2"
+# Anchor-adjacent matching:
+#   before-label (right-to-left from label):
+#     VA [icon←]     →  VB [icon, icon←]  → adjacent icons match
+#     VB pos 0 icon  →  NEW (far from label)
+#
+#   between-label-description (match from nearest anchor):
+#     VA []          →  VB [icon]  → VB only → NEW
+#
+#   after-description (left-to-right from description):
+#     VA [→icon]     →  VB [→icon]  → match
+
+# Identities and suffix assignment:
+#   Identity 1 (before-label, adjacent)         → first seen VA pos 0 → "icon"
+#   Identity 2 (after-description, adjacent)    → first seen VA pos 3 → "icon2"
+#   Identity 3 (between-label-desc, adjacent)   → first seen VB pos 3 → "icon3"
+#   Identity 4 (before-label, far)              → first seen VB pos 0 → "icon4"
 
 # Variant A: icon, label, description, icon2
-# Variant B: icon, icon4, label, icon3, description, icon2
+# Variant B: icon4, icon, label, icon3, description, icon2
 ```
 
 #### Edge cases and fallbacks
 
-**No anchors available**: If all siblings within a parent are duplicates (e.g., `[icon, icon, icon]` with no unique names), fall back to **absolute position within parent** — 1st → `icon`, 2nd → `icon2`, 3rd → `icon3`. This is the weakest heuristic but the only option when no context is available.
+**No anchors available**: If all siblings within a parent are duplicates (e.g., `[icon, icon, icon]` with no unique names), fall back to **left-to-right absolute position within parent** — 1st → `icon`, 2nd → `icon2`, 3rd → `icon3`. This is the weakest heuristic but the only option when no context is available. Positional matching here means a designer reordering layers changes suffix assignment — an accepted trade-off when no anchors exist to provide stability.
 
 **Anchor itself is absent in some variants**: If `label` appears in variant A but not variant B, it cannot serve as an anchor. Only names present in **every variant that contains them** qualify. In practice, this means: if an anchor is optional (absent in some variants), its segments are merged with adjacent segments in variants where it's missing.
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -281,82 +281,107 @@ Disambiguation must happen at the earliest point: during `Anatomy.traverse()`, b
 - Subsequent occurrences → append ascending numeric suffix (`name2`, `name3`, ...)
 - Attach the disambiguated name to the node for all downstream consumers (anatomy, elements, layout)
 
-**2. Cross-variant key stability**
+**2. Cross-variant key stability — global registry with anchor-relative matching**
 
-The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants so that differencing produces correct diffs. Two strategies are viable:
+The critical challenge: ensuring the same logical element receives the same disambiguated key across all variants so that differencing produces correct diffs. Pure positional matching (1st icon → `icon`, 2nd icon → `icon2`) fails when variants have different element counts or ordering, because the "2nd icon" in one variant may not be the same element as the "2nd icon" in another.
 
-#### Strategy A: Per-variant disambiguation + anatomy merge
+The solution is a **two-pass global registry** enhanced with **anchor-relative positioning** — using unique-named siblings as stable reference points to match duplicate elements across variants.
 
-Each variant is disambiguated independently using the collision-safe algorithm. The anatomy accumulates elements from all variants using `addNewElementsFromVariant()`. When a disambiguated key from variant B doesn't match any key in the anatomy (built from variant A), it's added as a new element.
+#### Pass 1 — Survey and anchor identification
 
-```yaml
-# Variant A layers: [icon, label, icon]
-# After disambiguation: icon, label, icon3 (icon2 might be reserved)
-# Anatomy after variant A: {icon, label, icon3}
-
-# Variant B layers: [icon, label]
-# After disambiguation: icon, label (no duplicates)
-# Anatomy merge: icon ✓ exists, label ✓ exists → no new elements
-
-# Variant C layers: [icon, icon, icon, label]
-# After disambiguation: icon, icon3, icon4, label
-# Anatomy merge: icon ✓, icon3 ✓, label ✓, icon4 is NEW → added
-# Final anatomy: {icon, label, icon3, icon4}
-```
-
-**Pros**:
-- Simple — single pass, fits existing processing pipeline
-- Each variant is self-contained; no coordination required
-
-**Cons**:
-- Suffix assignment depends on which variant is processed first (the baseline). If variant A has `[icon, icon]` → `icon, icon2` and variant B has `[icon, icon, icon]` → `icon, icon2, icon3`, the keys align. But if variant A has `[icon, label, icon]` and variant C has `[icon, icon, label]`, the second `icon` gets different suffixes in each (`icon3` vs `icon2` depending on the reserved set), and differencing may see them as different elements.
-- Variant processing order affects the anatomy's key set, which can produce inconsistent diffs.
-
-#### Strategy B: Global name registry (two-pass)
-
-Before processing any variant, scan all variants to build a **global disambiguation registry**:
-
-1. **Pass 1 — Survey**: For each unique name across all variants, record the maximum occurrence count and the set of names that exist as originals (for collision avoidance).
-2. **Pass 2 — Assign**: Using the global reserved set, assign suffixes using the collision-safe algorithm. Because the reserved set is the same for all variants, the same name at the same traversal position always gets the same suffix.
+Scan all variants within each parent scope to build:
+1. A **global reserved set**: all original element names across all variants (for collision-safe suffix assignment)
+2. An **anchor set**: element names that appear **exactly once** within a given parent in **every variant that contains them**. These are stable reference points — they don't move relative to their duplicated neighbors.
+3. For each duplicate name, a **maximum occurrence count** across all variants
 
 ```yaml
-# Survey pass:
-#   "icon" appears: 2× in variant A, 1× in variant B, 3× in variant C → max 3
-#   "icon2" appears: 1× in variant A (as an original name) → reserved
-#   "label" appears: 1× everywhere → max 1
+# Variant A siblings: [icon, label, icon]
+# Variant B siblings: [icon, icon, label, icon]
 
-# Global reserved set: {icon, icon2, label}
-# Disambiguation slots for "icon": icon (1st), icon3 (2nd, skip icon2), icon4 (3rd)
+# Anchors within this parent:
+#   "label" — appears exactly 1× in VA, 1× in VB → ✓ anchor
+#   "icon" — appears 2× in VA, 3× in VB → ✗ not an anchor
 
-# All variants now use the same slot assignments:
-#   Variant A: [icon, icon] → icon, icon3
-#   Variant B: [icon] → icon
-#   Variant C: [icon, icon, icon] → icon, icon3, icon4
-
-# Differencing: "icon3" in A and "icon3" in C are the SAME element (2nd icon)
+# Global reserved set: {icon, label}
+# Max "icon" count: 3 (from variant B)
 ```
 
-**Pros**:
-- Deterministic regardless of variant processing order
-- Same traversal position always maps to the same key across all variants
-- Differencing is accurate — no false positives from inconsistent suffixes
+#### Pass 2 — Anchor-relative identity assignment
 
-**Cons**:
-- Requires two passes over all variants (survey + assign), adding complexity to the processing pipeline
-- The "same traversal position" heuristic assumes designers maintain consistent layer ordering across variants. If variant A has `[icon-decorative, icon-functional]` and variant B has `[icon-functional, icon-decorative]` (swapped order, both named `icon`), they'll get swapped keys. This is an inherent limitation of positional matching without semantic analysis.
+For each group of duplicates sharing a name within a parent, split occurrences into **segments** bounded by anchors. Duplicates in the same segment at the same position within that segment are considered the **same element** across variants.
 
-#### Recommendation
+```yaml
+# Segments divided by anchor "label":
+#
+# Variant A: [icon, label, icon]
+#   segment BEFORE label: [icon]     → 1 icon
+#   segment AFTER label:  [icon]     → 1 icon
+#
+# Variant B: [icon, icon, label, icon]
+#   segment BEFORE label: [icon, icon] → 2 icons
+#   segment AFTER label:  [icon]       → 1 icon
 
-Strategy B (global registry) is preferred for correctness. The two-pass cost is low — the survey pass only collects name counts, not full element processing. The payoff is deterministic key stability across all variants, which directly impacts the quality of variant diffs.
+# Identity matching by segment + position within segment:
+#   "icon, before-label, pos 0" → VA ✓, VB ✓ → SAME element → "icon"
+#   "icon, before-label, pos 1" → VB only     → NEW element  → "icon3"
+#   "icon, after-label, pos 0"  → VA ✓, VB ✓ → SAME element → "icon2"
 
-Strategy A is acceptable as a first implementation if the two-pass approach proves too disruptive to the existing pipeline, with the understanding that edge cases around variant-order-dependent suffixes may produce suboptimal diffs.
+# Suffix assignment (collision-safe):
+#   Identity 1 (before-label, first) → "icon" (base name, first encountered)
+#   Identity 2 (after-label, first)  → "icon2" (next available, not reserved)
+#   Identity 3 (before-label, second) → "icon3" (next available)
+
+# Final disambiguation:
+#   Variant A: icon, label, icon2
+#   Variant B: icon, icon3, label, icon2
+#                          ^^^^^
+#                          anchor
+#
+# Differencing: "icon2" in A and "icon2" in B are the SAME element
+# (the icon after label). "icon3" appears only in B → new element diff.
+```
+
+#### Multi-anchor example
+
+When multiple anchors exist, they create finer-grained segments:
+
+```yaml
+# Variant A: [icon, label, description, icon]
+# Variant B: [icon, icon, label, icon, description, icon]
+
+# Anchors: "label" and "description" (both unique in all variants)
+# Segments: BEFORE-label, BETWEEN-label-description, AFTER-description
+
+# VA segments: [icon], [], [icon]
+# VB segments: [icon, icon], [icon], [icon]
+
+# Identity matching:
+#   before-label pos 0    → VA ✓, VB ✓ → "icon"
+#   before-label pos 1    → VB only    → "icon4"
+#   between-label-desc pos 0 → VB only → "icon3"
+#   after-description pos 0  → VA ✓, VB ✓ → "icon2"
+
+# Variant A: icon, label, description, icon2
+# Variant B: icon, icon4, label, icon3, description, icon2
+```
+
+#### Edge cases and fallbacks
+
+**No anchors available**: If all siblings within a parent are duplicates (e.g., `[icon, icon, icon]` with no unique names), fall back to **absolute position within parent** — 1st → `icon`, 2nd → `icon2`, 3rd → `icon3`. This is the weakest heuristic but the only option when no context is available.
+
+**Anchor itself is absent in some variants**: If `label` appears in variant A but not variant B, it cannot serve as an anchor. Only names present in **every variant that contains them** qualify. In practice, this means: if an anchor is optional (absent in some variants), its segments are merged with adjacent segments in variants where it's missing.
+
+**Nested duplicates**: Disambiguation is scoped to each parent independently. A parent named `header` with children `[icon, icon]` and a sibling parent `footer` with children `[icon, icon]` are separate scopes. The `icon` in `header` and the `icon` in `footer` are already distinct by ancestry — they have different keys in the flattened anatomy because the traversal encounters them in different subtrees.
+
+**Anchor ordering inconsistency**: If anchors themselves appear in different orders across variants (e.g., VA has `[label, description]` but VB has `[description, label]`), the segment boundaries diverge and anchor-relative matching degrades. This is treated as a design inconsistency — the algorithm falls back to absolute position for affected segments and may emit a diagnostic warning.
 
 **3. Variant differencing accuracy**
 
-Once elements have stable disambiguated keys:
-- `Elements.compare()` matches by disambiguated key — no change to comparison logic needed
+Once elements have stable, anchor-relative disambiguated keys:
+- `Elements.compare()` matches by disambiguated key — no change to comparison logic needed. Because anchor-relative matching ensures the same logical element gets the same key across variants, diffs correctly identify which elements changed vs. which are new/removed.
 - `Differencer.establishBaselineParity()` sees the full element set (no silent losses) — parity is established correctly
 - Layout diffing compares trees with disambiguated keys — structural differences are detected accurately
+- Elements that exist in some variants but not others (e.g., `icon3` appears only in variant B) surface as expected variant diffs, not as mismatched keys
 
 **4. Floating elements across variants**
 

--- a/adr/044-duplicate-layer-disambiguation.md
+++ b/adr/044-duplicate-layer-disambiguation.md
@@ -53,9 +53,9 @@ The original EGDS Specs generator solved this with a composite key: **layer name
 
 ## Options Considered
 
-### Option A: Collision-safe numeric suffix + `$extensions` metadata *(Selected)*
+### Option A: Collision-safe numeric suffix + open `$extensions` passthrough *(Selected)*
 
-Disambiguate duplicate names by appending a numeric suffix, determined by an ordered heuristic chain during a disambiguation phase that is separate from initial evaluation. Store the original Figma layer name under `$extensions["com.figma"].originalName` on `AnatomyElement`, following the existing DTCG extension convention used by `TokenReference` and `PropExtensions`.
+Disambiguate duplicate names by appending a numeric suffix, determined by an ordered heuristic chain during a disambiguation phase that is separate from initial evaluation. Add an **open-shape** `$extensions` passthrough to `AnatomyElement` — typed as `Record<string, unknown>` with `additionalProperties: true` in schema — so processing packages can attach reverse-domain provenance metadata without the schema constraining the inner structure. `specs-from-figma` writes the original Figma layer name under `$extensions["com.figma"].originalName` as a package-level convention, not a schema-enforced field.
 
 The suffix algorithm must be **collision-safe** — it cannot assign a suffix that conflicts with an existing element name:
 
@@ -72,11 +72,13 @@ The suffix algorithm must be **collision-safe** — it cannot assign a suffix th
 
 **Pros**:
 - Human-readable keys (`icon`, `icon3` is immediately understandable)
-- `$extensions["com.figma"].originalName` follows the established Figma provenance convention — consistent with `TokenReference.$extensions` and `PropExtensions["com.figma"]`
+- Open-shape `$extensions` lets processing packages attach arbitrary provenance (e.g. `com.figma.originalName`) without committing the schema to a specific inner contract
 - Collision-safe — never steals a name that belongs to an existing element
 - Additive schema change (MINOR) — `$extensions` is optional, existing specs are unaffected
+- Keeps the schema package minimal: no enums, no extension sub-types, no `$extensions` parity for `specs-schema` to maintain as `specs-from-figma` evolves its provenance vocabulary
 
 **Cons / Trade-offs**:
+- Consumers reading `$extensions["com.figma"].originalName` rely on the `specs-from-figma` convention, not a schema-validated field. Drift between producer and consumer is possible.
 - Key stability depends on the heuristic chain producing consistent identities across variants. When the chain reaches the weakest check (sibling index), reordering layers changes suffixes.
 - Suffix numbers may not be contiguous (e.g., `icon`, `icon3` when `icon2` is reserved by an original layer name). Intentional — contiguity is sacrificed for collision safety.
 
@@ -107,11 +109,23 @@ Use the full hierarchy path as the key: `root/content/icon:0`, `root/header/icon
 
 ### Option D: Processing-only fix, no schema change *(Rejected)*
 
-Disambiguate names in `specs-from-figma` using suffixes but add no schema metadata.
+Disambiguate names in `specs-from-figma` using suffixes but add no schema affordance for provenance — consumers receive disambiguated keys with no place to look for traceability data.
 
 **Rejected because**:
-- Consumers see `icon3` but can't determine whether it was originally named `icon3` in Figma or disambiguated from `icon`. The `$extensions["com.figma"].originalName` field makes this distinction explicit and supports round-trip fidelity.
-- Small schema cost (one optional field within an established extension pattern) for significant traceability gain.
+- Consumers see `icon3` but have no schema-sanctioned location to surface "originally named `icon`." Even an open-shape `$extensions` is preferable: it gives processing packages a recognized passthrough without committing the schema to specific inner fields.
+- Small schema cost (one optional open-shape object) for significant traceability gain.
+
+---
+
+### Option E: Typed `$extensions["com.figma"]` sub-shape *(Rejected)*
+
+Define a typed `FigmaAnatomyElementExtension` interface in `specs-schema` enumerating known fields (`originalName`, etc.) under `com.figma`, mirroring the existing `PropExtensions` / `FigmaPropExtension` pattern in `types/Props.ts`.
+
+**Rejected because**:
+- Couples the schema package to the producer's evolving provenance vocabulary — every new signal `specs-from-figma` wants to emit (round-trip metadata, match diagnostics, future heuristics) requires a coordinated `specs-schema` release.
+- `$extensions` per DTCG §5.2.3 is a platform-specific passthrough — its purpose is to escape the schema, not extend it.
+- Typed inner fields create a false guarantee for consumers: they suggest the schema validates the inner structure when in practice processing packages may add reverse-domain keys the schema has never seen.
+- The existing `PropExtensions` typing predates this principle and is itself a candidate for a future "open everything" cleanup ADR.
 
 ---
 
@@ -121,29 +135,40 @@ Disambiguate names in `specs-from-figma` using suffixes but add no schema metada
 
 | File | Change | Bump |
 |------|--------|------|
-| `Anatomy.ts` | Add optional `$extensions` to `AnatomyElement` with `com.figma` namespace containing `originalName` | MINOR |
+| `Anatomy.ts` | Add optional, open-shape `$extensions` to `AnatomyElement` typed as `Record<string, unknown>` | MINOR |
 
 **Example — new shape** (`types/Anatomy.ts`):
-```yaml
-# Before
-AnatomyElement:
-  type: ElementType | ElementTypeRef
-  detectedIn?: string
-  instanceOf?: string | SubcomponentRef
+```ts
+// Before
+type AnatomyElement = {
+  type: ElementType | ElementTypeRef;
+  detectedIn?: string;
+  instanceOf?: string | SubcomponentRef;
+};
 
-# After
-AnatomyElement:
-  type: ElementType | ElementTypeRef
-  detectedIn?: string
-  instanceOf?: string | SubcomponentRef
-  $extensions?:
-    com.figma?:
-      originalName?: string         # Present only when key differs from Figma layer name
+// After
+type AnatomyElement = {
+  type: ElementType | ElementTypeRef;
+  detectedIn?: string;
+  instanceOf?: string | SubcomponentRef;
+  /** DTCG §5.2.3 platform-specific extensions — open-shape passthrough. */
+  $extensions?: Record<string, unknown>;
+};
 ```
 
-`$extensions` is present only when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
+The schema does **not** constrain the inner shape of `$extensions`. Processing packages (e.g. `specs-from-figma`) write reverse-domain keys following their own conventions; consumers reading those conventions do so against the producer's contract, not the schema's.
 
-> **Future ADR**: A subsequent ADR (045) evaluates whether to add a **provenance signal** (e.g., `matchMethod`) to `$extensions["com.figma"]` indicating which heuristic resolved each element's cross-variant identity. This is a separable decision — disambiguation and collision-safe suffixing do not depend on it.
+**`specs-from-figma` convention** — when disambiguation occurs, the producer writes:
+
+```yaml
+$extensions:
+  com.figma:
+    originalName: <pre-disambiguation key>   # only when key differs from Figma layer name
+```
+
+`$extensions` is present only when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case). This is a producer convention — not a schema-enforced shape.
+
+> **Companion ADR**: ADR-045 evaluates whether `specs-from-figma` should additionally emit a `matchMethod` signal indicating which heuristic resolved each element's cross-variant identity. Under the open-passthrough policy adopted here, that decision is purely about the producer's emission vocabulary — no further schema change is required.
 
 **Example — spec output with disambiguation** (collision-safe):
 ```yaml
@@ -217,44 +242,35 @@ layout:
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition with `com.figma` sub-object containing `originalName` | MINOR |
+| `component.schema.json` | Add optional `$extensions` property to `AnatomyElement` definition — open-shape object | MINOR |
 
 **Example — new property** (under `#/definitions/AnatomyElement/properties`):
-```yaml
-$extensions:
-  type: object
-  description: "DTCG §5.2.3 platform-specific extensions."
-  properties:
-    com.figma:
-      type: object
-      properties:
-        originalName:
-          type: string
-          description: >
-            The original Figma layer name (after formatKey) before
-            disambiguation. Present only when the element key was modified
-            to resolve a duplicate name conflict. When absent, the key IS
-            the original layer name.
-      additionalProperties: false
-  additionalProperties: true
-  # not in required[] — optional field
+```json
+"$extensions": {
+  "type": "object",
+  "description": "DTCG §5.2.3 platform-specific extensions. Open-shape passthrough — processing packages may attach reverse-domain keys carrying provenance metadata. The schema does not constrain the inner structure.",
+  "additionalProperties": true
+}
 ```
+
+`$extensions` is not added to `required[]` — it remains optional. No inner properties are declared.
 
 ### Notes
 
-- **`$extensions` follows the established provenance pattern**: `TokenReference`, `BooleanProp`, `StringProp`, `EnumProp`, and `SlotProp` all use `$extensions["com.figma"]` for Figma extraction metadata. Placing `originalName` here is consistent with the ecosystem convention.
-- **`$extensions` presence is conditional on disambiguation**: `$extensions["com.figma"].originalName` is present **only** on elements whose key differs from their Figma layer name. When a component has no duplicate names, no `$extensions` appear anywhere — zero overhead for the common case.
-- **`originalName` stores the formatted key version** of the original name (after `formatKey` is applied), not the raw Figma name with original casing. This ensures consumers can compare `originalName` against other keys using the same format.
+- **Open-shape policy**: `$extensions` is a DTCG §5.2.3 passthrough — its purpose is to escape the schema. The schema package does not validate inner fields; consumers reading specific extension keys (e.g. `com.figma.originalName`) do so against the producing package's documented contract.
+- **`specs-from-figma` convention for disambiguation**: when an element key differs from its Figma layer name, the producer writes `$extensions["com.figma"].originalName` set to the formatted key version of the original name (after `formatKey`). When a component has no duplicate names, no `$extensions` appear anywhere — zero overhead for the common case.
 - **`Elements` and `Layout` do not need `$extensions`**: They use the same disambiguated keys as `Anatomy`. The anatomy is the canonical registry of element identity — consumers look up `originalName` there.
-- **The suffix format** (`name`, `name2`, `name3` with collision skipping) is a processing convention, not a schema constraint. The schema only guarantees unique keys and the `$extensions` field for traceability. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
+- **The suffix format** (`name`, `name2`, `name3` with collision skipping) is a processing convention, not a schema constraint. The schema only guarantees unique keys and an open `$extensions` slot. The suffix numbering strategy is an implementation detail of `specs-from-figma`.
+- **Existing typed extensions (`PropExtensions`, `FigmaPropExtension`) are not in scope**: the typed pattern in `types/Props.ts` predates this open-passthrough policy and is left untouched here. A future cleanup ADR may open those as well.
 
 ---
 
 ## Type ↔ Schema Impact
 
-- **Symmetric**: Yes — one optional `$extensions` object with one property added to both `AnatomyElement` type and schema definition.
+- **Symmetric**: Yes — one optional, open-shape `$extensions` object added to both `AnatomyElement` type and schema definition.
 - **Parity check**:
-  - `AnatomyElement.$extensions["com.figma"].originalName` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/originalName` (schema)
+  - `AnatomyElement.$extensions: Record<string, unknown>` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions` (`type: object`, `additionalProperties: true`) (schema)
+  - No inner-shape parity needed — neither side constrains the inner structure.
 
 ---
 
@@ -507,7 +523,7 @@ Parity tests in `specs-testing`:
 
 **Version bump**: `0.21.0` → `0.22.0` (`MINOR`)
 
-**Justification**: The only schema change is an additive optional field (`originalName` on `AnatomyElement`). No existing fields are modified, removed, or renamed. Per constitution III: "additive types or new optional fields → MINOR."
+**Justification**: The only schema change is an additive optional open-shape `$extensions` object on `AnatomyElement`. No existing fields are modified, removed, or renamed. Per constitution III: "additive types or new optional fields → MINOR."
 
 ---
 
@@ -515,9 +531,10 @@ Parity tests in `specs-testing`:
 
 - Spec output represents every element in the Figma source — no silent data loss from duplicate layer names
 - Components with unique layer names (the majority) produce identical output — no `$extensions` present, keys unchanged
-- Consumers can distinguish between an element named `icon2` by the designer and one disambiguated from `icon` by checking for `$extensions["com.figma"].originalName`
+- Consumers can distinguish between an element named `icon2` by the designer and one disambiguated from `icon` by reading `$extensions["com.figma"].originalName` — surfaced by `specs-from-figma` as a documented convention, not a schema-validated field
 - The collision-safe algorithm guarantees no name theft — an original `icon2` layer is never displaced by a disambiguated `icon` duplicate
 - Variant differencing operates on complete element sets, producing accurate diffs
 - **Evaluation/disambiguation separation** makes the algorithm testable at two levels: "did we collect the right signals?" and "did we resolve correctly given these signals?"
 - The ordered heuristic chain (name → type → ancestry → anchor → index) provides explicit, auditable disambiguation with graceful degradation
-- The `$extensions` pattern on `AnatomyElement` opens the door for future Figma provenance metadata (ADR-045 evaluates a `matchMethod` signal indicating which heuristic resolved each element)
+- The open-shape `$extensions` slot on `AnatomyElement` lets `specs-from-figma` evolve its provenance vocabulary (e.g. ADR-045's `matchMethod`) without further schema releases
+- **Trade-off accepted**: producer/consumer drift on `$extensions` keys is possible. Mitigation lives in `specs-from-figma` and `specs-cli` docs, not in the schema

--- a/adr/045-processing-provenance-signals.md
+++ b/adr/045-processing-provenance-signals.md
@@ -14,11 +14,11 @@ The Specs schema currently carries **what** the processing engine produced but n
 
 This gap matters most for two consumer classes:
 
-1. **LLM consumers** — language models consuming spec output to generate code, documentation, or design reviews. An LLM has no access to the source Figma file or the processing algorithm. Without provenance signals, it must treat all data as equally reliable. With them, it can adjust its reasoning: "This element was matched positionally — its identity across variants is less certain. Treat its diff with appropriate skepticism."
+1. **LLM consumers** — language models consuming spec output to generate code, documentation, or design reviews. An LLM has no access to the source Figma file or the processing algorithm. Without provenance signals, it must treat all data as equally reliable. With them, it can adjust its reasoning: "This element was matched by sibling index — its identity across variants is less certain."
 
 2. **Diagnostic tools** — the plugin UI, CLI output, and future review workflows. Surfacing "this element used a low-confidence heuristic" lets designers verify the cases most likely to be wrong, rather than reviewing the entire spec.
 
-ADR-044 introduces `$extensions["com.figma"]` on `AnatomyElement` with `originalName` for disambiguation traceability. This ADR evaluates whether to extend that same namespace with a **method signal** — and whether to establish provenance signaling as a general pattern for other processing steps.
+ADR-044 introduces `$extensions["com.figma"]` on `AnatomyElement` with `originalName` for disambiguation traceability. It also introduces a **five-level heuristic chain** for resolving element identity (name → type → ancestry → anchor → index). This ADR evaluates whether to extend the same namespace with a **method signal** recording which heuristic level resolved each element — and whether to establish provenance signaling as a general pattern.
 
 ### Existing `$extensions["com.figma"]` usage
 
@@ -40,6 +40,7 @@ Each of these records **what Figma provided**. This ADR proposes also recording 
 - **Minimal initial scope**: Start with the disambiguation use case (ADR-044), define a pattern that future processing steps can follow
 - **No logic in schema**: The schema defines the field shape; processing packages decide when and how to populate it
 - **LLM-friendly**: Signal names should be human-readable strings that a language model can interpret without external documentation
+- **Aligned with heuristic chain**: Values must map directly to ADR-044's ordered check levels so consumers know exactly which heuristic resolved the element
 
 ---
 
@@ -47,7 +48,7 @@ Each of these records **what Figma provided**. This ADR proposes also recording 
 
 ### Option A: `matchMethod` on `AnatomyElement` — scoped provenance field *(Selected)*
 
-Add a `matchMethod` field to `AnatomyElement.$extensions["com.figma"]` that records the heuristic used to determine each element's cross-variant identity. Define a string literal union (`MatchMethod`) for the known methods.
+Add a `matchMethod` field to `AnatomyElement.$extensions["com.figma"]` that records which heuristic check resolved each element's cross-variant identity. Define a string literal union (`MatchMethod`) for the five levels in ADR-044's chain.
 
 This is **scoped to disambiguation only** — it addresses the immediate need without introducing a generic provenance framework. Future processing steps that want provenance signals would add their own named fields to the relevant `$extensions["com.figma"]` objects, following this precedent.
 
@@ -55,8 +56,8 @@ This is **scoped to disambiguation only** — it addresses the immediate need wi
 - Solves the immediate need: consumers know which element keys are high-confidence vs. heuristic fallback
 - Small, focused change — one field, one type, one schema property
 - Follows the established `$extensions["com.figma"]` pattern exactly
-- LLM-readable: `"anchor-adjacent"` and `"positional"` are self-explanatory strings
-- No framework overhead — future provenance fields are independent decisions
+- LLM-readable: `"ancestry"` and `"sibling-index"` are self-explanatory strings
+- Values map 1:1 to ADR-044's heuristic chain — no interpretation gap
 
 **Cons / Trade-offs**:
 - Each new provenance signal requires its own ADR and field addition — no reusable structure
@@ -71,8 +72,8 @@ Add a generic `$extensions["com.figma"].provenance` object with standardized fie
 **Rejected because**:
 - Over-engineered for the current need — only disambiguation has a concrete use case today
 - The `confidence` enum is misleading: "high" vs. "medium" means different things for element matching vs. prop inference vs. subcomponent detection. A generic scale hides domain-specific nuance.
-- Violates "minimal initial scope" — designs a framework before proving the pattern with one case
-- Harder to validate: a generic `method: string` can't be schema-constrained the way `matchMethod: 'unique' | 'anchor-adjacent' | 'positional'` can
+- ADR-044's heuristic chain already provides an **ordered confidence scale** through the check level itself — `unique` is highest, `sibling-index` is lowest. A separate confidence field would duplicate this information.
+- Harder to validate: a generic `method: string` can't be schema-constrained the way a five-value enum can
 
 ---
 
@@ -95,13 +96,15 @@ Emit provenance signals only in diagnostic/debug output (CLI `--verbose`, plugin
 |------|--------|------|
 | `Anatomy.ts` | Add optional `matchMethod` to `AnatomyElement.$extensions["com.figma"]` | MINOR |
 
-**`MatchMethod`** — a string literal union describing the heuristic used to assign an element's cross-variant identity:
+**`MatchMethod`** — a string literal union recording which heuristic check (ADR-044 §3) resolved the element's cross-variant identity:
 
 ```yaml
 MatchMethod:
-  | 'unique'            # No disambiguation needed — name was already unique across all variants
-  | 'anchor-adjacent'   # Matched via proximity to a unique-named anchor sibling
-  | 'positional'        # No anchors available — matched by absolute position within parent
+  | 'unique'            # Check 1 — name was already unique, no disambiguation needed
+  | 'layer-type'        # Check 2 — name + Figma node type narrowed to unique identity
+  | 'ancestry'          # Check 3 — ancestor path distinguished this element from others
+  | 'anchor-adjacent'   # Check 4 — proximity to a unique-named sibling resolved identity
+  | 'sibling-index'     # Check 5 — positional index among same-name+type siblings (lowest confidence)
 ```
 
 **Example — new shape** (`types/Anatomy.ts`):
@@ -131,9 +134,10 @@ AnatomyElement:
 `matchMethod` is present on **every** anatomy element when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
 
 When present, the value distribution conveys the component's matching quality at a glance:
-- All `'unique'` + some `'anchor-adjacent'` → high confidence, anchors were available
-- Mix of `'anchor-adjacent'` + `'positional'` → medium confidence, some segments lacked anchors
-- All `'positional'` → low confidence, no unique siblings existed to anchor against
+- All `'unique'` → no disambiguation was needed (duplicates existed elsewhere in the component, but not for this element)
+- `'layer-type'` or `'ancestry'` → high confidence, structural signals resolved identity
+- `'anchor-adjacent'` → medium confidence, sibling context was used
+- `'sibling-index'` → low confidence, positional fallback was the only option
 
 ### Schema changes (`schema/`)
 
@@ -145,13 +149,14 @@ When present, the value distribution conveys the component's matching quality at
 ```yaml
 matchMethod:
   type: string
-  enum: [unique, anchor-adjacent, positional]
+  enum: [unique, layer-type, ancestry, anchor-adjacent, sibling-index]
   description: >
-    The heuristic used to determine this element's cross-variant
-    identity. "unique" = no disambiguation needed. "anchor-adjacent"
-    = matched via proximity to a unique-named anchor sibling.
-    "positional" = no anchors available, matched by absolute
-    position within parent (lowest confidence).
+    Which heuristic check (ADR-044) resolved this element's cross-variant
+    identity. Values are ordered by confidence: "unique" (highest) through
+    "sibling-index" (lowest). "unique" = no disambiguation needed.
+    "layer-type" = name + node type was sufficient. "ancestry" = ancestor
+    path distinguished the element. "anchor-adjacent" = proximity to a
+    unique sibling. "sibling-index" = positional fallback.
 ```
 
 ### Example output
@@ -170,31 +175,31 @@ anatomy:
     instanceOf: Checkbox
     $extensions:
       com.figma:
-        matchMethod: positional         # No anchors among the checkboxes
+        matchMethod: sibling-index      # No anchors among the checkboxes
   checkbox2:
     type: instance
     instanceOf: Checkbox
     $extensions:
       com.figma:
         originalName: checkbox
-        matchMethod: positional
+        matchMethod: sibling-index
   checkbox3:
     type: instance
     instanceOf: Checkbox
     $extensions:
       com.figma:
         originalName: checkbox
-        matchMethod: positional
+        matchMethod: sibling-index
   icon2:
     type: glyph
     $extensions:
       com.figma:
-        matchMethod: unique             # "icon2" IS the original name
+        matchMethod: unique              # "icon2" IS the original name
   icon:
     type: glyph
     $extensions:
       com.figma:
-        matchMethod: anchor-adjacent    # Adjacent to "icon2" anchor
+        matchMethod: anchor-adjacent     # Adjacent to "icon2" anchor
   icon3:
     type: glyph
     $extensions:
@@ -203,15 +208,44 @@ anatomy:
         matchMethod: anchor-adjacent
 ```
 
+A component with ancestry-resolved duplicates:
+
+```yaml
+# Header > [Icon], Footer > [Icon]
+anatomy:
+  header:
+    type: container
+    $extensions:
+      com.figma:
+        matchMethod: unique
+  footer:
+    type: container
+    $extensions:
+      com.figma:
+        matchMethod: unique
+  icon:
+    type: glyph
+    $extensions:
+      com.figma:
+        matchMethod: ancestry            # Distinguished by Header vs Footer parent
+  icon2:
+    type: glyph
+    $extensions:
+      com.figma:
+        originalName: icon
+        matchMethod: ancestry
+```
+
 ### Notes
 
-- **`matchMethod` extends, not replaces, `originalName`**: The two fields serve different purposes. `originalName` enables round-trip traceability (what was the Figma name?). `matchMethod` enables confidence assessment (how was cross-variant identity determined?). Both live under `com.figma` because both are Figma-processing provenance.
+- **`matchMethod` extends, not replaces, `originalName`**: The two fields serve different purposes. `originalName` enables round-trip traceability (what was the Figma name?). `matchMethod` enables confidence assessment (which heuristic resolved cross-variant identity?). Both live under `com.figma` because both are Figma-processing provenance.
+- **Enum values map 1:1 to ADR-044's heuristic chain**: `unique` = Check 1, `layer-type` = Check 2, `ancestry` = Check 3, `anchor-adjacent` = Check 4, `sibling-index` = Check 5. The ordering is implicit in the enum — earlier values are higher confidence.
 - **Enum values are lowercase kebab-case**, consistent with the `FigmaPropExtension` source kind values (`variant`, `codeOnlyProp`). They are intentionally not `SCREAMING_CASE` — the constitution's screaming-case rule applies to "string literal union types used as enum values in `Styles` and its child types," not to extension metadata values.
 - **The pattern, not the field, is the precedent**: This ADR establishes that processing steps should embed their method signal in the output. Future candidates include:
   - `props.$extensions["com.figma"].inferenceSource` — how a prop type was determined (`explicit`, `heuristic`, `code-only`)
   - `anatomy.element.$extensions["com.figma"].detectionMethod` — how an element type was classified (`name-pattern`, `node-type`, `instance-analysis`)
   - Each would be its own field with its own enum, evaluated independently — no generic framework required.
-- **Consumer guidance for LLMs**: An LLM consuming spec output can use `matchMethod` directly in its reasoning chain. Suggested prompt pattern: "Elements with `matchMethod: 'positional'` have weaker cross-variant identity — their diffs may reflect suffix instability rather than true design changes. Prefer trusting `'unique'` and `'anchor-adjacent'` elements when generating variant-conditional code."
+- **Consumer guidance for LLMs**: An LLM consuming spec output can use `matchMethod` directly in its reasoning chain. Suggested prompt pattern: "Elements with `matchMethod: 'sibling-index'` have the weakest cross-variant identity — their diffs may reflect positional instability rather than true design changes. Prefer trusting `'unique'`, `'layer-type'`, and `'ancestry'` elements when generating variant-conditional code."
 
 ---
 
@@ -220,7 +254,7 @@ anatomy:
 - **Symmetric**: Yes — one optional string field added to both the `AnatomyElement` type and schema definition, within the existing `$extensions["com.figma"]` object.
 - **Parity check**:
   - `AnatomyElement.$extensions["com.figma"].matchMethod` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/matchMethod` (schema)
-  - `MatchMethod` string literal union (type) ↔ `enum: [unique, anchor-adjacent, positional]` (schema)
+  - `MatchMethod` string literal union (type) ↔ `enum: [unique, layer-type, ancestry, anchor-adjacent, sibling-index]` (schema)
 
 ---
 
@@ -228,17 +262,17 @@ anatomy:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | **Medium** — Must emit `matchMethod` alongside disambiguation (ADR-044). The method is already known at assignment time — this is surfacing existing information, not computing new information | Emit `matchMethod` during Pass 2 of the global registry (ADR-044 §2) |
+| `specs-from-figma` | **Medium** — Must emit `matchMethod` during Phase 2 of ADR-044's disambiguation. The check level is already known at resolution time — this is surfacing existing information, not computing new information | Record which check resolved each element during the heuristic chain |
 | `specs-cli` | **Low** — Recompile against new types. May optionally surface `matchMethod` in diagnostic output | Recompile |
 | `specs-plugin-2` | **Low** — Recompile. May optionally highlight low-confidence elements in the UI | Recompile |
 
 ### Implementation sequencing
 
-This ADR is designed to be implemented **concurrently with ADR-044** — in the same schema release and the same `specs-from-figma` implementation phase. The schema change is additive (one more field on the same `$extensions` object). The processing change is trivial: at the point where ADR-044's Pass 2 assigns a suffix, the algorithm already knows whether it used anchor-adjacent or positional matching — it simply records that decision.
+This ADR is designed to be implemented **concurrently with ADR-044** — in the same schema release and the same `specs-from-figma` implementation phase. The schema change is additive (one more field on the same `$extensions` object). The processing change is trivial: at the point where ADR-044's heuristic chain resolves an element, it already knows which check succeeded — it simply records that check level.
 
 Recommended approach:
 1. **Schema**: Include `matchMethod` in the same `AnatomyElement.$extensions` addition as ADR-044's `originalName`. Ship both in a single MINOR release.
-2. **Processing**: Emit `matchMethod` during ADR-044's Phase B (disambiguation). No separate phase needed.
+2. **Processing**: Record the resolving check level during ADR-044's Phase 2 (heuristic chain). No separate phase needed.
 3. **Testing**: Extend ADR-044's test cases to assert `matchMethod` values alongside disambiguated keys.
 
 ---
@@ -255,7 +289,8 @@ Recommended approach:
 
 - Spec output becomes **self-documenting** for disambiguation confidence — consumers can assess element key reliability without re-running the algorithm or inspecting the source Figma file
 - LLM consumers gain a structured signal for reasoning about variant diff trustworthiness
-- Diagnostic tools (plugin UI, CLI) can surface warnings specifically for `'positional'` elements, directing designer review to the cases most likely to mismatch
+- Diagnostic tools (plugin UI, CLI) can surface warnings specifically for `'sibling-index'` elements, directing designer review to the cases most likely to mismatch
 - The `$extensions["com.figma"]` namespace on `AnatomyElement` now carries both traceability (`originalName`) and confidence (`matchMethod`) — a complete provenance record for disambiguation
+- **The five-value enum is inherently ordered**: consumers can treat it as a confidence scale without external documentation — earlier values in the chain = higher confidence
 - **Pattern established**: Processing steps that resolve ambiguity should embed their method signal in the output. Future provenance fields follow the same approach — scoped field, named enum, within `$extensions["com.figma"]` on the relevant type — without requiring a generic framework
 - When a component has no duplicate names, zero overhead — no `$extensions`, no `matchMethod`, identical output to pre-ADR behavior

--- a/adr/045-processing-provenance-signals.md
+++ b/adr/045-processing-provenance-signals.md
@@ -18,27 +18,28 @@ This gap matters most for two consumer classes:
 
 2. **Diagnostic tools** — the plugin UI, CLI output, and future review workflows. Surfacing "this element used a low-confidence heuristic" lets designers verify the cases most likely to be wrong, rather than reviewing the entire spec.
 
-ADR-044 introduces `$extensions["com.figma"]` on `AnatomyElement` with `originalName` for disambiguation traceability. It also introduces a **five-level heuristic chain** for resolving element identity (name → type → ancestry → anchor → index). This ADR evaluates whether to extend the same namespace with a **method signal** recording which heuristic level resolved each element — and whether to establish provenance signaling as a general pattern.
+ADR-044 adds an **open-shape** `$extensions` passthrough to `AnatomyElement` (typed as `Record<string, unknown>`, `additionalProperties: true` in schema). It also introduces a **five-level heuristic chain** for resolving element identity (name → type → ancestry → anchor → index). The schema does not type the inner contents — `specs-from-figma` writes `$extensions["com.figma"].originalName` purely as a package convention. This ADR evaluates whether `specs-from-figma` should also emit a **method signal** recording which heuristic level resolved each element.
 
-### Existing `$extensions["com.figma"]` usage
+Because ADR-044 settled the schema policy as open-passthrough, this ADR is **not** a schema change. The signal lands inside the same already-open `$extensions` slot — no new types, no new schema properties, no schema version bump.
 
-The `com.figma` namespace is already established across the schema:
+### Existing `$extensions["com.figma"]` conventions
 
-- **`TokenReference.$extensions["com.figma"]`** — carries `id`, `name`, `collectionName`, `rawValue` for Figma extraction provenance on token references
-- **`PropExtensions["com.figma"]`** — carries `FigmaPropExtension` (source kind: `variant`, `codeOnlyProp`, etc.) on prop definitions
-- **`AnatomyElement.$extensions["com.figma"]`** (ADR-044) — carries `originalName` for disambiguation traceability
+The `com.figma` reverse-domain key is in use across processing-package conventions:
 
-Each of these records **what Figma provided**. This ADR proposes also recording **how the engine interpreted it**.
+- **`TokenReference.$extensions["com.figma"]`** — carries `id`, `name`, `collectionName`, `rawValue` for Figma extraction provenance on token references (typed in `specs-schema`, predates the open-passthrough policy)
+- **`PropExtensions["com.figma"]`** — carries `FigmaPropExtension` (source kind: `variant`, `codeOnlyProp`, etc.) on prop definitions (typed in `specs-schema`, predates the open-passthrough policy)
+- **`AnatomyElement.$extensions["com.figma"]`** (ADR-044) — open-shape; `specs-from-figma` writes `originalName` by convention for disambiguation traceability
+
+Each of these records **what Figma provided**. This ADR proposes also recording **how the engine interpreted it** — under the new policy, as a producer convention rather than a typed schema field.
 
 ---
 
 ## Decision Drivers
 
 - **Self-documenting output**: Spec data should carry enough context for any consumer to assess reliability without re-running the algorithm or accessing the source file
-- **Additive change**: Must be MINOR — optional fields only, no breaking changes
-- **Consistent extension pattern**: New fields belong in `$extensions["com.figma"]` following the established DTCG §5.2.3 convention
-- **Minimal initial scope**: Start with the disambiguation use case (ADR-044), define a pattern that future processing steps can follow
-- **No logic in schema**: The schema defines the field shape; processing packages decide when and how to populate it
+- **No schema change**: Per ADR-044's open-passthrough policy, new provenance signals MUST be producer conventions inside `$extensions`, not typed schema fields
+- **Consistent extension pattern**: New conventions land under `$extensions["com.figma"]` following DTCG §5.2.3 reverse-domain usage
+- **Minimal initial scope**: Start with the disambiguation use case (ADR-044), define the producer-convention precedent that future processing steps can follow
 - **LLM-friendly**: Signal names should be human-readable strings that a language model can interpret without external documentation
 - **Aligned with heuristic chain**: Values must map directly to ADR-044's ordered check levels so consumers know exactly which heuristic resolved the element
 
@@ -46,45 +47,58 @@ Each of these records **what Figma provided**. This ADR proposes also recording 
 
 ## Options Considered
 
-### Option A: `matchMethod` on `AnatomyElement` — scoped provenance field *(Selected)*
+### Option A: `matchMethod` emitted under open `$extensions` as a producer convention *(Selected)*
 
-Add a `matchMethod` field to `AnatomyElement.$extensions["com.figma"]` that records which heuristic check resolved each element's cross-variant identity. Define a string literal union (`MatchMethod`) for the five levels in ADR-044's chain.
+`specs-from-figma` writes a `matchMethod` string under `AnatomyElement.$extensions["com.figma"]` whenever it resolves an element's cross-variant identity. The value comes from a fixed vocabulary that maps 1:1 to ADR-044's heuristic chain. This vocabulary is documented in `specs-from-figma` (and surfaced in `specs-cli` / `specs-plugin-2` consumer docs), **not** declared in the `specs-schema` types or JSON schema.
 
-This is **scoped to disambiguation only** — it addresses the immediate need without introducing a generic provenance framework. Future processing steps that want provenance signals would add their own named fields to the relevant `$extensions["com.figma"]` objects, following this precedent.
+This is **scoped to disambiguation only** — it addresses the immediate need without introducing a generic provenance framework. Future processing steps that want provenance signals would add their own named keys under the same open-passthrough slot, following this precedent.
 
 **Pros**:
 - Solves the immediate need: consumers know which element keys are high-confidence vs. heuristic fallback
-- Small, focused change — one field, one type, one schema property
-- Follows the established `$extensions["com.figma"]` pattern exactly
+- Zero schema impact — no new types, no schema bump, no `specs-schema` release coordination
+- Follows ADR-044's open-passthrough policy: `$extensions` exists to escape the schema
 - LLM-readable: `"ancestry"` and `"sibling-index"` are self-explanatory strings
 - Values map 1:1 to ADR-044's heuristic chain — no interpretation gap
+- `specs-from-figma` can extend or refine the vocabulary independently as the chain evolves
 
 **Cons / Trade-offs**:
-- Each new provenance signal requires its own ADR and field addition — no reusable structure
-- Field naming is ad-hoc — `matchMethod` for disambiguation, `inferenceMethod` for props, etc. No enforced convention beyond the namespace
+- No schema-level validation: a consumer reading `matchMethod` relies on the producer's documented contract; typos in the producer would silently propagate
+- Each new provenance signal still requires producer-side documentation — no reusable framework
+- Discoverability lives in `specs-from-figma` docs and this ADR, not in the schema itself
 
 ---
 
-### Option B: Generic `provenance` object with `method` + `confidence` *(Rejected)*
+### Option B: Typed enum + schema field on `AnatomyElement.$extensions["com.figma"].matchMethod` *(Rejected)*
 
-Add a generic `$extensions["com.figma"].provenance` object with standardized fields (`method: string`, `confidence: 'high' | 'medium' | 'low'`, `details?: string`) that any processing step could populate.
+Define `MatchMethod` as a string literal union in `types/Anatomy.ts`, type `FigmaAnatomyElementExtension.matchMethod?: MatchMethod`, and add a constrained `enum` to `component.schema.json`. This was the originally selected option in this ADR.
+
+**Rejected because**:
+- Directly contradicts ADR-044's revised open-passthrough policy — `$extensions` is a DTCG §5.2.3 escape hatch, not an extension point for schema-enforced fields
+- Couples `specs-schema` to `specs-from-figma`'s evolving provenance vocabulary — every refinement of the heuristic chain would require a coordinated schema release
+- Creates a false guarantee: typed fields suggest schema validation while the surrounding `$extensions` slot accepts arbitrary keys the schema has never seen
+- Two of the five values (`anchor-adjacent`, `sibling-index`) are themselves implementation details of `specs-from-figma`'s algorithm — codifying them in the schema package elevates internals to public contract
+
+---
+
+### Option C: Generic `provenance` object with `method` + `confidence` *(Rejected)*
+
+Standardise a generic `$extensions["com.figma"].provenance` object with `method: string`, `confidence: 'high' | 'medium' | 'low'`, `details?: string` that any processing step could populate.
 
 **Rejected because**:
 - Over-engineered for the current need — only disambiguation has a concrete use case today
 - The `confidence` enum is misleading: "high" vs. "medium" means different things for element matching vs. prop inference vs. subcomponent detection. A generic scale hides domain-specific nuance.
 - ADR-044's heuristic chain already provides an **ordered confidence scale** through the check level itself — `unique` is highest, `sibling-index` is lowest. A separate confidence field would duplicate this information.
-- Harder to validate: a generic `method: string` can't be schema-constrained the way a five-value enum can
 
 ---
 
-### Option C: Processing-only signals, no schema change *(Rejected)*
+### Option D: Processing-only signals, no spec output *(Rejected)*
 
 Emit provenance signals only in diagnostic/debug output (CLI `--verbose`, plugin console), not in the spec data itself.
 
 **Rejected because**:
 - LLM consumers and downstream tools consuming the JSON/YAML output never see diagnostics — the signal is lost at the point where it's most valuable
 - Diagnostic output is ephemeral; spec output is the durable artifact that gets stored, versioned, and consumed across workflows
-- Small schema cost (one optional string field within an established extension) for significant consumer value
+- The open `$extensions` slot exists precisely for this kind of producer-attached metadata — zero schema cost for significant consumer value
 
 ---
 
@@ -92,72 +106,44 @@ Emit provenance signals only in diagnostic/debug output (CLI `--verbose`, plugin
 
 ### Type changes (`types/`)
 
-| File | Change | Bump |
-|------|--------|------|
-| `Anatomy.ts` | Add optional `matchMethod` to `AnatomyElement.$extensions["com.figma"]` | MINOR |
+**None.** Per ADR-044's open-passthrough policy, `AnatomyElement.$extensions` is typed as `Record<string, unknown>` and the schema declares only `additionalProperties: true`. The `matchMethod` signal is a producer convention written inside the existing open slot — no `specs-schema` change is required.
 
-**`MatchMethod`** — a string literal union recording which heuristic check (ADR-044 §3) resolved the element's cross-variant identity:
+### Schema changes (`schema/`)
+
+**None.** Same rationale as above.
+
+### `specs-from-figma` producer convention
+
+When `specs-from-figma` runs ADR-044's disambiguation, it writes — at the point where the heuristic chain resolves each element's identity — a `matchMethod` key under `$extensions["com.figma"]`. The value vocabulary is:
 
 ```yaml
-MatchMethod:
-  | 'unique'            # Check 1 — name was already unique, no disambiguation needed
-  | 'layer-type'        # Check 2 — name + Figma node type narrowed to unique identity
-  | 'ancestry'          # Check 3 — ancestor path distinguished this element from others
-  | 'anchor-adjacent'   # Check 4 — proximity to a unique-named sibling resolved identity
-  | 'sibling-index'     # Check 5 — positional index among same-name+type siblings (lowest confidence)
+matchMethod values (ordered by confidence, highest first):
+  'unique'            # Check 1 — name was already unique, no disambiguation needed
+  'layer-type'        # Check 2 — name + Figma node type narrowed to unique identity
+  'ancestry'          # Check 3 — ancestor path distinguished this element from others
+  'anchor-adjacent'   # Check 4 — proximity to a unique-named sibling resolved identity
+  'sibling-index'     # Check 5 — positional index among same-name+type siblings (lowest confidence)
 ```
 
-**Example — new shape** (`types/Anatomy.ts`):
+This vocabulary is owned by `specs-from-figma`. Consumer packages (`specs-cli`, `specs-plugin-2`, LLM consumers reading the output) read it against `specs-from-figma`'s documented contract, not against `specs-schema`.
+
+**Illustrative output shape** (note: schema does not enforce this inner structure):
 ```yaml
-# Before (after ADR-044)
-AnatomyElement:
-  type: ElementType | ElementTypeRef
-  detectedIn?: string
-  instanceOf?: string | SubcomponentRef
-  $extensions?:
-    com.figma?:
-      originalName?: string
-
-# After
-AnatomyElement:
-  type: ElementType | ElementTypeRef
-  detectedIn?: string
-  instanceOf?: string | SubcomponentRef
-  $extensions?:
-    com.figma?:
-      originalName?: string
-      matchMethod?: MatchMethod
+$extensions:
+  com.figma:
+    originalName?: <string>      # ADR-044 convention
+    matchMethod?: <one of the five strings above>
 ```
 
-### Presence rules
+### Presence rules (producer-side)
 
-`matchMethod` is present on **every** anatomy element when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
+`matchMethod` is emitted on **every** anatomy element when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
 
 When present, the value distribution conveys the component's matching quality at a glance:
 - All `'unique'` → no disambiguation was needed (duplicates existed elsewhere in the component, but not for this element)
 - `'layer-type'` or `'ancestry'` → high confidence, structural signals resolved identity
 - `'anchor-adjacent'` → medium confidence, sibling context was used
 - `'sibling-index'` → low confidence, positional fallback was the only option
-
-### Schema changes (`schema/`)
-
-| File | Change | Bump |
-|------|--------|------|
-| `component.schema.json` | Add optional `matchMethod` to `AnatomyElement.$extensions["com.figma"]` | MINOR |
-
-**Example — new property** (under `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties`):
-```yaml
-matchMethod:
-  type: string
-  enum: [unique, layer-type, ancestry, anchor-adjacent, sibling-index]
-  description: >
-    Which heuristic check (ADR-044) resolved this element's cross-variant
-    identity. Values are ordered by confidence: "unique" (highest) through
-    "sibling-index" (lowest). "unique" = no disambiguation needed.
-    "layer-type" = name + node type was sufficient. "ancestry" = ancestor
-    path distinguished the element. "anchor-adjacent" = proximity to a
-    unique sibling. "sibling-index" = positional fallback.
-```
 
 ### Example output
 
@@ -238,23 +224,17 @@ anatomy:
 
 ### Notes
 
-- **`matchMethod` extends, not replaces, `originalName`**: The two fields serve different purposes. `originalName` enables round-trip traceability (what was the Figma name?). `matchMethod` enables confidence assessment (which heuristic resolved cross-variant identity?). Both live under `com.figma` because both are Figma-processing provenance.
-- **Enum values map 1:1 to ADR-044's heuristic chain**: `unique` = Check 1, `layer-type` = Check 2, `ancestry` = Check 3, `anchor-adjacent` = Check 4, `sibling-index` = Check 5. The ordering is implicit in the enum — earlier values are higher confidence.
-- **Enum values are lowercase kebab-case**, consistent with the `FigmaPropExtension` source kind values (`variant`, `codeOnlyProp`). They are intentionally not `SCREAMING_CASE` — the constitution's screaming-case rule applies to "string literal union types used as enum values in `Styles` and its child types," not to extension metadata values.
-- **The pattern, not the field, is the precedent**: This ADR establishes that processing steps should embed their method signal in the output. Future candidates include:
-  - `props.$extensions["com.figma"].inferenceSource` — how a prop type was determined (`explicit`, `heuristic`, `code-only`)
-  - `anatomy.element.$extensions["com.figma"].detectionMethod` — how an element type was classified (`name-pattern`, `node-type`, `instance-analysis`)
-  - Each would be its own field with its own enum, evaluated independently — no generic framework required.
+- **`matchMethod` extends, not replaces, `originalName`**: The two keys serve different purposes. `originalName` enables round-trip traceability (what was the Figma name?). `matchMethod` enables confidence assessment (which heuristic resolved cross-variant identity?). Both live under `com.figma` because both are Figma-processing provenance — both are producer conventions, not schema fields.
+- **Values map 1:1 to ADR-044's heuristic chain**: `unique` = Check 1, `layer-type` = Check 2, `ancestry` = Check 3, `anchor-adjacent` = Check 4, `sibling-index` = Check 5. The ordering is implicit in the vocabulary — earlier values are higher confidence.
+- **Values are lowercase kebab-case**, consistent with the `FigmaPropExtension` source kind values (`variant`, `codeOnlyProp`). They are intentionally not `SCREAMING_CASE` — the constitution's screaming-case rule applies to "string literal union types used as enum values in `Styles` and its child types," and in any case does not bind producer-convention values that live outside the schema.
+- **The producer-convention pattern is the precedent**: Processing steps that want to surface method signals write them as documented keys under the relevant `$extensions["com.figma"]` slot — no schema work required. Future candidates include `com.figma.inferenceSource` for prop type derivation, `com.figma.detectionMethod` for element type classification, etc.
 - **Consumer guidance for LLMs**: An LLM consuming spec output can use `matchMethod` directly in its reasoning chain. Suggested prompt pattern: "Elements with `matchMethod: 'sibling-index'` have the weakest cross-variant identity — their diffs may reflect positional instability rather than true design changes. Prefer trusting `'unique'`, `'layer-type'`, and `'ancestry'` elements when generating variant-conditional code."
 
 ---
 
 ## Type ↔ Schema Impact
 
-- **Symmetric**: Yes — one optional string field added to both the `AnatomyElement` type and schema definition, within the existing `$extensions["com.figma"]` object.
-- **Parity check**:
-  - `AnatomyElement.$extensions["com.figma"].matchMethod` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/matchMethod` (schema)
-  - `MatchMethod` string literal union (type) ↔ `enum: [unique, layer-type, ancestry, anchor-adjacent, sibling-index]` (schema)
+- **None.** No type or schema changes in `specs-schema`. The signal lives entirely inside the open `$extensions` slot defined by ADR-044.
 
 ---
 
@@ -262,26 +242,27 @@ anatomy:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | **Medium** — Must emit `matchMethod` during Phase 2 of ADR-044's disambiguation. The check level is already known at resolution time — this is surfacing existing information, not computing new information | Record which check resolved each element during the heuristic chain |
-| `specs-cli` | **Low** — Recompile against new types. May optionally surface `matchMethod` in diagnostic output | Recompile |
-| `specs-plugin-2` | **Low** — Recompile. May optionally highlight low-confidence elements in the UI | Recompile |
+| `specs-schema` | **None** — no type or schema change | None |
+| `specs-from-figma` | **Medium** — Must emit `matchMethod` under `$extensions["com.figma"]` during Phase 2 of ADR-044's disambiguation. The check level is already known at resolution time — this is surfacing existing information, not computing new information. Vocabulary documented in `specs-from-figma` README / docs | Record which check resolved each element during the heuristic chain and emit the corresponding string |
+| `specs-cli` | **Low** — May optionally surface `matchMethod` in diagnostic output. No recompile required (open-shape `$extensions` already in `0.22.0`) | Optional |
+| `specs-plugin-2` | **Low** — May optionally highlight low-confidence elements in the UI | Optional |
 
 ### Implementation sequencing
 
-This ADR is designed to be implemented **concurrently with ADR-044** — in the same schema release and the same `specs-from-figma` implementation phase. The schema change is additive (one more field on the same `$extensions` object). The processing change is trivial: at the point where ADR-044's heuristic chain resolves an element, it already knows which check succeeded — it simply records that check level.
+This ADR is **purely a producer-side commitment**. It can ship independently of any `specs-schema` release once ADR-044's open `$extensions` slot is available (`specs-schema@0.22.0`).
 
 Recommended approach:
-1. **Schema**: Include `matchMethod` in the same `AnatomyElement.$extensions` addition as ADR-044's `originalName`. Ship both in a single MINOR release.
-2. **Processing**: Record the resolving check level during ADR-044's Phase 2 (heuristic chain). No separate phase needed.
-3. **Testing**: Extend ADR-044's test cases to assert `matchMethod` values alongside disambiguated keys.
+1. **`specs-schema`**: Already complete via ADR-044 (open-shape `$extensions` shipped in `0.22.0`).
+2. **`specs-from-figma`**: During ADR-044's Phase 2 (heuristic chain), record the resolving check level and write it as `$extensions["com.figma"].matchMethod`. Document the vocabulary in package README / API docs.
+3. **Testing**: Extend `specs-from-figma`'s test cases to assert `matchMethod` values alongside disambiguated keys.
 
 ---
 
 ## Semver Decision
 
-**Version bump**: Included in ADR-044's `0.22.0` release (`MINOR`)
+**`specs-schema` version bump**: None — no schema change.
 
-**Justification**: One additional optional field within an already-new optional `$extensions` object. No existing fields modified. Per constitution III: "additive types or new optional fields → MINOR."
+**`specs-from-figma` version bump**: MINOR (new producer-emitted metadata key in spec output). Owned by the `specs-from-figma` release process; not governed by `specs-schema`'s constitution.
 
 ---
 
@@ -290,7 +271,8 @@ Recommended approach:
 - Spec output becomes **self-documenting** for disambiguation confidence — consumers can assess element key reliability without re-running the algorithm or inspecting the source Figma file
 - LLM consumers gain a structured signal for reasoning about variant diff trustworthiness
 - Diagnostic tools (plugin UI, CLI) can surface warnings specifically for `'sibling-index'` elements, directing designer review to the cases most likely to mismatch
-- The `$extensions["com.figma"]` namespace on `AnatomyElement` now carries both traceability (`originalName`) and confidence (`matchMethod`) — a complete provenance record for disambiguation
-- **The five-value enum is inherently ordered**: consumers can treat it as a confidence scale without external documentation — earlier values in the chain = higher confidence
-- **Pattern established**: Processing steps that resolve ambiguity should embed their method signal in the output. Future provenance fields follow the same approach — scoped field, named enum, within `$extensions["com.figma"]` on the relevant type — without requiring a generic framework
+- The `$extensions["com.figma"]` slot on `AnatomyElement` now carries both traceability (`originalName`) and confidence (`matchMethod`) — a complete provenance record for disambiguation
+- **The five-value vocabulary is inherently ordered**: consumers can treat it as a confidence scale without external documentation — earlier values in the chain = higher confidence
+- **Producer-convention precedent established**: Processing steps that resolve ambiguity embed their method signal in the output by writing documented keys under `$extensions["com.figma"]`. No schema work required for future provenance signals.
+- **Trade-off accepted**: No schema-level validation. A consumer reading `matchMethod` trusts the `specs-from-figma` contract. Mitigation: the vocabulary is small, stable, and documented in producer docs and this ADR
 - When a component has no duplicate names, zero overhead — no `$extensions`, no `matchMethod`, identical output to pre-ADR behavior

--- a/adr/045-processing-provenance-signals.md
+++ b/adr/045-processing-provenance-signals.md
@@ -1,0 +1,261 @@
+# ADR: Processing Provenance Signals
+
+**Branch**: `adr/044-duplicate-layer-disambiguation`
+**Created**: 2026-05-07
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Depends on**: ADR-044 (Duplicate Layer Name Disambiguation)
+
+---
+
+## Context
+
+The Specs schema currently carries **what** the processing engine produced but not **how confident** the engine was in each decision. When `specs-from-figma` resolves ambiguity — matching duplicate-named elements across variants, inferring prop types, detecting subcomponent boundaries — the algorithm knows its own confidence level at every step. Today that signal is discarded: consumers see final keys and values with no indication of which were straightforward and which required heuristic fallbacks.
+
+This gap matters most for two consumer classes:
+
+1. **LLM consumers** — language models consuming spec output to generate code, documentation, or design reviews. An LLM has no access to the source Figma file or the processing algorithm. Without provenance signals, it must treat all data as equally reliable. With them, it can adjust its reasoning: "This element was matched positionally — its identity across variants is less certain. Treat its diff with appropriate skepticism."
+
+2. **Diagnostic tools** — the plugin UI, CLI output, and future review workflows. Surfacing "this element used a low-confidence heuristic" lets designers verify the cases most likely to be wrong, rather than reviewing the entire spec.
+
+ADR-044 introduces `$extensions["com.figma"]` on `AnatomyElement` with `originalName` for disambiguation traceability. This ADR evaluates whether to extend that same namespace with a **method signal** — and whether to establish provenance signaling as a general pattern for other processing steps.
+
+### Existing `$extensions["com.figma"]` usage
+
+The `com.figma` namespace is already established across the schema:
+
+- **`TokenReference.$extensions["com.figma"]`** — carries `id`, `name`, `collectionName`, `rawValue` for Figma extraction provenance on token references
+- **`PropExtensions["com.figma"]`** — carries `FigmaPropExtension` (source kind: `variant`, `codeOnlyProp`, etc.) on prop definitions
+- **`AnatomyElement.$extensions["com.figma"]`** (ADR-044) — carries `originalName` for disambiguation traceability
+
+Each of these records **what Figma provided**. This ADR proposes also recording **how the engine interpreted it**.
+
+---
+
+## Decision Drivers
+
+- **Self-documenting output**: Spec data should carry enough context for any consumer to assess reliability without re-running the algorithm or accessing the source file
+- **Additive change**: Must be MINOR — optional fields only, no breaking changes
+- **Consistent extension pattern**: New fields belong in `$extensions["com.figma"]` following the established DTCG §5.2.3 convention
+- **Minimal initial scope**: Start with the disambiguation use case (ADR-044), define a pattern that future processing steps can follow
+- **No logic in schema**: The schema defines the field shape; processing packages decide when and how to populate it
+- **LLM-friendly**: Signal names should be human-readable strings that a language model can interpret without external documentation
+
+---
+
+## Options Considered
+
+### Option A: `matchMethod` on `AnatomyElement` — scoped provenance field *(Selected)*
+
+Add a `matchMethod` field to `AnatomyElement.$extensions["com.figma"]` that records the heuristic used to determine each element's cross-variant identity. Define a string literal union (`MatchMethod`) for the known methods.
+
+This is **scoped to disambiguation only** — it addresses the immediate need without introducing a generic provenance framework. Future processing steps that want provenance signals would add their own named fields to the relevant `$extensions["com.figma"]` objects, following this precedent.
+
+**Pros**:
+- Solves the immediate need: consumers know which element keys are high-confidence vs. heuristic fallback
+- Small, focused change — one field, one type, one schema property
+- Follows the established `$extensions["com.figma"]` pattern exactly
+- LLM-readable: `"anchor-adjacent"` and `"positional"` are self-explanatory strings
+- No framework overhead — future provenance fields are independent decisions
+
+**Cons / Trade-offs**:
+- Each new provenance signal requires its own ADR and field addition — no reusable structure
+- Field naming is ad-hoc — `matchMethod` for disambiguation, `inferenceMethod` for props, etc. No enforced convention beyond the namespace
+
+---
+
+### Option B: Generic `provenance` object with `method` + `confidence` *(Rejected)*
+
+Add a generic `$extensions["com.figma"].provenance` object with standardized fields (`method: string`, `confidence: 'high' | 'medium' | 'low'`, `details?: string`) that any processing step could populate.
+
+**Rejected because**:
+- Over-engineered for the current need — only disambiguation has a concrete use case today
+- The `confidence` enum is misleading: "high" vs. "medium" means different things for element matching vs. prop inference vs. subcomponent detection. A generic scale hides domain-specific nuance.
+- Violates "minimal initial scope" — designs a framework before proving the pattern with one case
+- Harder to validate: a generic `method: string` can't be schema-constrained the way `matchMethod: 'unique' | 'anchor-adjacent' | 'positional'` can
+
+---
+
+### Option C: Processing-only signals, no schema change *(Rejected)*
+
+Emit provenance signals only in diagnostic/debug output (CLI `--verbose`, plugin console), not in the spec data itself.
+
+**Rejected because**:
+- LLM consumers and downstream tools consuming the JSON/YAML output never see diagnostics — the signal is lost at the point where it's most valuable
+- Diagnostic output is ephemeral; spec output is the durable artifact that gets stored, versioned, and consumed across workflows
+- Small schema cost (one optional string field within an established extension) for significant consumer value
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Anatomy.ts` | Add optional `matchMethod` to `AnatomyElement.$extensions["com.figma"]` | MINOR |
+
+**`MatchMethod`** — a string literal union describing the heuristic used to assign an element's cross-variant identity:
+
+```yaml
+MatchMethod:
+  | 'unique'            # No disambiguation needed — name was already unique across all variants
+  | 'anchor-adjacent'   # Matched via proximity to a unique-named anchor sibling
+  | 'positional'        # No anchors available — matched by absolute position within parent
+```
+
+**Example — new shape** (`types/Anatomy.ts`):
+```yaml
+# Before (after ADR-044)
+AnatomyElement:
+  type: ElementType | ElementTypeRef
+  detectedIn?: string
+  instanceOf?: string | SubcomponentRef
+  $extensions?:
+    com.figma?:
+      originalName?: string
+
+# After
+AnatomyElement:
+  type: ElementType | ElementTypeRef
+  detectedIn?: string
+  instanceOf?: string | SubcomponentRef
+  $extensions?:
+    com.figma?:
+      originalName?: string
+      matchMethod?: MatchMethod
+```
+
+### Presence rules
+
+`matchMethod` is present on **every** anatomy element when the component contains at least one duplicate name group. When a component has no duplicates, `$extensions` is omitted entirely (no noise for the common case).
+
+When present, the value distribution conveys the component's matching quality at a glance:
+- All `'unique'` + some `'anchor-adjacent'` → high confidence, anchors were available
+- Mix of `'anchor-adjacent'` + `'positional'` → medium confidence, some segments lacked anchors
+- All `'positional'` → low confidence, no unique siblings existed to anchor against
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add optional `matchMethod` to `AnatomyElement.$extensions["com.figma"]` | MINOR |
+
+**Example — new property** (under `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties`):
+```yaml
+matchMethod:
+  type: string
+  enum: [unique, anchor-adjacent, positional]
+  description: >
+    The heuristic used to determine this element's cross-variant
+    identity. "unique" = no disambiguation needed. "anchor-adjacent"
+    = matched via proximity to a unique-named anchor sibling.
+    "positional" = no anchors available, matched by absolute
+    position within parent (lowest confidence).
+```
+
+### Example output
+
+Building on ADR-044's collision-safe example:
+
+```yaml
+anatomy:
+  root:
+    type: container
+    $extensions:
+      com.figma:
+        matchMethod: unique
+  checkbox:
+    type: instance
+    instanceOf: Checkbox
+    $extensions:
+      com.figma:
+        matchMethod: positional         # No anchors among the checkboxes
+  checkbox2:
+    type: instance
+    instanceOf: Checkbox
+    $extensions:
+      com.figma:
+        originalName: checkbox
+        matchMethod: positional
+  checkbox3:
+    type: instance
+    instanceOf: Checkbox
+    $extensions:
+      com.figma:
+        originalName: checkbox
+        matchMethod: positional
+  icon2:
+    type: glyph
+    $extensions:
+      com.figma:
+        matchMethod: unique             # "icon2" IS the original name
+  icon:
+    type: glyph
+    $extensions:
+      com.figma:
+        matchMethod: anchor-adjacent    # Adjacent to "icon2" anchor
+  icon3:
+    type: glyph
+    $extensions:
+      com.figma:
+        originalName: icon
+        matchMethod: anchor-adjacent
+```
+
+### Notes
+
+- **`matchMethod` extends, not replaces, `originalName`**: The two fields serve different purposes. `originalName` enables round-trip traceability (what was the Figma name?). `matchMethod` enables confidence assessment (how was cross-variant identity determined?). Both live under `com.figma` because both are Figma-processing provenance.
+- **Enum values are lowercase kebab-case**, consistent with the `FigmaPropExtension` source kind values (`variant`, `codeOnlyProp`). They are intentionally not `SCREAMING_CASE` — the constitution's screaming-case rule applies to "string literal union types used as enum values in `Styles` and its child types," not to extension metadata values.
+- **The pattern, not the field, is the precedent**: This ADR establishes that processing steps should embed their method signal in the output. Future candidates include:
+  - `props.$extensions["com.figma"].inferenceSource` — how a prop type was determined (`explicit`, `heuristic`, `code-only`)
+  - `anatomy.element.$extensions["com.figma"].detectionMethod` — how an element type was classified (`name-pattern`, `node-type`, `instance-analysis`)
+  - Each would be its own field with its own enum, evaluated independently — no generic framework required.
+- **Consumer guidance for LLMs**: An LLM consuming spec output can use `matchMethod` directly in its reasoning chain. Suggested prompt pattern: "Elements with `matchMethod: 'positional'` have weaker cross-variant identity — their diffs may reflect suffix instability rather than true design changes. Prefer trusting `'unique'` and `'anchor-adjacent'` elements when generating variant-conditional code."
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — one optional string field added to both the `AnatomyElement` type and schema definition, within the existing `$extensions["com.figma"]` object.
+- **Parity check**:
+  - `AnatomyElement.$extensions["com.figma"].matchMethod` (type) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/matchMethod` (schema)
+  - `MatchMethod` string literal union (type) ↔ `enum: [unique, anchor-adjacent, positional]` (schema)
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | **Medium** — Must emit `matchMethod` alongside disambiguation (ADR-044). The method is already known at assignment time — this is surfacing existing information, not computing new information | Emit `matchMethod` during Pass 2 of the global registry (ADR-044 §2) |
+| `specs-cli` | **Low** — Recompile against new types. May optionally surface `matchMethod` in diagnostic output | Recompile |
+| `specs-plugin-2` | **Low** — Recompile. May optionally highlight low-confidence elements in the UI | Recompile |
+
+### Implementation sequencing
+
+This ADR is designed to be implemented **concurrently with ADR-044** — in the same schema release and the same `specs-from-figma` implementation phase. The schema change is additive (one more field on the same `$extensions` object). The processing change is trivial: at the point where ADR-044's Pass 2 assigns a suffix, the algorithm already knows whether it used anchor-adjacent or positional matching — it simply records that decision.
+
+Recommended approach:
+1. **Schema**: Include `matchMethod` in the same `AnatomyElement.$extensions` addition as ADR-044's `originalName`. Ship both in a single MINOR release.
+2. **Processing**: Emit `matchMethod` during ADR-044's Phase B (disambiguation). No separate phase needed.
+3. **Testing**: Extend ADR-044's test cases to assert `matchMethod` values alongside disambiguated keys.
+
+---
+
+## Semver Decision
+
+**Version bump**: Included in ADR-044's `0.22.0` release (`MINOR`)
+
+**Justification**: One additional optional field within an already-new optional `$extensions` object. No existing fields modified. Per constitution III: "additive types or new optional fields → MINOR."
+
+---
+
+## Consequences
+
+- Spec output becomes **self-documenting** for disambiguation confidence — consumers can assess element key reliability without re-running the algorithm or inspecting the source Figma file
+- LLM consumers gain a structured signal for reasoning about variant diff trustworthiness
+- Diagnostic tools (plugin UI, CLI) can surface warnings specifically for `'positional'` elements, directing designer review to the cases most likely to mismatch
+- The `$extensions["com.figma"]` namespace on `AnatomyElement` now carries both traceability (`originalName`) and confidence (`matchMethod`) — a complete provenance record for disambiguation
+- **Pattern established**: Processing steps that resolve ambiguity should embed their method signal in the output. Future provenance fields follow the same approach — scoped field, named enum, within `$extensions["com.figma"]` on the relevant type — without requiring a generic framework
+- When a component has no duplicate names, zero overhead — no `$extensions`, no `matchMethod`, identical output to pre-ADR behavior

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 044 | Duplicate Layer Name Disambiguation | |
 | 043 | Custom Color Format Configuration | |
 | 042 | Composition as a First-Class Type | |
 | 041 | Layout Positioning — Constraint-Based Naming | |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 045 | Processing Provenance Signals | |
 | 044 | Duplicate Layer Name Disambiguation | |
 | 043 | Custom Color Format Configuration | |
 | 042 | Composition as a First-Class Type | |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
+
 ## [0.13.0] - 2026-05-06
 
 Adds configurable color output format (`config.format.color`) with nine options from hex strings to structured DTCG Color objects. Fixes EISDIR crash when outputDirectory targets a directory, and corrects config template URLs.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Command-line interface for Specs design system operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -5,13 +5,11 @@ All notable changes to the Specs schema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.21.0] - Unreleased
+## [0.22.0] - Unreleased
 
 ### Added
 
-### Changed
-
-### Removed
+- `AnatomyElement.$extensions` — typed as `Record<string, unknown>`; open-shape DTCG §5.2.3 passthrough for processing-package provenance metadata (e.g. duplicate-name disambiguation)
 
 
 ## [0.20.0] - 2026-05-06

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Specs schema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
+
 ## [0.20.0] - 2026-05-06
 
 Adds configurable color output format (`Config.format.color`) supporting nine format options from hex strings to structured DTCG Color objects. Renames `ColorValue` to `ColorObject` for specificity and widens `ColorStyle`, `Shadow.color`, and `GradientStop.color` to accept formatted color strings alongside structured objects and token references.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-schema",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Specs UI Component Schema - TypeScript types and JSON schema definitions for component specifications",
   "license": "CC-BY-4.0",
   "author": "Nathan Curtis <nathan@directededges.com>",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-schema",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Specs UI Component Schema - TypeScript types and JSON schema definitions for component specifications",
   "license": "CC-BY-4.0",
   "author": "Nathan Curtis <nathan@directededges.com>",

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -143,6 +143,11 @@
             }
           ],
           "description": "The component or component set name that this instance element references, or a subcomponent reference"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "DTCG §5.2.3 platform-specific extensions. Open-shape passthrough — processing packages may attach reverse-domain keys carrying provenance metadata. The schema does not constrain the inner structure.",
+          "additionalProperties": true
         }
       },
       "required": [

--- a/packages/schema/tests/Anatomy.test-d.ts
+++ b/packages/schema/tests/Anatomy.test-d.ts
@@ -89,3 +89,17 @@ if (typeof element.type === 'string') {
 } else {
   const _ref: string = element.type.$ref;
 }
+
+// ─── $extensions (ADR-044) ──────────────────────────────────────────────────
+
+// AnatomyElement.$extensions is optional
+const noExtensions: AnatomyElement = { type: 'glyph' };
+
+// AnatomyElement.$extensions is an open-shape passthrough — any reverse-domain key allowed
+const withExtensions: AnatomyElement = {
+  type: 'glyph',
+  $extensions: {
+    'com.figma': { originalName: 'icon', matchMethod: 'anchor-adjacent' },
+    'com.example': { anything: true, nested: { value: 1 } },
+  },
+};

--- a/packages/schema/types/Anatomy.ts
+++ b/packages/schema/types/Anatomy.ts
@@ -37,4 +37,12 @@ export type AnatomyElement = {
   detectedIn?: string;
   /** The component or component set name that this instance element references, or a subcomponent reference. */
   instanceOf?: string | SubcomponentRef;
+  /**
+   * DTCG §5.2.3 platform-specific extensions. Open-shape passthrough —
+   * processing packages (e.g. `specs-from-figma`) may attach reverse-domain
+   * keys (such as `'com.figma'`) carrying provenance metadata. The schema
+   * does not constrain the inner structure.
+   * @since 0.22.0
+   */
+  $extensions?: Record<string, unknown>;
 };

--- a/site/src/content/docs/schema/anatomy.md
+++ b/site/src/content/docs/schema/anatomy.md
@@ -16,6 +16,7 @@ type Anatomy = Record<string, AnatomyElement>;
 | `type` | `ElementType \| ElementTypeRef` | Yes | What kind of element this is |
 | `detectedIn` | `string` | No | Frame or node name where this element was found |
 | `instanceOf` | `string \| SubcomponentRef` | No | Component name this element is an instance of, or a `$ref` to a subcomponent |
+| `$extensions` | `Record<string, unknown>` | No | DTCG §5.2.3 platform-specific extensions. Open-shape passthrough — processing packages may attach reverse-domain keys (e.g. `'com.figma'`) carrying provenance metadata; the schema does not constrain the inner structure |
 
 ### ElementType
 
@@ -59,3 +60,4 @@ Within variants, each element's runtime properties (children, styles, content) a
 
 - [ADR 012 — Element Type References](https://github.com/DirectedEdges/specs/blob/main/adr/012-element-type-references.md) — widens `AnatomyElement.type` to support `$ref`-based external element type definitions
 - [ADR 030 — Subcomponent $ref for instanceOf](https://github.com/DirectedEdges/specs/blob/main/adr/030-subcomponent-refs.md) — adds `SubcomponentRef` to `instanceOf` on AnatomyElement and Element
+- [ADR 044 — Duplicate Layer Name Disambiguation](https://github.com/DirectedEdges/specs/blob/main/adr/044-duplicate-layer-disambiguation.md) — adds open-shape `$extensions` to `AnatomyElement` so processing packages can attach disambiguation provenance (e.g. `originalName`)


### PR DESCRIPTION
## Summary

- **ADR-044** (Duplicate Layer Name Disambiguation): Collision-safe numeric suffixes for duplicate Figma layer names, originalName extension for traceability, and a two-phase processing architecture (evaluation then disambiguation) with a five-level ordered heuristic chain (name, type, ancestry, anchor, sibling index)
- **ADR-045** (Processing Provenance Signals): matchMethod field on AnatomyElement extensions recording which heuristic resolved each element (unique, layer-type, ancestry, anchor-adjacent, sibling-index)
- Both ship together in schema 0.22.0 (MINOR — additive optional fields only)

## Test plan

- [ ] Review ADR-044 algorithm design and worked examples
- [ ] Review ADR-045 enum values align 1:1 with ADR-044 heuristic chain
- [ ] Confirm schema change is additive (MINOR) with no breaking changes
- [ ] Validate cross-references between ADR-044 and ADR-045 are consistent

Generated with [Claude Code](https://claude.com/claude-code)