### PR TITLE
Capture cross-repo closing refs in CLI and Schema release agents

### DIFF
--- a/.github/agents/CLI.release.agent.md
+++ b/.github/agents/CLI.release.agent.md
@@ -116,12 +116,15 @@ All commands in this agent run from the **CLI package directory**: `packages/cli
        ```bash
        git push --follow-tags
        ```
-    2. **Collect issue references** from PRs merged into this release branch since it diverged from main:
+    2. **Collect issue references** from both PR bodies and commit messages on this release branch since it diverged from main. Capture cross-repo refs (e.g. `DirectedEdges/specs-plugin-2#42`) as well as bare `#N` refs — required because closing trailers can live on commits that touch upstream issues in sibling repos, not just on PRs in this repo:
        ```bash
-       gh pr list --repo DirectedEdges/specs --base release/[branch-name] --state merged --json body --jq '.[].body' \
-         | grep -oiE '(closes|fixes|resolves) #[0-9]+' | sort -u
+       BRANCH=$(git branch --show-current)
+       {
+         gh pr list --repo DirectedEdges/specs --base "$BRANCH" --state merged --json body --jq '.[].body'
+         git log main.."$BRANCH" --pretty=%B
+       } | grep -oiE '(closes|fixes|resolves)[[:space:]]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+' | sort -fu
        ```
-       Append each unique `Closes #N` line to the PR body so issues auto-close when this PR merges to main.
+       Normalize each match to `Closes <ref>` (preserving any `owner/repo` prefix) and append one per line to the PR body so issues auto-close when this PR merges to main. Cross-repo refs require `owner/repo#N` — without that prefix GitHub won't reach the sibling repo's issue.
 
     3. Finalize the tracking PR. Step 0 opened a draft PR at the start; now mark it ready and update title/body:
        ```bash

--- a/.github/agents/Schema.release.agent.md
+++ b/.github/agents/Schema.release.agent.md
@@ -107,12 +107,15 @@ All commands in this agent run from the **schema package directory**: `packages/
       ```bash
       git push --follow-tags
       ```
-   2. **Collect issue references** from PRs merged into this release branch since it diverged from main:
+   2. **Collect issue references** from both PR bodies and commit messages on this release branch since it diverged from main. Capture cross-repo refs (e.g. `DirectedEdges/specs-plugin-2#42`) as well as bare `#N` refs — required because closing trailers can live on commits that touch upstream issues in sibling repos, not just on PRs in this repo:
       ```bash
-      gh pr list --repo DirectedEdges/specs --base release/[branch-name] --state merged --json body --jq '.[].body' \
-        | grep -oiE '(closes|fixes|resolves) #[0-9]+' | sort -u
+      BRANCH=$(git branch --show-current)
+      {
+        gh pr list --repo DirectedEdges/specs --base "$BRANCH" --state merged --json body --jq '.[].body'
+        git log main.."$BRANCH" --pretty=%B
+      } | grep -oiE '(closes|fixes|resolves)[[:space:]]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+' | sort -fu
       ```
-      Append each unique `Closes #N` line to the PR body so issues auto-close when this PR merges to main.
+      Normalize each match to `Closes <ref>` (preserving any `owner/repo` prefix) and append one per line to the PR body so issues auto-close when this PR merges to main. Cross-repo refs require `owner/repo#N` — without that prefix GitHub won't reach the sibling repo's issue.
 
    3. Finalize the tracking PR. Step 0 opened a draft PR at the start; now mark it ready and update title/body:
       ```bash


### PR DESCRIPTION
## Summary

Mirrors specs-plugin-2#103. The CLI and Schema release agents each collect `closes #N` / `fixes #N` / `resolves #N` refs from merged PR bodies and copy them into the release-to-main PR body so issues autoclose on merge. Two gaps:

- The regex only matched bare `#N`, dropping the `owner/repo` prefix needed for cross-repo refs (e.g. `DirectedEdges/specs-plugin-2#42`).
- The collector only scanned PR bodies, so closing trailers added directly to commit messages were invisible.

This change updates both agents to:
- Match `owner/repo#N` as well as `#N`.
- Pipe in `git log main..HEAD --pretty=%B` alongside PR bodies so commit-message trailers are captured.
- Normalize each match to `Closes <ref>` (preserving any cross-repo prefix) in the release PR body.

No runtime behavior change to the CLI or Schema packages.

## Test plan

- [ ] Dry-run the regex against a sample branch with cross-repo `Closes DirectedEdges/foo#N` trailers and confirm the prefix is preserved.
- [ ] Confirm bare `#N` from PR descriptions (e.g. "Fixes #58") still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
