### PR TITLE
Add issue templates and auto-label workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Report something that is not working correctly
+type: Bug
+labels: []
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Sub-project
+      description: Which part of Specs does this affect?
+      options:
+        - schema
+        - cli
+        - plugin
+        - generator
+        - demo
+        - testing
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's broken? Describe the issue from a user's perspective.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can someone reproduce this?
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. See ...
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What conditions must be met to consider this fixed?
+      placeholder: |
+        - [ ] ...
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Screenshots, environment info, or anything else relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+type: Feature
+labels: []
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Sub-project
+      description: Which part of Specs does this affect?
+      options:
+        - schema
+        - cli
+        - plugin
+        - generator
+        - demo
+        - testing
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: What should the feature look like from a user's perspective?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What conditions must be met?
+      placeholder: |
+        - [ ] ...
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Links, mockups, or related issues.

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,31 @@
+name: Auto-label from template
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply sub-project label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const match = body.match(/### Sub-project\s*\n\s*\n\s*(\w+)/);
+            if (!match) return;
+
+            const label = match[1].toLowerCase();
+            const valid = ['schema', 'cli', 'plugin', 'generator', 'demo', 'testing'];
+            if (!valid.includes(label)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label]
+            });


### PR DESCRIPTION
## Summary
- Bug report and feature request YAML form templates with sub-project dropdown
- Auto-label GitHub Actions workflow that applies the sub-project label on issue creation
- Template config enabling blank issues

All issues across the Specs ecosystem will now be tracked on this repo, with sub-project labels (schema, cli, plugin, generator, demo, testing) to indicate which area is affected.

## Test plan
- [ ] Create a test issue using each template — verify dropdown renders and type is set
- [ ] Verify auto-label workflow triggers and applies the correct sub-project label
- [ ] Verify blank issue creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)