### PR TITLE
release: @directededges/specs-cli v0.14.0

### DIFF
--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 044 | Duplicate Layer Name Disambiguation | |
 | 043 | Custom Color Format Configuration | |
 | 042 | Composition as a First-Class Type | |
 | 041 | Layout Positioning — Constraint-Based Naming | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
     },
     "../specs-from-figma": {
       "name": "@directededges/specs-from-figma",
-      "version": "0.14.0",
+      "version": "0.18.0",
       "license": "PolyForm-Internal-Use-1.0.0",
       "dependencies": {
-        "@directededges/specs-schema": "^0.17.0",
+        "@directededges/specs-schema": "^0.20.0",
         "fs-extra": "^11.3.3",
         "yaml": "^2.8.0"
       },
@@ -1745,11 +1745,11 @@
     },
     "packages/cli": {
       "name": "@directededges/specs-cli",
-      "version": "0.10.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@directededges/specs-from-figma": "^0.14.0",
-        "@directededges/specs-schema": "^0.17.0",
+        "@directededges/specs-from-figma": "^0.18.0",
+        "@directededges/specs-schema": "^0.20.0",
         "commander": "^11.1.0",
         "fs-extra": "^11.2.0",
         "tslib": "^2.6.2",
@@ -1765,6 +1765,12 @@
         "typescript": "^5.3.3",
         "vitest": "^3.0.0"
       }
+    },
+    "packages/cli/node_modules/@directededges/specs-schema": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@directededges/specs-schema/-/specs-schema-0.20.0.tgz",
+      "integrity": "sha512-6H3MZ7EEpMDOWprApTtZYodoooE40W42DOP1q1aNBpFKg35aBPykvFKAUcmK+k1iFxnmhP5Yx08HCtMM2rF5+Q==",
+      "license": "CC-BY-4.0"
     },
     "packages/cli/node_modules/@esbuild/aix-ppc64": {
       "version": "0.20.2",
@@ -2198,7 +2204,7 @@
     },
     "packages/schema": {
       "name": "@directededges/specs-schema",
-      "version": "0.17.0",
+      "version": "0.21.0",
       "license": "CC-BY-4.0",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
+
 ## [0.13.0] - 2026-05-06
 
 Adds configurable color output format (`config.format.color`) with nine options from hex strings to structured DTCG Color objects. Fixes EISDIR crash when outputDirectory targets a directory, and corrects config template URLs.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - Unreleased
+## [0.14.0] - 2026-05-15
 
-### Added
+Dependency-only release that picks up specs-from-figma 0.18.0. No CLI source changes.
 
-### Changed
+### Dependency updates
 
-### Removed
+- **@directededges/specs-from-figma 0.18.0** — Restores ~170 invalid variants previously dropped by the empty-variant filter, accounting for the bulk of test-round 0009 parity diffs. Fixes a `figma.mixed` Symbol crash on text nodes with mixed text styles. `TEXT` elements now emit explicit size styles (`width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight`); `GLYPH` elements now emit shadow/blur effects and aspect-ratio constraints alongside their fill color.
 
 ## [0.13.1] - 2026-05-08
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Command-line interface for Specs design system operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@directededges/specs-schema": "^0.20.0",
-    "@directededges/specs-from-figma": "^0.17.0",
+    "@directededges/specs-from-figma": "^0.18.0",
     "commander": "^11.1.0",
     "fs-extra": "^11.2.0",
     "yaml": "^2.3.4",

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Specs schema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
+
 ## [0.20.0] - 2026-05-06
 
 Adds configurable color output format (`Config.format.color`) supporting nine format options from hex strings to structured DTCG Color objects. Renames `ColorValue` to `ColorObject` for specificity and widens `ColorStyle`, `Shadow.color`, and `GradientStop.color` to accept formatted color strings alongside structured objects and token references.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-schema",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Specs UI Component Schema - TypeScript types and JSON schema definitions for component specifications",
   "license": "CC-BY-4.0",
   "author": "Nathan Curtis <nathan@directededges.com>",

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -16,6 +16,8 @@ export default defineConfig({
       },
       components: {
         SocialIcons: './src/components/SocialIcons.astro',
+        ThemeSelect: './src/components/ThemeSelect.astro',
+        Sidebar: './src/components/Sidebar.astro',
       },
       customCss: ['./src/custom.css'],
       head: [

--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -1,0 +1,68 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
+import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
+
+const GITHUB_URL = 'https://github.com/DirectedEdges/specs';
+const FIGMA_PLUGIN_URL = 'https://www.figma.com/community/plugin/1549454283615386215/specs-2-formerly-anova';
+const GITHUB_PATH = 'M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57L9 21.07c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.09-.73.09-.73 1.2.09 1.83 1.24 1.83 1.24 1.08 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.64 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.8 5.63-5.48 5.92.42.36.81 1.1.81 2.22l-.01 3.29c0 .31.2.69.82.57A12 12 0 0 0 12 .3Z';
+const FIGMA_PATH = 'M47.7206 95.4082C29.9906 95.4082 15.6176 109.776 15.6176 127.5C15.6176 145.224 29.9906 159.592 47.7206 159.592H80.6912V127.5V95.4082H47.7206ZM128.412 79.7959L129.279 79.7959C147.009 79.7959 161.382 65.4279 161.382 47.7041C161.382 29.9802 147.009 15.6122 129.279 15.6122H96.3088V79.7959L128.412 79.7959ZM155.448 87.602C168.429 79.0765 177 64.3908 177 47.7041C177 21.3578 155.635 0 129.279 0H96.3088H88.5H80.6912H47.7206C21.3652 0 0 21.3578 0 47.7041C0 64.3908 8.57068 79.0765 21.5515 87.602C8.57068 96.1276 0 110.813 0 127.5C0 144.187 8.57067 158.872 21.5515 167.398C8.57067 175.923 0 190.609 0 207.296C0 233.697 21.6358 255 47.9363 255C74.4764 255 96.3088 233.503 96.3088 206.862V175.204V167.398V162.796C104.785 170.505 116.05 175.204 128.412 175.204H129.279C155.635 175.204 177 153.846 177 127.5C177 110.813 168.429 96.1276 155.448 87.602ZM129.279 95.4082L128.412 95.4082C110.682 95.4082 96.3088 109.776 96.3088 127.5C96.3088 145.224 110.682 159.592 128.412 159.592H129.279C147.009 159.592 161.382 145.224 161.382 127.5C161.382 109.776 147.009 95.4082 129.279 95.4082ZM15.6176 207.296C15.6176 189.572 29.9906 175.204 47.7206 175.204H80.6912V206.862C80.6912 224.771 65.9608 239.388 47.9363 239.388C30.1515 239.388 15.6176 224.965 15.6176 207.296ZM80.6912 79.7959H47.7206C29.9906 79.7959 15.6176 65.4279 15.6176 47.7041C15.6176 29.9802 29.9906 15.6122 47.7206 15.6122H80.6912V79.7959Z';
+
+const { sidebar } = Astro.props;
+---
+
+<ul class="sidebar-top-links top-level">
+	<li>
+		<a href={GITHUB_URL} class="large" rel="me" target="_blank">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" class="sidebar-top-icon"><path d={GITHUB_PATH} /></svg>
+			GitHub
+		</a>
+	</li>
+	<li>
+		<a href={FIGMA_PLUGIN_URL} class="large" rel="me" target="_blank">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 187 265" fill="currentColor" aria-hidden="true" class="sidebar-top-icon figma-nav-icon"><path fill-rule="evenodd" clip-rule="evenodd" d={FIGMA_PATH} /></svg>
+			Figma Plugin
+		</a>
+	</li>
+</ul>
+
+<SidebarPersister {...Astro.props}>
+	<SidebarSublist sublist={sidebar} />
+</SidebarPersister>
+
+<div class="md:sl-hidden">
+	<MobileMenuFooter {...Astro.props} />
+</div>
+
+<style>
+	.sidebar-top-links {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+	.sidebar-top-links li {
+		margin: 0;
+	}
+	.sidebar-top-links a {
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+		font-size: var(--sl-text-sm);
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+		padding: calc(0.2em + 5.2px) var(--sl-sidebar-item-padding-inline, 0.5rem);
+	}
+	.sidebar-top-links a:hover,
+	.sidebar-top-links a:focus {
+		color: var(--sl-color-white);
+	}
+	.sidebar-top-icon {
+		width: 1rem;
+		height: 1rem;
+		flex-shrink: 0;
+	}
+	.figma-nav-icon {
+		width: calc(1rem * 187 / 265);
+	}
+</style>

--- a/site/src/components/ThemeSelect.astro
+++ b/site/src/components/ThemeSelect.astro
@@ -1,0 +1,9 @@
+---
+// Force dark theme, hide the theme toggle.
+---
+<script is:inline>
+	document.documentElement.dataset.theme = 'dark';
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('starlight-theme', 'dark');
+	}
+</script>

--- a/site/src/content/docs/overview/licensing.md
+++ b/site/src/content/docs/overview/licensing.md
@@ -45,6 +45,42 @@ From your Polar dashboard you can:
 - Purchase top-off generation packs
 - Download invoices
 
+## Team Licensing
+
+Teams can purchase a single subscription that covers multiple seats, with volume discounts that apply automatically at checkout:
+
+| Team size | Discount |
+|-----------|----------|
+| 1–4 seats | None (standard Pro price) |
+| 5–9 seats | 10% off |
+| 10+ seats | 20% off |
+
+Each seat is functionally identical to an individual Pro subscription: when a team member claims their seat, they receive their own plugin and CLI key pair by email, activated and managed the same way as any other Pro subscriber.
+
+### Purchasing and managing seats
+
+A team subscription is purchased by an administrator, who becomes the owner of the subscription and the only person who can adjust it. Seats are managed by email address — the administrator enters each team member's email individually, and Polar sends that person an invitation to claim their seat.
+
+Seats are managed **one at a time** rather than via bulk import or CSV upload. The administrator adds, removes, or reassigns seats individually through the Polar customer portal.
+
+### Claiming a seat
+
+When a team member is invited, they receive an email with a link to claim their seat. **Invitations must be claimed within 24 hours** — after that the invitation expires and the administrator needs to re-send it from the portal. Once claimed, the team member receives their own plugin and CLI keys and activates them like any individual Pro subscriber.
+
+A seat that hasn't been claimed yet still counts toward the subscription's seat total and is billed normally. Administrators can revoke a pending invitation and reassign the seat to a different email at any time.
+
+### Adjusting your subscription
+
+Administrators manage everything from the Polar customer portal — the same portal used for any Pro subscription. From the portal, the administrator can:
+
+- Add new seats or remove existing ones
+- See which seats are claimed and by whom
+- Revoke a seat from a team member who has left
+- Re-send an expired invitation
+- Update payment method, download invoices, and cancel the subscription
+
+The total seat count can be adjusted up or down at any time. Changes are **prorated** on month-to-month invoices — adding a seat mid-cycle adds a partial charge for the remaining days, and removing a seat issues a partial credit applied to the next invoice. The volume discount tier is re-evaluated whenever the seat count crosses a threshold (for example, going from 4 to 5 seats activates the 10% discount on the next invoice).
+
 ## Free vs Pro
 
 ### Free

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -11,50 +11,54 @@ type Styles = Partial<{ /* 48 properties */ }>;
 
 ## Properties
 
-| Name | Category | Evaluated For |
-|------|----------|---------------|
-| `aspectRatio` | size | container, slot, rectangle, text, vector, ellipse, star, polygon |
-| `backgroundColor` | color | container, slot, rectangle |
-| `clipContent` | visibility | container, slot |
-| `cornerRadius` | border | container, slot |
-| `cornerSmoothing` | border | container, rectangle, vector, ellipse, star, polygon |
-| `crossAxisAlignment` | layout | container |
-| `effects` | effects | container, slot, rectangle, text, vector, ellipse, star, polygon, line |
-| `fillColor` | color | glyph, vector, ellipse, star, polygon, line |
-| `height` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon |
-| `itemReverseZIndex` | layout | container |
-| `itemSpacing` | spacing | container |
-| `layoutMode` | layout | container |
-| `position` | layout | all |
-| `top` | position | all |
-| `bottom` | position | all |
-| `start` | position | all |
-| `end` | position | all |
-| `centerHorizontalOffset` | position | all |
-| `centerVerticalOffset` | position | all |
-| `layoutSizingHorizontal` | layout | all |
-| `layoutSizingVertical` | layout | all |
-| `locked` | visibility | all |
-| `maxHeight` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon, line |
-| `maxWidth` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon, line |
-| `minHeight` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon, line |
-| `minWidth` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon, line |
-| `opacity` | visibility | all |
-| `padding` | spacing | container |
-| `mainAxisAlignment` | layout | container |
-| `primaryAxisSizingMode` | layout | container |
-| `rotation` | transform | all |
-| `strokeAlign` | border | container, rectangle, vector, ellipse, star, polygon, line |
-| `strokes` | color | container, rectangle, vector, ellipse, star, polygon, line |
-| `strokeWeight` | border | container, rectangle, vector, ellipse, star, polygon, line |
-| `textAlignHorizontal` | text | text |
-| `textAlignVertical` | text | text |
-| `textColor` | color | text |
-| `typography` | text | text |
-| `visible` | visibility | all |
-| `width` | size | container, slot, rectangle, glyph, vector, ellipse, star, polygon, line |
-| `wrap` | layout | container |
-| `wrapAlignment` | layout | container |
+Combined view: every style property, grouped by category and then by name, with the element-type categories it is evaluated for. `container` covers `COMPONENT`/`FRAME`/`SLOT`/`INSTANCE`; `vectors` covers `RECTANGLE`/`VECTOR`/`ELLIPSE`/`STAR`/`POLYGON`; `text`, `glyph`, and `line` cover their like-named element types.
+
+| Category | Name | container | text | glyph | vectors | line |
+|----------|------|-----------|------|-------|---------|------|
+| Border | `cornerRadius` | ✓ |  |  |  |  |
+| Border | `cornerSmoothing` | ✓ |  |  | ✓ |  |
+| Border | `strokeAlign` | ✓ |  |  | ✓ | ✓ |
+| Border | `strokeWeight` | ✓ |  |  | ✓ | ✓ |
+| Color | `backgroundColor` | ✓ |  |  | ✓ |  |
+| Color | `fillColor` |  |  | ✓ | ✓ | ✓ |
+| Color | `strokes` | ✓ |  |  | ✓ | ✓ |
+| Color | `textColor` |  | ✓ |  |  |  |
+| Effects | `effects` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `bottom` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `centerHorizontalOffset` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `centerVerticalOffset` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `end` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `layoutSizingHorizontal` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `layoutSizingVertical` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `position` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `start` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (child) | `top` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Layout (parent) | `crossAxisAlignment` | ✓ |  |  |  |  |
+| Layout (parent) | `itemReverseZIndex` | ✓ |  |  |  |  |
+| Layout (parent) | `layoutMode` | ✓ |  |  |  |  |
+| Layout (parent) | `mainAxisAlignment` | ✓ |  |  |  |  |
+| Layout (parent) | `primaryAxisSizingMode` | ✓ |  |  |  |  |
+| Layout (parent) | `wrap` | ✓ |  |  |  |  |
+| Layout (parent) | `wrapAlignment` | ✓ |  |  |  |  |
+| Size | `aspectRatio` | ✓ | ✓ | ✓ | ✓ |  |
+| Size | `height` | ✓ | ✓ | ✓ | ✓ |  |
+| Size | `maxHeight` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Size | `maxWidth` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Size | `minHeight` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Size | `minWidth` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Size | `width` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Spacing | `itemSpacing` | ✓ |  |  |  |  |
+| Spacing | `padding` | ✓ |  |  |  |  |
+| Text | `textAlignHorizontal` |  | ✓ |  |  |  |
+| Text | `textAlignVertical` |  | ✓ |  |  |  |
+| Text | `typography` |  | ✓ |  |  |  |
+| Transform | `rotation` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Visibility | `clipContent` | ✓ |  |  |  |  |
+| Visibility | `locked` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Visibility | `opacity` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Visibility | `visible` | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+**Note on the `vectors` column.** This column unions `RECTANGLE` with the vector-family element types (`VECTOR`, `ELLIPSE`, `STAR`, `POLYGON`), which share most styling but split on color: `backgroundColor` is evaluated only for `RECTANGLE`, while `fillColor` is evaluated only for the vector family. Both show ✓ under `vectors` here, but a given element of one subtype will only honor one or the other.
 
 ## Key Mapping from Figma
 

--- a/site/src/custom.css
+++ b/site/src/custom.css
@@ -1,3 +1,65 @@
+/* ── Layout overrides ── */
+
+/* 2× page padding and nav–content gutter at wide viewports */
+@media (min-width: 72rem) {
+	/* Content area padding */
+	.content-panel {
+		padding-left: 3rem !important;
+		padding-right: 3rem !important;
+	}
+	/* Top nav bar padding */
+	.header {
+		padding-left: 3rem !important;
+		padding-right: 3rem !important;
+		gap: 3rem !important;
+	}
+	/* Nav–content gutter */
+	.main-pane {
+		--sl-nav-gap: 3rem;
+	}
+}
+
+/* Remove distinct surface color and borders from nav/sidebar */
+.header,
+nav.sidebar {
+	background-color: var(--sl-color-bg) !important;
+}
+.sidebar-pane {
+	background-color: var(--sl-color-bg) !important;
+}
+/* Remove all divider borders */
+.header {
+	border-bottom-color: transparent !important;
+}
+.sidebar-pane {
+	border-inline-end-color: transparent !important;
+}
+.content-panel + .content-panel {
+	border-top-color: transparent !important;
+}
+.sidebar-content ul ul {
+	border-inline-start-color: transparent !important;
+}
+
+/* +4px spacing between left nav items */
+.sidebar-content li {
+	margin-top: calc(0.75rem + 4px);
+}
+.sidebar-content ul ul li {
+	margin-top: 0;
+}
+
+/* +2px padding within each left nav item (default 0.2em → 8px) */
+.sidebar-content {
+	--sl-sidebar-item-padding-inline: calc(0.5rem + 2px);
+}
+.sidebar-content a {
+	padding-block: calc(0.2em + 5.2px);
+}
+.sidebar-content .group-label {
+	padding-block: calc(0.3em + 2px);
+}
+
 /* Make top-level sidebar links match the style of links inside accordions */
 ul.top-level > li > a.large {
 	font-size: var(--sl-text-sm);
@@ -63,9 +125,9 @@ ul.top-level > li > a.large[aria-current='page']:focus {
 	background-color: var(--sl-color-text-accent);
 }
 
-/* Gap between header social links */
-.social-link + .social-link {
-	margin-left: 0.75rem;
+/* Hide social links in header (moved to sidebar) */
+.social-icons {
+	display: none !important;
 }
 
 /* Site title in top nav bar — neutral instead of accent-colored */


### PR DESCRIPTION
## Summary
- Release @directededges/specs-cli v0.14.0
- Compatible with @directededges/specs-schema ^0.20.0 and @directededges/specs-from-figma ^0.18.0
- Dependency-only release picking up specs-from-figma 0.18.0; no CLI source changes
- See packages/cli/CHANGELOG.md for details

Note: this branch also carries the `chore: start @directededges/specs-schema v0.21.0 development` scaffolding commit. Schema 0.21.0 is not being released in this cycle (no source changes since 0.20.0).