### PR TITLE
chore(adr): reserve numbers 045-049 in INDEX

### DIFF
--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,12 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 044 | Duplicate Layer Name Disambiguation | |
+| 049 | Nested Slot Compositions | Recursion follow-on to ADR-047: fill nested instances' slots from a parent context (reserved, draft on `042-composition-type` branch) |
+| 048 | PropConfigurations PropBinding | Widen `PropConfigurations` value union to add `PropBinding` (reserved, draft on `042-composition-type` branch) |
+| 047 | Slot Content — Component.slotContent and SlotBinding | Add `Component.slotContent: Record<string, Composition>` + `SlotBinding` extending `PropBinding` with `$extensions['com.figma'].default` (reserved, draft on `042-composition-type` branch) |
+| 046 | Component Examples — InstanceExample and Component.examples | Add `InstanceExample` and `ComponentExamples`; add `Component.examples?` named record (reserved, draft on `042-composition-type` branch) |
+| 045 | Processing Provenance Signals | (reserved, draft in PR #60) |
+| 044 | Duplicate Layer Name Disambiguation | (reserved, draft in PR #60) |
 | 043 | Custom Color Format Configuration | |
 | 042 | Composition as a First-Class Type | |
 | 041 | Layout Positioning — Constraint-Based Naming | |


### PR DESCRIPTION
## Summary

Cherry-picks ADR numbers **045–049** in `adr/INDEX.md` so concurrent feature branches don't collide on numbering.

| # | Title | Source |
|---|-------|--------|
| 045 | Processing Provenance Signals | PR #60 (was missing from index) |
| 046 | Component Examples — InstanceExample and Component.examples | branch `042-composition-type` |
| 047 | Slot Content — Component.slotContent and SlotBinding | branch `042-composition-type` |
| 048 | PropConfigurations PropBinding | branch `042-composition-type` |
| 049 | Nested Slot Compositions | branch `042-composition-type` (stub; recursion follow-on to 047) |

## Why

The `042-composition-type` branch initially claimed 043–045 for new ADRs, but in the meantime main merged `043-custom-color-format-config` and PR #60 claimed 044/045. The `042-composition-type` branch has now been renumbered to 046–048 (plus 049 for the deferred recursion ADR), and PR #60 retains 044/045.

Reserving the numbers on main is the convention; this PR just catches up the index. No ADR files are added here — those live on their respective feature branches/PRs.

## Test plan

- [ ] Index entries render correctly in the docs site (if applicable)
- [ ] No other open PR is silently claiming 045–049
