### PR TITLE
fix(cli): default missing props to {} in split-concerns output (#84)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-05-08
+
+Patch fix for `--split-concerns` output shape.
+
+### Fixed
+
+- **`props` defaults to `{}` instead of `[]` when a component has no props (#84)** — `splitComponentByConcern` and `extractApiFromSubcomponents` were filling missing `props` with an empty array, producing output that violated the schema (`Props` is an object). Components like `egdsDivider` and `egdsSearchBarExperimental` now emit `props: {}`. The `ComponentApiData` and `SubcomponentApiData` interfaces are corrected to type `props` as `Record<string, any>`.
+
+
 ## [0.13.0] - 2026-05-06
 
 Adds configurable color output format (`config.format.color`) with nine options from hex strings to structured DTCG Color objects. Fixes EISDIR crash when outputDirectory targets a directory, and corrects config template URLs.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Command-line interface for Specs design system operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/Writers/DataTransformers.ts
+++ b/packages/cli/src/Writers/DataTransformers.ts
@@ -6,7 +6,7 @@
 export interface ComponentApiData {
   title: string;
   anatomy: any;
-  props: any[];
+  props: Record<string, any>;
   subcomponents?: Record<string, SubcomponentApiData>;
   metadata: any;
 }
@@ -17,7 +17,7 @@ export interface ComponentApiData {
 export interface SubcomponentApiData {
   title: string;
   anatomy: any;
-  props: any[];
+  props: Record<string, any>;
   metadata: any;
 }
 
@@ -57,10 +57,10 @@ export function splitComponentByConcern(data: Record<string, any>): {
   const api: ComponentApiData = {
     title: data.title,
     anatomy: data.anatomy,
-    props: data.props || [],
+    props: data.props || {},
     metadata: data.metadata
   };
-  
+
   // Handle subcomponents recursively for API
   if (data.subcomponents) {
     api.subcomponents = extractApiFromSubcomponents(data.subcomponents);
@@ -103,7 +103,7 @@ export function extractApiFromSubcomponents(
     const apiData: SubcomponentApiData = {
       title: data.title,
       anatomy: data.anatomy,
-      props: data.props || [],
+      props: data.props || {},
       metadata: data.metadata
     };
     

--- a/packages/cli/tests/unit/writers/DataTransformers.test.ts
+++ b/packages/cli/tests/unit/writers/DataTransformers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  splitComponentByConcern,
+  extractApiFromSubcomponents,
+} from '../../../src/Writers/DataTransformers';
+
+describe('splitComponentByConcern', () => {
+  it('defaults missing props to {} (regression #84)', () => {
+    const { api } = splitComponentByConcern({
+      title: 'egdsDivider',
+      anatomy: {},
+      metadata: {},
+    });
+    expect(api.props).toEqual({});
+    expect(Array.isArray(api.props)).toBe(false);
+  });
+
+  it('passes through props object when present', () => {
+    const props = { variant: { type: 'VARIANT', values: ['a', 'b'] } };
+    const { api } = splitComponentByConcern({
+      title: 'X',
+      anatomy: {},
+      props,
+      metadata: {},
+    });
+    expect(api.props).toBe(props);
+  });
+});
+
+describe('extractApiFromSubcomponents', () => {
+  it('defaults missing props on subcomponents to {} (regression #84)', () => {
+    const result = extractApiFromSubcomponents({
+      child: { title: 'child', anatomy: {}, metadata: {} },
+    });
+    expect(result?.child.props).toEqual({});
+    expect(Array.isArray(result?.child.props)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `splitComponentByConcern` and `extractApiFromSubcomponents` were filling missing `props` with `[]` instead of `{}`, producing output that violated the schema (`Props` is an object). Components with no Figma properties (e.g. `egdsDivider`, `egdsSearchBarExperimental`) now emit `props: {}`.
- Corrects `ComponentApiData` / `SubcomponentApiData` to type `props` as `Record<string, any>`.
- Bumps CLI to 0.13.1; adds regression tests for both helpers.

## Test plan

- [x] `npm test` in `packages/cli` — 176 passed (3 new)
- [x] `npm run build` succeeds
- [ ] Verify against a real `--split-concerns` run on a propless component

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)