### PR TITLE
fix(cli): generate a v2 markdown table and honors escaped pipes

### DIFF
--- a/openspec/changes/generate-v2-manifest-support/.openspec.yaml
+++ b/openspec/changes/generate-v2-manifest-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/generate-v2-manifest-support/design.md
+++ b/openspec/changes/generate-v2-manifest-support/design.md
@@ -1,0 +1,130 @@
+## Context
+
+`specs scan` and `specs generate` form the documented pipeline for turning Figma data into structured specs:
+
+```
+fetch → scan → generate
+         │       │
+         │       └─ reads {alias}.manifest.md
+         └─ writes {alias}.manifest.md
+```
+
+The scan writer was migrated to a v2 table format. The generate reader was not. As a result, the documented round-trip fails on a fresh project.
+
+Today's state of the parsing utilities:
+
+```
+packages/cli/src/utilities/
+├── ManifestParser.ts          v1 only. checkbox-list. legacy.
+├── ManifestParserV2.ts        v2 only. table. ScanCommand already uses it.
+└── ManifestMigrationV1ToV2.ts isolated legacy adapter, has a DELETE-WHEN
+                               comment for when v1 disappears entirely.
+```
+
+`ScanCommand` already routes between v1 and v2 (via `ManifestMigrationV1ToV2`) when reading an existing manifest. `GenerateCommand` does not — it has a single inline check `trimmed.includes('- [')` and a single `ManifestParser.parse()` call.
+
+Constraint: the project explicitly designs `ManifestMigrationV1ToV2.ts` as an isolated legacy module so v1 can be deleted mechanically later. Any new code should preserve that property — v1-specific knowledge should not leak into new call sites.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `specs generate` accepts a v2 manifest as a valid source format.
+- `specs generate` continues to accept v1 manifests and JSON files unchanged.
+- v2 component names containing `\|` round-trip correctly through `scan → generate`.
+- v1 support remains structured as a single deletable branch.
+- Public types of `ManifestParserV2` (`ManifestRowV2`, `ManifestMetadataV2`, `ManifestResultV2`) are unchanged.
+
+**Non-Goals:**
+
+- Removing or deprecating v1 manifests.
+- Changing the v2 manifest emitter in `ScanCommand`.
+- Unifying `ManifestParser` and `ManifestParserV2` behind a common interface or façade.
+- Expanding the `DevStatus` enum (today's `ROW_REGEX` hard-codes `READY_FOR_DEV|NONE`; that constraint is preserved here and tracked separately).
+- Verifying downstream consumers via `npm pack` — release/consumer concern.
+
+## Decisions
+
+### D1. Dispatch lives in `GenerateCommand`, not behind a façade
+
+`GenerateCommand` will detect source format and pick the parser directly:
+
+```
+read sourceContent
+├─ starts with '{'              → JSON mode
+├─ ManifestParserV2.isV2(c)     → v2 manifest mode
+├─ isV1Manifest(c)              → v1 manifest mode
+└─ else                         → error (unchanged message + exit code)
+```
+
+**Alternatives considered:**
+
+- _Façade on `ManifestParserV2` exposing `isManifest()` + unified `parse()`._ Rejected: it grows the public API, requires `ManifestParserV2` to import v1 helpers, and breaks the "isolated legacy" property of `ManifestMigrationV1ToV2.ts`. When v1 is removed, a façade has to be unwound; an explicit `if` branch in `GenerateCommand` is one-line deletion.
+- _Unified `ManifestResult` type across v1/v2._ Rejected: `GenerateCommand` consumes only `{ id, name, included }` and `metadata.file`, which both shapes already satisfy. No unifying type is needed; coupling shapes now would just create migration drag later.
+
+### D2. v2 row parsing: separate recognition from extraction
+
+Current `ManifestParserV2.ROW_REGEX` does both in one regex:
+
+```
+/^\|\s*\[([x ])\]\s*\|\s*(.+?)\s*\|\s*(\d+:\d+)\s*\|\s*(COMPONENT_SET|COMPONENT)\s*\|\s*(READY_FOR_DEV|NONE)\s*\|/i
+```
+
+It cannot honor escaped pipes — `(.+?)` stops at the first literal `|` regardless of a preceding `\`.
+
+The new approach:
+
+```
+1. Recognition (cheap regex):
+   line matches /^\|\s*\[[x ]\]\s*\|/
+
+2. Extraction (character walker):
+   walk between outer '|'s, treating '\|' as part of the cell.
+   trim each cell. replaceAll('\\|', '|') on the trimmed cell.
+   → cells: [checkbox, name, id, type, devStatus]
+
+3. Validation:
+   id matches /^\d+:\d+$/
+   type ∈ {COMPONENT, COMPONENT_SET}
+   devStatus ∈ {READY_FOR_DEV, NONE}
+   rows that fail validation are skipped (matches today's silent-skip behavior).
+```
+
+**Alternatives considered:**
+
+- _Extend `ROW_REGEX` with a negative-lookbehind for `\`._ Rejected: hard to read, hard to extend if a second escape ever appears, and JS regex engines vary in lookbehind support across runtimes the CLI targets.
+- _Pull in a markdown table parser dependency._ Rejected: adds a runtime dep for one trivial parsing concern; the input format is fully controlled by `ScanCommand`.
+
+### D3. Public shape of `ManifestParserV2.parse()` does not change
+
+Same return type, same fields, same semantics for valid rows. Only the row-extraction internals change. Existing tests of the parse output must continue to pass.
+
+### D4. Error path and exit codes preserved
+
+`GenerateCommand` keeps:
+
+- the same error message `Error: Unrecognized source format. Expected JSON file or markdown manifest.`
+- the same exit code `ERROR_CODES.INVALID_ARGS`
+- the same verbose mode label (`Mode: ${isManifest ? 'manifest' : 'file'}`) — `isManifest` becomes "v1 OR v2".
+
+## Risks / Trade-offs
+
+- **Risk:** A v2 manifest with no recognizable rows would now produce an empty `components` array and `GenerateCommand` already errors on that with `No components found in manifest`. → Mitigation: behavior matches the current v1 case; no change needed.
+- **Risk:** Hardening the row extractor could change which rows are accepted vs silently dropped at the margins (e.g., trailing whitespace, missing dev-status column). → Mitigation: keep the validation set identical to today's regex (id pattern, type enum, devStatus enum); only the _splitting_ changes. Add unit tests pinning the accept/reject set.
+- **Risk:** Future `DevStatus` values silently drop rows. → Mitigation: out of scope for this change, but documented here. Followup change should make the enum the single source of truth.
+- **Trade-off:** Two `if` branches in `GenerateCommand` (v1, v2) instead of a single façade call. Slightly more lines at the call site, in exchange for a one-line deletion when v1 is dropped.
+- **Trade-off:** Character-walking splitter is more code than a regex, but it's the smallest correct implementation for the escape rule `ScanCommand` already emits.
+
+## Migration Plan
+
+No data migration. The change is read-side compatible:
+
+- existing v1 manifests on disk continue to work
+- existing v2 manifests on disk start working with `generate`
+- no config flag, no opt-in
+
+Rollback is a straight revert; manifests on disk are unaffected.
+
+## Open Questions
+
+None. v1 retention is decided (kept). Escape handling is decided (in-scope).

--- a/openspec/changes/generate-v2-manifest-support/proposal.md
+++ b/openspec/changes/generate-v2-manifest-support/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`specs scan` emits a v2 markdown table manifest, but `specs generate` only detects the legacy v1 checkbox-list format (`- [`) and fails with `Error: Unrecognized source format. Expected JSON file or markdown manifest.` The codebase already ships `ManifestParserV2` with `isV2()` and `parse()` — `GenerateCommand` was never wired to it, so the documented `scan && generate` round-trip is broken out of the box.
+
+A latent secondary defect: even when `ManifestParserV2.parse()` is invoked, its single combined `ROW_REGEX` cannot honor escaped pipes (`\|`) inside component names. `ScanCommand` already escapes them via `escapeCell`, so the read side must be capable of round-tripping them.
+
+## What Changes
+
+- `specs generate` recognizes v2 manifests (table form, `**Scan format version:** 2`) as a valid source format, in addition to JSON files and v1 manifests.
+- `specs generate` dispatches parsing to `ManifestParserV2` for v2 manifests and to `ManifestParser` for v1 manifests; JSON mode is unchanged.
+- v1 manifests remain accepted input. Deprecation is out of scope.
+- `ManifestParserV2` row parsing is hardened to honor `\|` escapes inside cell content, so a component name like `Toggle | On/Off` round-trips through `scan → generate`.
+- The public `{ components, metadata }` shape of `ManifestParserV2.parse()` is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `generate-source-formats`: The contract for what source formats `specs generate` accepts (JSON file, v2 markdown manifest, v1 markdown manifest), how they are detected, and the requirement that the v2 manifest parser correctly handles escaped pipes inside component names.
+
+### Modified Capabilities
+
+<!-- none — no prior specs in openspec/specs/ -->
+
+## Impact
+
+- **Code**:
+  - `packages/cli/src/commands/GenerateCommand.ts` — replace `trimmed.includes('- [')` detection; route to v2 or v1 parser.
+  - `packages/cli/src/utilities/ManifestParserV2.ts` — replace combined row regex with recognition regex + escape-aware splitter; preserve the public result shape.
+- **Tests**:
+  - `packages/cli/tests/unit/utilities/ManifestParserV2.test.ts` — add escaped-pipe row coverage.
+  - `packages/cli/tests/unit/commands/GenerateCommand.test.ts` — add v2 manifest end-to-end; preserve v1 and JSON regressions.
+- **APIs**: no public type changes. `ManifestParserV2.parse()` keeps the same return shape; `ManifestParser` is untouched.
+- **Dependencies**: none.
+- **Out of scope**: removing v1, changing `ScanCommand` output format, expanding `DevStatus` enum, `npm pack`/downstream verification.

--- a/openspec/changes/generate-v2-manifest-support/specs/generate-source-formats/spec.md
+++ b/openspec/changes/generate-v2-manifest-support/specs/generate-source-formats/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Generate accepts JSON file sources
+
+The `specs generate` command SHALL accept a JSON file as a source. JSON mode is identified by the trimmed source content starting with `{`.
+
+#### Scenario: JSON source is recognized
+
+- **WHEN** the source file content (after trimming leading whitespace) starts with `{`
+- **THEN** `specs generate` processes the file in JSON mode without printing the unrecognized-source error
+
+#### Scenario: JSON mode still requires --component
+
+- **WHEN** a JSON source is provided without `--component`
+- **THEN** `specs generate` exits with the existing JSON-mode argument error and a non-zero exit code
+
+### Requirement: Generate accepts v2 markdown manifests
+
+The `specs generate` command SHALL accept a v2 markdown manifest as a source. A v2 manifest is identified by `ManifestParserV2.isV2(content)` returning true (presence of `**Scan format version:** N` where `N >= 2`).
+
+#### Scenario: v2 manifest emitted by scan round-trips through generate
+
+- **WHEN** `specs scan` produces a v2 manifest at `{dataDirectory}/{alias}.manifest.md` and `specs generate` is invoked with no `--source` argument
+- **THEN** `specs generate` loads the manifest, prints `✓ Loaded manifest: N components (M selected)`, and proceeds to generation
+- **AND** `specs generate` does NOT print `Error: Unrecognized source format. Expected JSON file or markdown manifest.`
+
+#### Scenario: v2 manifest with zero selected components
+
+- **WHEN** a valid v2 manifest is provided but no row has `[x]`
+- **THEN** `specs generate` exits with `Error: No components selected in manifest (none have [x])` and a non-zero exit code
+
+### Requirement: Generate accepts v1 markdown manifests
+
+The `specs generate` command SHALL continue to accept v1 (legacy checkbox-list) markdown manifests as a source. A v1 manifest is identified by `isV1Manifest(content)` returning true (no `**Scan format version:**` header AND at least one line matching `- [x]` or `- [ ]`).
+
+#### Scenario: Legacy v1 manifest still parses and generates
+
+- **WHEN** a v1 manifest with `- [x] Name (id, COMPONENT_SET)` lines is provided as a source
+- **THEN** `specs generate` loads the manifest and proceeds to generation with the same `✓ Loaded manifest` output as v2
+
+### Requirement: Generate rejects unrecognized source formats
+
+When a source file is neither JSON, a v2 manifest, nor a v1 manifest, `specs generate` SHALL exit with the existing error message and exit code.
+
+#### Scenario: Plain text file is rejected
+
+- **WHEN** a source file is provided whose content is neither JSON nor a recognizable manifest
+- **THEN** `specs generate` prints `Error: Unrecognized source format. Expected JSON file or markdown manifest.` and exits with `ERROR_CODES.INVALID_ARGS`
+
+### Requirement: v2 manifest parser honors escaped pipes in cell content
+
+The v2 manifest parser SHALL treat the two-character sequence `\|` inside a table cell as a literal `|` belonging to that cell, NOT as a column separator. After splitting a row into cells, each cell SHALL have `\|` replaced with `|` and surrounding whitespace trimmed.
+
+#### Scenario: Component name with an escaped pipe round-trips
+
+- **WHEN** a v2 manifest row is `| [x] | Toggle \| On/Off | 99:1 | COMPONENT | NONE |`
+- **THEN** `ManifestParserV2.parse()` produces a component with `name === 'Toggle | On/Off'`, `id === '99:1'`, `type === 'COMPONENT'`, `included === true`
+
+#### Scenario: Names without pipes are unaffected
+
+- **WHEN** a v2 manifest row is `| [x] | .base button | 12719:50050 | COMPONENT_SET | NONE |`
+- **THEN** `ManifestParserV2.parse()` produces a component with `name === '.base button'` (no spurious escape handling artifacts)
+
+### Requirement: v2 manifest parser public shape is stable
+
+`ManifestParserV2.parse(content)` SHALL return an object with the existing `ManifestResultV2` shape: `components: ManifestRowV2[]` and `metadata: ManifestMetadataV2`. No fields are added, removed, or renamed by this change.
+
+#### Scenario: Result shape is preserved
+
+- **WHEN** `ManifestParserV2.parse()` is called on any valid v2 manifest
+- **THEN** the returned object has exactly the keys `components` and `metadata`
+- **AND** each entry of `components` has exactly the keys `id`, `name`, `type`, `included`, `devStatus`
+- **AND** `metadata` has the keys `scanFormatVersion` and optionally `file`, `variables`, `fileLastModified`

--- a/openspec/changes/generate-v2-manifest-support/tasks.md
+++ b/openspec/changes/generate-v2-manifest-support/tasks.md
@@ -1,0 +1,29 @@
+## 1. ManifestParserV2 — escape-aware row parsing
+
+- [x] 1.1 Replace the combined `ROW_REGEX` with a cheap recognition regex matching `^\|\s*\[[x ]\]\s*\|` plus a separate character-walking row splitter that treats `\|` as part of the cell.
+- [x] 1.2 After splitting, trim each cell and `replaceAll('\\|', '|')`; validate `id` matches `\d+:\d+`, `type ∈ {COMPONENT, COMPONENT_SET}`, `devStatus ∈ {READY_FOR_DEV, NONE}`; skip rows that fail validation (matches current behavior).
+- [x] 1.3 Keep the public `ManifestResultV2`, `ManifestRowV2`, `ManifestMetadataV2` shapes unchanged. Do not export the new splitter from the package surface.
+- [x] 1.4 Add a failing unit test in `packages/cli/tests/unit/utilities/ManifestParserV2.test.ts` for `| [x] | Toggle \| On/Off | 99:1 | COMPONENT | NONE |` → name `Toggle | On/Off`. Confirm it fails against the current parser.
+- [x] 1.5 Implement 1.1–1.3 until 1.4 passes; confirm all existing `ManifestParserV2` tests still pass.
+
+## 2. GenerateCommand — v2/v1 detection and routing
+
+- [x] 2.1 In `packages/cli/src/commands/GenerateCommand.ts`, import `ManifestParserV2` and `isV1Manifest` from `../utilities/ManifestParserV2.js` and `../utilities/ManifestMigrationV1ToV2.js`.
+- [x] 2.2 Replace `const isManifest = trimmed.includes('- [');` with detection that sets `isJson`, `isV2Manifest`, `isV1ManifestSrc`, and a derived `isManifest = isV2Manifest || isV1ManifestSrc`.
+- [x] 2.3 Preserve the existing `Error: Unrecognized source format. Expected JSON file or markdown manifest.` message and `ERROR_CODES.INVALID_ARGS` exit code for the `!isManifest && !isJson` branch.
+- [x] 2.4 In the manifest branch, replace the `ManifestParser.parse(sourceContent)` call with a conditional: `isV2Manifest ? ManifestParserV2.parse(sourceContent) : ManifestParser.parse(sourceContent)`. Downstream code (`components.filter(c => c.included)`, `metadata.file`, success log line) is unchanged.
+- [x] 2.5 Preserve the existing verbose-mode log (`[CLI] Mode: ${isManifest ? 'manifest' : 'file'}`).
+
+## 3. Command-level tests
+
+- [x] 3.1 In `packages/cli/tests/unit/commands/GenerateCommand.test.ts`, add a test that runs `generate` against a v2 manifest fixture and asserts the success path (no unrecognized-source error, components loaded).
+- [x] 3.2 Add a regression test that v1 manifests still parse and generate.
+- [x] 3.3 Add a regression test that JSON source mode still works and still requires `--component`.
+- [x] 3.4 Add a test that an unrecognized source still prints the existing error and exits with `ERROR_CODES.INVALID_ARGS`.
+
+## 4. Validation
+
+- [x] 4.1 Run `npm test --workspace=packages/cli`. All tests pass.
+- [x] 4.2 Run `npm run build`. Build succeeds.
+- [x] 4.3 Manual round-trip: in a configured project, run `node packages/cli/dist/specs.js scan` then `node packages/cli/dist/specs.js generate`. Confirm `✓ Loaded manifest: N components (M selected)` and no `Unrecognized source format` error.
+- [x] 4.4 `openspec validate generate-v2-manifest-support --strict` passes.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/packages/cli/src/commands/GenerateCommand.ts
+++ b/packages/cli/src/commands/GenerateCommand.ts
@@ -8,28 +8,36 @@
  * Both modes use Components.fromRestApi() batch API.
  */
 
-import { Command } from 'commander';
-import fs from 'fs-extra';
-import path from 'path';
-import yaml from 'yaml';
-import { Components } from '@directededges/specs-from-figma';
-import type { ProgressEvent, RestLicenseInput } from '@directededges/specs-from-figma';
-import { ConfigLoader } from '../Config/ConfigLoader.js';
-import { loadFoundations } from '../utilities/loadFoundations.js';
-import { ManifestParser } from '../utilities/ManifestParser.js';
-import { LicenseStatus } from '../utilities/LicenseStatus.js';
-import { FileManifest } from '../Writers/FileManifest.js';
-import { SingleFileWriter } from '../Writers/SingleFileWriter.js';
-import { ComponentFileWriter } from '../Writers/ComponentFileWriter.js';
-import { ConcernFileWriter } from '../Writers/ConcernFileWriter.js';
-import { CombinedFileWriter } from '../Writers/CombinedFileWriter.js';
-import type { FileWriter, WriteResult } from '../Writers/FileWriter.js';
-import type { OutputFormat } from '../Types/OutputConfig.js';
+import { Command } from "commander";
+import fs from "fs-extra";
+import path from "path";
+import yaml from "yaml";
+import { Components } from "@directededges/specs-from-figma";
+import type {
+  ProgressEvent,
+  RestLicenseInput,
+} from "@directededges/specs-from-figma";
+import { ConfigLoader } from "../Config/ConfigLoader.js";
+import { loadFoundations } from "../utilities/loadFoundations.js";
+import { ManifestParser } from "../utilities/ManifestParser.js";
+import { ManifestParserV2 } from "../utilities/ManifestParserV2.js";
+import { isV1Manifest } from "../utilities/ManifestMigrationV1ToV2.js";
+import { LicenseStatus } from "../utilities/LicenseStatus.js";
+import { FileManifest } from "../Writers/FileManifest.js";
+import { SingleFileWriter } from "../Writers/SingleFileWriter.js";
+import { ComponentFileWriter } from "../Writers/ComponentFileWriter.js";
+import { ConcernFileWriter } from "../Writers/ConcernFileWriter.js";
+import { CombinedFileWriter } from "../Writers/CombinedFileWriter.js";
+import type { FileWriter, WriteResult } from "../Writers/FileWriter.js";
+import type { OutputFormat } from "../Types/OutputConfig.js";
 
 // Re-export for backward compatibility
-export { ManifestParser } from '../utilities/ManifestParser.js';
-export type { ManifestComponent, ManifestMetadata } from '../utilities/ManifestParser.js';
-export { LicenseStatus } from '../utilities/LicenseStatus.js';
+export { ManifestParser } from "../utilities/ManifestParser.js";
+export type {
+  ManifestComponent,
+  ManifestMetadata,
+} from "../utilities/ManifestParser.js";
+export { LicenseStatus } from "../utilities/LicenseStatus.js";
 
 // Error codes from contracts/error-codes.md
 const ERROR_CODES = {
@@ -40,7 +48,7 @@ const ERROR_CODES = {
   NETWORK_ERROR: 4,
   AUTH_ERROR: 5,
   RATE_LIMIT: 6,
-  COMPONENT_NOT_FOUND: 7
+  COMPONENT_NOT_FOUND: 7,
 };
 
 interface GenerateOptions {
@@ -58,21 +66,39 @@ interface GenerateOptions {
   useSubfolders?: boolean;
 }
 
-export const Generate = new Command('generate')
-  .description('Generate component specifications from Figma data or manifest')
-  .argument('[source]', 'Path to Figma JSON file or markdown manifest (default: {dataDirectory}/{alias}.manifest.md from config)')
-  .option('-c, --component <name|id>', 'Component name or ID (required for file mode)')
-  .option('-l, --license <key>', 'License key for premium features (or set SPECS_LICENSE_KEY)')
-  .option('-f, --format <format>', 'Output format (yaml or json) - overrides config')
-  .option('-o, --output <path>', 'Output file or directory path')
-  .option('-v, --variables <path>', 'External variables JSON file')
-  .option('-s, --styles <path>', 'External styles JSON file')
-  .option('--data-dir <dir>', 'Override data directory for loading source files')
-  .option('--config <path>', 'Path to config file (specs.config.yaml)')
-  .option('--split-components', 'Create separate file per component')
-  .option('--split-concerns', 'Separate API and variants into different files')
-  .option('--use-subfolders', 'Organize component files in subdirectories (requires --split-components)')
-  .option('--verbose', 'Enable detailed logging', false)
+export const Generate = new Command("generate")
+  .description("Generate component specifications from Figma data or manifest")
+  .argument(
+    "[source]",
+    "Path to Figma JSON file or markdown manifest (default: {dataDirectory}/{alias}.manifest.md from config)",
+  )
+  .option(
+    "-c, --component <name|id>",
+    "Component name or ID (required for file mode)",
+  )
+  .option(
+    "-l, --license <key>",
+    "License key for premium features (or set SPECS_LICENSE_KEY)",
+  )
+  .option(
+    "-f, --format <format>",
+    "Output format (yaml or json) - overrides config",
+  )
+  .option("-o, --output <path>", "Output file or directory path")
+  .option("-v, --variables <path>", "External variables JSON file")
+  .option("-s, --styles <path>", "External styles JSON file")
+  .option(
+    "--data-dir <dir>",
+    "Override data directory for loading source files",
+  )
+  .option("--config <path>", "Path to config file (specs.config.yaml)")
+  .option("--split-components", "Create separate file per component")
+  .option("--split-concerns", "Separate API and variants into different files")
+  .option(
+    "--use-subfolders",
+    "Organize component files in subdirectories (requires --split-components)",
+  )
+  .option("--verbose", "Enable detailed logging", false)
   .action(async (source: string | undefined, options: GenerateOptions) => {
     try {
       // Load configuration (needed to resolve default source path)
@@ -89,28 +115,41 @@ export const Generate = new Command('generate')
         ? path.resolve(options.dataDir)
         : config.dataDirectory
           ? path.resolve(config.dataDirectory)
-          : path.join(process.cwd(), 'data');
+          : path.join(process.cwd(), "data");
 
       // Resolve default source path: {dataDirectory}/{alias}.manifest.md
       // Alias preference: `library` if configured with `data: [file]`, else first source with `data: [file]`.
       if (!source) {
         const sources = config.sources || {};
         const defaultAlias = (() => {
-          if (sources.library && Array.isArray(sources.library.data) && sources.library.data.includes('file')) return 'library';
-          const candidate = Object.entries(sources).find(([, s]) => Array.isArray(s.data) && s.data.includes('file'));
+          if (
+            sources.library &&
+            Array.isArray(sources.library.data) &&
+            sources.library.data.includes("file")
+          )
+            return "library";
+          const candidate = Object.entries(sources).find(
+            ([, s]) => Array.isArray(s.data) && s.data.includes("file"),
+          );
           return candidate ? candidate[0] : null;
         })();
 
         if (!defaultAlias) {
-          console.error('Error: No source argument provided and no default manifest could be resolved');
-          console.error('Tip: run `specs scan` to generate a manifest, or configure a source with `data: [file]` in specs.config.yaml');
+          console.error(
+            "Error: No source argument provided and no default manifest could be resolved",
+          );
+          console.error(
+            "Tip: run `specs scan` to generate a manifest, or configure a source with `data: [file]` in specs.config.yaml",
+          );
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
         source = path.join(sourceDir, `${defaultAlias}.manifest.md`);
 
         if (options.verbose) {
-          console.log(`[CLI] Using default manifest: ${path.relative(process.cwd(), source)}`);
+          console.log(
+            `[CLI] Using default manifest: ${path.relative(process.cwd(), source)}`,
+          );
         }
       }
 
@@ -123,25 +162,29 @@ export const Generate = new Command('generate')
       // Validate source exists
       if (!fs.existsSync(sourcePath)) {
         console.error(`Error: Source file not found: ${source}`);
-        if (source.endsWith('.manifest.md')) {
-          console.error('Tip: run `specs scan` to generate the manifest');
+        if (source.endsWith(".manifest.md")) {
+          console.error("Tip: run `specs scan` to generate the manifest");
         }
         process.exit(ERROR_CODES.FILE_ERROR);
       }
 
       // Auto-detect mode by content
-      const sourceContent = await fs.readFile(sourcePath, 'utf-8');
+      const sourceContent = await fs.readFile(sourcePath, "utf-8");
       const trimmed = sourceContent.trimStart();
-      const isManifest = trimmed.includes('- [');
-      const isJson = trimmed.startsWith('{');
+      const isJson = trimmed.startsWith("{");
+      const isV2ManifestSrc = ManifestParserV2.isV2(sourceContent);
+      const isV1ManifestSrc = !isV2ManifestSrc && isV1Manifest(sourceContent);
+      const isManifest = isV2ManifestSrc || isV1ManifestSrc;
 
       if (!isManifest && !isJson) {
-        console.error('Error: Unrecognized source format. Expected JSON file or markdown manifest.');
+        console.error(
+          "Error: Unrecognized source format. Expected JSON file or markdown manifest.",
+        );
         process.exit(ERROR_CODES.INVALID_ARGS);
       }
 
       if (options.verbose) {
-        console.log(`[CLI] Mode: ${isManifest ? 'manifest' : 'file'}`);
+        console.log(`[CLI] Mode: ${isManifest ? "manifest" : "file"}`);
       }
 
       // ---------------------------------------------------------------
@@ -154,39 +197,60 @@ export const Generate = new Command('generate')
       if (isManifest) {
         // MANIFEST MODE
         if (!options.output && !config.outputDirectory) {
-          console.error('Error: Specify --output or set outputDirectory in config');
+          console.error(
+            "Error: Specify --output or set outputDirectory in config",
+          );
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
-        const { components, metadata } = ManifestParser.parse(sourceContent);
+        const { components, metadata } = isV2ManifestSrc
+          ? ManifestParserV2.parse(sourceContent)
+          : ManifestParser.parse(sourceContent);
 
         if (components.length === 0) {
-          console.error('Error: No components found in manifest');
+          console.error("Error: No components found in manifest");
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
-        const selectedComponents = components.filter(c => c.included);
+        const selectedComponents = components.filter((c) => c.included);
 
         if (selectedComponents.length === 0) {
-          console.error('Error: No components selected in manifest (none have [x])');
+          console.error(
+            "Error: No components selected in manifest (none have [x])",
+          );
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
-        console.log(`✓ Loaded manifest: ${components.length} components (${selectedComponents.length} selected)`);
+        console.log(
+          `✓ Loaded manifest: ${components.length} components (${selectedComponents.length} selected)`,
+        );
 
         // Determine source file
         const componentSourceAlias = (() => {
           const sources = config.sources || {};
-          if (sources.library && Array.isArray(sources.library.data) && sources.library.data.includes('file')) return 'library';
-          const candidates = Object.entries(sources).filter(([, s]) => Array.isArray(s.data) && s.data.includes('file'));
+          if (
+            sources.library &&
+            Array.isArray(sources.library.data) &&
+            sources.library.data.includes("file")
+          )
+            return "library";
+          const candidates = Object.entries(sources).filter(
+            ([, s]) => Array.isArray(s.data) && s.data.includes("file"),
+          );
           return candidates.length > 0 ? candidates[0][0] : null;
         })();
 
-        const sourceFile = metadata.file || (componentSourceAlias ? path.join(sourceDir, `${componentSourceAlias}.file.json`) : undefined);
+        const sourceFile =
+          metadata.file ||
+          (componentSourceAlias
+            ? path.join(sourceDir, `${componentSourceAlias}.file.json`)
+            : undefined);
 
         if (!sourceFile) {
-          console.error('Error: No component source file specified');
-          console.error('Include **File:** in the manifest header (from `specs audit`) or configure a source alias with `data: [file]` in specs.config.yaml');
+          console.error("Error: No component source file specified");
+          console.error(
+            "Include **File:** in the manifest header (from `specs audit`) or configure a source alias with `data: [file]` in specs.config.yaml",
+          );
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
@@ -196,17 +260,23 @@ export const Generate = new Command('generate')
         }
 
         libraryJson = await fs.readJSON(sourceFile);
-        componentIds = selectedComponents.map(c => c.id);
-        componentNames = new Map(selectedComponents.map(c => [c.id, c.name]));
+        componentIds = selectedComponents.map((c) => c.id);
+        componentNames = new Map(selectedComponents.map((c) => [c.id, c.name]));
 
         if (options.verbose) {
-          console.log(`[CLI] File loaded: ${libraryJson.name || path.basename(sourceFile)}`);
+          console.log(
+            `[CLI] File loaded: ${libraryJson.name || path.basename(sourceFile)}`,
+          );
         }
       } else {
         // FILE MODE
         if (!options.component) {
-          console.error('Error: --component is required when source is a JSON file');
-          console.error('Usage: specs generate <file.json> -c <component-name|id>');
+          console.error(
+            "Error: --component is required when source is a JSON file",
+          );
+          console.error(
+            "Usage: specs generate <file.json> -c <component-name|id>",
+          );
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
@@ -219,7 +289,9 @@ export const Generate = new Command('generate')
         componentNames = new Map([[options.component, resolvedName]]);
 
         if (options.verbose) {
-          console.log(`[CLI] File loaded: ${libraryJson.name || path.basename(sourcePath)}`);
+          console.log(
+            `[CLI] File loaded: ${libraryJson.name || path.basename(sourcePath)}`,
+          );
         }
       }
 
@@ -227,45 +299,64 @@ export const Generate = new Command('generate')
       // Load foundations
       // ---------------------------------------------------------------
       const fileDir = isManifest ? sourceDir : path.dirname(sourcePath);
-      const foundationsDir = path.basename(fileDir) === 'foundations'
-        ? fileDir
-        : path.join(fileDir, 'foundations');
+      const foundationsDir =
+        path.basename(fileDir) === "foundations"
+          ? fileDir
+          : path.join(fileDir, "foundations");
 
       const variablesPaths = options.variables
         ? [path.resolve(options.variables)]
         : Object.entries(config.sources || {})
-            .filter(([, s]) => Array.isArray(s.data) && s.data.includes('variables'))
+            .filter(
+              ([, s]) => Array.isArray(s.data) && s.data.includes("variables"),
+            )
             .map(([alias]) => path.join(sourceDir, `${alias}.variables.json`))
-            .filter(p => p.length > 0);
+            .filter((p) => p.length > 0);
 
       const stylesPaths = options.styles
         ? [path.resolve(options.styles)]
         : Object.entries(config.sources || {})
-            .filter(([, s]) => Array.isArray(s.data) && s.data.includes('styles'))
+            .filter(
+              ([, s]) => Array.isArray(s.data) && s.data.includes("styles"),
+            )
             .map(([alias]) => path.join(sourceDir, `${alias}.styles.json`))
-            .filter(p => p.length > 0);
+            .filter((p) => p.length > 0);
 
       // Auto-discovery fallback for file mode
-      const finalVariablesPaths = variablesPaths.length > 0 ? variablesPaths : (isManifest ? [] : [path.join(foundationsDir, 'variables.json')]);
-      const finalStylesPaths = stylesPaths.length > 0 ? stylesPaths : (isManifest ? [] : [path.join(foundationsDir, 'styles.json')]);
+      const finalVariablesPaths =
+        variablesPaths.length > 0
+          ? variablesPaths
+          : isManifest
+            ? []
+            : [path.join(foundationsDir, "variables.json")];
+      const finalStylesPaths =
+        stylesPaths.length > 0
+          ? stylesPaths
+          : isManifest
+            ? []
+            : [path.join(foundationsDir, "styles.json")];
 
       if (options.verbose) {
         for (const p of finalVariablesPaths) {
           if (fs.existsSync(p)) {
-            console.log(`[CLI] Found variables: ${path.relative(process.cwd(), p)}`);
+            console.log(
+              `[CLI] Found variables: ${path.relative(process.cwd(), p)}`,
+            );
           }
         }
         for (const p of finalStylesPaths) {
           if (fs.existsSync(p)) {
-            console.log(`[CLI] Found styles: ${path.relative(process.cwd(), p)}`);
+            console.log(
+              `[CLI] Found styles: ${path.relative(process.cwd(), p)}`,
+            );
           }
         }
       }
 
       const { styles, variables, collections } = await loadFoundations(
-        finalVariablesPaths.filter(p => fs.existsSync(p)),
-        finalStylesPaths.filter(p => fs.existsSync(p)),
-        libraryJson
+        finalVariablesPaths.filter((p) => fs.existsSync(p)),
+        finalStylesPaths.filter((p) => fs.existsSync(p)),
+        libraryJson,
       );
 
       if (options.verbose) {
@@ -278,15 +369,20 @@ export const Generate = new Command('generate')
       // ---------------------------------------------------------------
       // Resolve license
       // ---------------------------------------------------------------
-      const licenseKey = options.license || process.env.SPECS_LICENSE_KEY || process.env.ANOVA_LICENSE_KEY;
-      const licenseInput: RestLicenseInput | undefined = licenseKey ? { key: licenseKey } : undefined;
+      const licenseKey =
+        options.license ||
+        process.env.SPECS_LICENSE_KEY ||
+        process.env.ANOVA_LICENSE_KEY;
+      const licenseInput: RestLicenseInput | undefined = licenseKey
+        ? { key: licenseKey }
+        : undefined;
 
       // ---------------------------------------------------------------
       // Process components via batch API
       // ---------------------------------------------------------------
       if (isManifest) {
         console.log(`⏳ Processing ${componentIds.length} components...`);
-        console.log('');
+        console.log("");
       }
 
       const results = await Components.fromRestApi(
@@ -297,12 +393,20 @@ export const Generate = new Command('generate')
         (event: ProgressEvent) => {
           if (!isManifest) {
             // File mode: quiet progress (verbose only)
-            if (options.verbose) console.log(`[CLI] ${event.status}: ${event.component}`);
+            if (options.verbose)
+              console.log(`[CLI] ${event.status}: ${event.component}`);
           } else {
             // Manifest mode: per-component progress
-            const symbol = event.status === 'error' ? '✗' : event.status === 'success' ? '✓' : '…';
-            process.stdout.write(`\r[${event.index + 1}/${event.total}] ${componentNames.get(event.component) || event.component}... ${symbol}`);
-            if (event.status !== 'processing') process.stdout.write('\n');
+            const symbol =
+              event.status === "error"
+                ? "✗"
+                : event.status === "success"
+                  ? "✓"
+                  : "…";
+            process.stdout.write(
+              `\r[${event.index + 1}/${event.total}] ${componentNames.get(event.component) || event.component}... ${symbol}`,
+            );
+            if (event.status !== "processing") process.stdout.write("\n");
           }
         },
         licenseInput,
@@ -311,9 +415,10 @@ export const Generate = new Command('generate')
       // ---------------------------------------------------------------
       // Hard-fail: wrong-runtime license key → AUTH_ERROR
       // ---------------------------------------------------------------
-      if (results.length > 0 && results.every(r => 'error' in r)) {
-        const firstError = (results[0] as { name: string; error: string }).error;
-        if (firstError.includes('not valid for this runtime')) {
+      if (results.length > 0 && results.every((r) => "error" in r)) {
+        const firstError = (results[0] as { name: string; error: string })
+          .error;
+        if (firstError.includes("not valid for this runtime")) {
           console.error(`Error: ${firstError}`);
           process.exit(ERROR_CODES.AUTH_ERROR);
         }
@@ -322,13 +427,19 @@ export const Generate = new Command('generate')
       // ---------------------------------------------------------------
       // Separate successes and errors
       // ---------------------------------------------------------------
-      const processedComponents: Array<{ name: string; spec: Record<string, unknown> }> = [];
+      const processedComponents: Array<{
+        name: string;
+        spec: Record<string, unknown>;
+      }> = [];
       const errors: Array<{ component: string; error: string }> = [];
 
       for (const result of results) {
-        if ('component' in result) {
+        if ("component" in result) {
           const displayName = componentNames.get(result.name) || result.name;
-          processedComponents.push({ name: displayName, spec: result.component as Record<string, unknown> });
+          processedComponents.push({
+            name: displayName,
+            spec: result.component as Record<string, unknown>,
+          });
         } else {
           const displayName = componentNames.get(result.name) || result.name;
           errors.push({ component: displayName, error: result.error });
@@ -337,7 +448,7 @@ export const Generate = new Command('generate')
 
       // Display summary for manifest mode
       if (isManifest) {
-        console.log('');
+        console.log("");
         console.log(`✓ Generated specs`);
         console.log(`  - ${processedComponents.length} components successful`);
         if (errors.length > 0) {
@@ -354,9 +465,11 @@ export const Generate = new Command('generate')
       // Handle file mode errors
       if (!isManifest && errors.length > 0) {
         const msg = errors[0].error;
-        if (msg.includes('Component not found') || msg.includes('not found')) {
+        if (msg.includes("Component not found") || msg.includes("not found")) {
           console.error(`Error: ${msg}`);
-          console.error(`Tip: Use a component name like "DS Alert" or component ID like "123:456"`);
+          console.error(
+            `Tip: Use a component name like "DS Alert" or component ID like "123:456"`,
+          );
           process.exit(ERROR_CODES.COMPONENT_NOT_FOUND);
         }
         console.error(`Error: ${msg}`);
@@ -364,7 +477,7 @@ export const Generate = new Command('generate')
       }
 
       if (processedComponents.length === 0) {
-        console.error('Error: No components were successfully processed');
+        console.error("Error: No components were successfully processed");
         process.exit(ERROR_CODES.GENERAL_ERROR);
       }
 
@@ -377,9 +490,10 @@ export const Generate = new Command('generate')
           ? options.format.toLowerCase()
           : modelConfig.format.output.toLowerCase();
 
-        const formattedOutput = outputFormat === 'yaml'
-          ? yaml.stringify(componentData)
-          : JSON.stringify(componentData, null, 2);
+        const formattedOutput =
+          outputFormat === "yaml"
+            ? yaml.stringify(componentData)
+            : JSON.stringify(componentData, null, 2);
 
         console.log(formattedOutput);
         process.exit(ERROR_CODES.SUCCESS);
@@ -390,15 +504,18 @@ export const Generate = new Command('generate')
       // File output via manifest + writer
       // ---------------------------------------------------------------
       const resolvedFormat: OutputFormat = options.format
-        ? options.format.toLowerCase() as OutputFormat
-        : modelConfig.format.output.toLowerCase() as OutputFormat;
+        ? (options.format.toLowerCase() as OutputFormat)
+        : (modelConfig.format.output.toLowerCase() as OutputFormat);
 
       const outputConfig = {
         ...config.output,
-        splitComponents: options.splitComponents ?? config.output?.splitComponents ?? false,
-        splitConcerns: options.splitConcerns ?? config.output?.splitConcerns ?? false,
-        useSubfolders: options.useSubfolders ?? config.output?.useSubfolders ?? false,
-        defaultFormat: resolvedFormat
+        splitComponents:
+          options.splitComponents ?? config.output?.splitComponents ?? false,
+        splitConcerns:
+          options.splitConcerns ?? config.output?.splitConcerns ?? false,
+        useSubfolders:
+          options.useSubfolders ?? config.output?.useSubfolders ?? false,
+        defaultFormat: resolvedFormat,
       };
 
       let outputPath: string;
@@ -414,20 +531,32 @@ export const Generate = new Command('generate')
 
       // When in single-file mode and outputPath is an existing directory,
       // append a default filename so we don't try to open a directory as a file
-      const isSingleFileMode = !outputConfig.splitComponents && !outputConfig.splitConcerns;
-      if (isSingleFileMode && fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()) {
+      const isSingleFileMode =
+        !outputConfig.splitComponents && !outputConfig.splitConcerns;
+      if (
+        isSingleFileMode &&
+        fs.existsSync(outputPath) &&
+        fs.statSync(outputPath).isDirectory()
+      ) {
         outputPath = path.join(outputPath, `library.${resolvedFormat}`);
       }
 
-      const baseDir = outputConfig.splitComponents || outputConfig.splitConcerns
-        ? outputPath
-        : path.dirname(outputPath);
+      const baseDir =
+        outputConfig.splitComponents || outputConfig.splitConcerns
+          ? outputPath
+          : path.dirname(outputPath);
 
-      const outputFileName = (!outputConfig.splitComponents && !outputConfig.splitConcerns)
-        ? path.basename(outputPath)
-        : undefined;
+      const outputFileName =
+        !outputConfig.splitComponents && !outputConfig.splitConcerns
+          ? path.basename(outputPath)
+          : undefined;
 
-      const manifest = new FileManifest(processedComponents, outputConfig, baseDir, outputFileName);
+      const manifest = new FileManifest(
+        processedComponents,
+        outputConfig,
+        baseDir,
+        outputFileName,
+      );
 
       // Select appropriate writer
       let writer: FileWriter;
@@ -444,25 +573,28 @@ export const Generate = new Command('generate')
       const writeResult: WriteResult = await writer.write(manifest);
 
       if (writeResult.warnings.length > 0) {
-        writeResult.warnings.forEach(warning => console.log(warning));
+        writeResult.warnings.forEach((warning) => console.log(warning));
       }
 
       if (writeResult.errors.length > 0) {
-        writeResult.errors.forEach(error => console.error(`Error: ${error}`));
+        writeResult.errors.forEach((error) => console.error(`Error: ${error}`));
         process.exit(ERROR_CODES.FILE_ERROR);
       }
 
       if (writeResult.filesWritten.length === 1) {
         console.log(`✓ Saved to ${writeResult.filesWritten[0]}`);
       } else {
-        console.log(`✓ Generated ${writeResult.filesWritten.length} files in ${path.relative(process.cwd(), baseDir)}/`);
-        writeResult.filesWritten.forEach(file => {
+        console.log(
+          `✓ Generated ${writeResult.filesWritten.length} files in ${path.relative(process.cwd(), baseDir)}/`,
+        );
+        writeResult.filesWritten.forEach((file) => {
           console.log(`  ${file}`);
         });
       }
 
-      process.exit(errors.length > 0 ? ERROR_CODES.GENERAL_ERROR : ERROR_CODES.SUCCESS);
-
+      process.exit(
+        errors.length > 0 ? ERROR_CODES.GENERAL_ERROR : ERROR_CODES.SUCCESS,
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(`Error: ${message}`);

--- a/packages/cli/src/utilities/ManifestParserV2.ts
+++ b/packages/cli/src/utilities/ManifestParserV2.ts
@@ -11,12 +11,12 @@
  *   | [ ] | Card | 1:45 | COMPONENT | NONE |
  */
 
-import type { DevStatus } from './ComponentDiscovery.js';
+import type { DevStatus } from "./ComponentDiscovery.js";
 
 export interface ManifestRowV2 {
   id: string;
   name: string;
-  type: 'COMPONENT' | 'COMPONENT_SET';
+  type: "COMPONENT" | "COMPONENT_SET";
   included: boolean;
   devStatus: DevStatus;
 }
@@ -38,9 +38,43 @@ const FILE_HEADER_REGEX = /\*\*File:\*\*\s+(.+?)$/m;
 const VARIABLES_HEADER_REGEX = /\*\*Variables:\*\*\s+(.+?)$/m;
 const FILE_LAST_MODIFIED_REGEX = /\*\*File last modified:\*\*\s+(.+?)$/m;
 
-// | [x] | Name | id | TYPE | DEV_STATUS |
-const ROW_REGEX =
-  /^\|\s*\[([x ])\]\s*\|\s*(.+?)\s*\|\s*(\d+:\d+)\s*\|\s*(COMPONENT_SET|COMPONENT)\s*\|\s*(READY_FOR_DEV|NONE)\s*\|/i;
+// Cheap recognition: a row starts with `| [x] |` or `| [ ] |`.
+// Field extraction is handled separately by splitRow so that `\|` inside a
+// cell (emitted by ScanCommand's escapeCell) is treated as part of the cell
+// rather than as a column separator.
+const ROW_RECOGNITION_REGEX = /^\|\s*\[[x ]\]\s*\|/i;
+const ID_REGEX = /^\d+:\d+$/;
+
+/**
+ * Split a markdown table row into cell contents. Treats `\|` as an escaped
+ * pipe that is part of the cell, not a column separator. Trims each cell and
+ * unescapes `\|` → `|` after splitting.
+ */
+function splitRow(row: string): string[] {
+  const trimmed = row.trim();
+  // Strip leading and trailing outer pipes if present.
+  const inner = trimmed.startsWith("|") ? trimmed.slice(1) : trimmed;
+  const body = inner.endsWith("|") ? inner.slice(0, -1) : inner;
+
+  const cells: string[] = [];
+  let cell = "";
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (ch === "\\" && body[i + 1] === "|") {
+      cell += "|";
+      i += 1;
+      continue;
+    }
+    if (ch === "|") {
+      cells.push(cell.trim());
+      cell = "";
+      continue;
+    }
+    cell += ch;
+  }
+  cells.push(cell.trim());
+  return cells;
+}
 
 export class ManifestParserV2 {
   /** Returns true when the content declares scan format version 2 (or higher). */
@@ -53,7 +87,7 @@ export class ManifestParserV2 {
   static parse(content: string): ManifestResultV2 {
     const versionMatch = content.match(SCAN_FORMAT_VERSION_REGEX);
     const metadata: ManifestMetadataV2 = {
-      scanFormatVersion: versionMatch ? Number(versionMatch[1]) : 2
+      scanFormatVersion: versionMatch ? Number(versionMatch[1]) : 2,
     };
 
     const fileMatch = content.match(FILE_HEADER_REGEX);
@@ -63,26 +97,44 @@ export class ManifestParserV2 {
     if (variablesMatch) metadata.variables = variablesMatch[1].trim();
 
     const lastModifiedMatch = content.match(FILE_LAST_MODIFIED_REGEX);
-    if (lastModifiedMatch) metadata.fileLastModified = lastModifiedMatch[1].trim();
+    if (lastModifiedMatch)
+      metadata.fileLastModified = lastModifiedMatch[1].trim();
 
     const components: ManifestRowV2[] = [];
     let inComponentsSection = false;
-    for (const line of content.split('\n')) {
+    for (const line of content.split("\n")) {
       const heading = line.match(/^##\s+(.+?)\s*$/);
       if (heading) {
-        inComponentsSection = heading[1].toLowerCase() === 'components';
+        inComponentsSection = heading[1].toLowerCase() === "components";
         continue;
       }
       if (!inComponentsSection) continue;
-      const match = line.match(ROW_REGEX);
-      if (!match) continue;
-      const [, checkbox, name, id, type, devStatus] = match;
+      if (!ROW_RECOGNITION_REGEX.test(line)) continue;
+
+      const cells = splitRow(line);
+      if (cells.length < 5) continue;
+
+      const [rawCheckbox, name, id, rawType, rawDevStatus] = cells;
+      const checkbox = rawCheckbox
+        .replace(/[\[\]]/g, "")
+        .trim()
+        .toLowerCase();
+      if (checkbox !== "x" && checkbox !== "") continue;
+
+      if (!ID_REGEX.test(id)) continue;
+
+      const type = rawType.toUpperCase();
+      if (type !== "COMPONENT" && type !== "COMPONENT_SET") continue;
+
+      const devStatus = rawDevStatus.toUpperCase();
+      if (devStatus !== "READY_FOR_DEV" && devStatus !== "NONE") continue;
+
       components.push({
         id,
-        name: name.trim(),
-        type: type.toUpperCase() as 'COMPONENT' | 'COMPONENT_SET',
-        included: checkbox.toLowerCase() === 'x',
-        devStatus: devStatus.toUpperCase() as DevStatus
+        name,
+        type: type as "COMPONENT" | "COMPONENT_SET",
+        included: checkbox === "x",
+        devStatus: devStatus as DevStatus,
       });
     }
 

--- a/packages/cli/tests/unit/commands/GenerateCommand.test.ts
+++ b/packages/cli/tests/unit/commands/GenerateCommand.test.ts
@@ -1,80 +1,94 @@
-import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
-import { Generate } from '../../../src/commands/GenerateCommand.js';
-import { ManifestParser } from '../../../src/utilities/ManifestParser.js';
-import { LicenseStatus } from '../../../src/utilities/LicenseStatus.js';
-import type { ComponentsData } from '@directededges/specs-from-figma';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
+import { Generate } from "../../../src/commands/GenerateCommand.js";
+import { ManifestParser } from "../../../src/utilities/ManifestParser.js";
+import { ManifestParserV2 } from "../../../src/utilities/ManifestParserV2.js";
+import { isV1Manifest } from "../../../src/utilities/ManifestMigrationV1ToV2.js";
+import { LicenseStatus } from "../../../src/utilities/LicenseStatus.js";
+import type { ComponentsData } from "@directededges/specs-from-figma";
 
 // ============================================================================
 // COMMAND REGISTRATION
 // ============================================================================
 
-describe('GenerateCommand', () => {
-  describe('registration', () => {
-    it('registers name and description', () => {
-      expect(Generate.name()).toBe('generate');
-      expect(Generate.description()).toContain('Generate');
+describe("GenerateCommand", () => {
+  describe("registration", () => {
+    it("registers name and description", () => {
+      expect(Generate.name()).toBe("generate");
+      expect(Generate.description()).toContain("Generate");
     });
 
-    it('has source as an optional argument (defaults to manifest from config)', () => {
+    it("has source as an optional argument (defaults to manifest from config)", () => {
       const args = Generate.registeredArguments;
       expect(args).toHaveLength(1);
-      expect(args[0].name()).toBe('source');
+      expect(args[0].name()).toBe("source");
       expect(args[0].required).toBe(false);
     });
 
-    it('component option is not mandatory (optional for manifest mode)', () => {
-      const componentOption = Generate.options.find(o => o.long === '--component');
+    it("component option is not mandatory (optional for manifest mode)", () => {
+      const componentOption = Generate.options.find(
+        (o) => o.long === "--component",
+      );
       expect(componentOption).toBeDefined();
       // mandatory means the option itself must be provided; required means its value needs an argument
       // component is optional (.option not .requiredOption) but takes a required value <name|id>
       expect(componentOption!.mandatory).toBeFalsy();
     });
 
-    it('registers all expected options', () => {
-      const options = Generate.options.map(option => option.long).filter(Boolean);
+    it("registers all expected options", () => {
+      const options = Generate.options
+        .map((option) => option.long)
+        .filter(Boolean);
 
-      expect(options).toContain('--component');
-      expect(options).toContain('--license');
-      expect(options).toContain('--format');
-      expect(options).toContain('--output');
-      expect(options).toContain('--variables');
-      expect(options).toContain('--styles');
-      expect(options).toContain('--data-dir');
-      expect(options).toContain('--config');
-      expect(options).toContain('--split-components');
-      expect(options).toContain('--split-concerns');
-      expect(options).toContain('--use-subfolders');
-      expect(options).toContain('--verbose');
+      expect(options).toContain("--component");
+      expect(options).toContain("--license");
+      expect(options).toContain("--format");
+      expect(options).toContain("--output");
+      expect(options).toContain("--variables");
+      expect(options).toContain("--styles");
+      expect(options).toContain("--data-dir");
+      expect(options).toContain("--config");
+      expect(options).toContain("--split-components");
+      expect(options).toContain("--split-concerns");
+      expect(options).toContain("--use-subfolders");
+      expect(options).toContain("--verbose");
     });
 
-    it('has short aliases for key options', () => {
-      const shorts = Generate.options.map(o => o.short).filter(Boolean);
+    it("has short aliases for key options", () => {
+      const shorts = Generate.options.map((o) => o.short).filter(Boolean);
 
-      expect(shorts).toContain('-c');
-      expect(shorts).toContain('-l');
-      expect(shorts).toContain('-f');
-      expect(shorts).toContain('-o');
-      expect(shorts).toContain('-v');
-      expect(shorts).toContain('-s');
+      expect(shorts).toContain("-c");
+      expect(shorts).toContain("-l");
+      expect(shorts).toContain("-f");
+      expect(shorts).toContain("-o");
+      expect(shorts).toContain("-v");
+      expect(shorts).toContain("-s");
     });
 
-    it('split-components has no Commander default (defers to config)', () => {
-      const opt = Generate.options.find(o => o.long === '--split-components');
+    it("split-components has no Commander default (defers to config)", () => {
+      const opt = Generate.options.find((o) => o.long === "--split-components");
       expect(opt!.defaultValue).toBeUndefined();
     });
 
-    it('split-concerns has no Commander default (defers to config)', () => {
-      const opt = Generate.options.find(o => o.long === '--split-concerns');
+    it("split-concerns has no Commander default (defers to config)", () => {
+      const opt = Generate.options.find((o) => o.long === "--split-concerns");
       expect(opt!.defaultValue).toBeUndefined();
     });
 
-    it('use-subfolders has no Commander default (defers to config)', () => {
-      const opt = Generate.options.find(o => o.long === '--use-subfolders');
+    it("use-subfolders has no Commander default (defers to config)", () => {
+      const opt = Generate.options.find((o) => o.long === "--use-subfolders");
       expect(opt!.defaultValue).toBeUndefined();
     });
 
-    it('verbose defaults to false', () => {
-      const opt = Generate.options.find(o => o.long === '--verbose');
+    it("verbose defaults to false", () => {
+      const opt = Generate.options.find((o) => o.long === "--verbose");
       expect(opt!.defaultValue).toBe(false);
     });
   });
@@ -84,28 +98,28 @@ describe('GenerateCommand', () => {
 // MANIFEST PARSING (T01 + T03)
 // ============================================================================
 
-describe('parseManifest', () => {
-  describe('component parsing', () => {
-    it('parses checked components as included', () => {
+describe("parseManifest", () => {
+  describe("component parsing", () => {
+    it("parses checked components as included", () => {
       const manifest = `# Components\n- [x] DS Button (123:456, COMPONENT_SET)\n- [x] DS Alert (789:012, COMPONENT)`;
       const { components } = ManifestParser.parse(manifest);
 
       expect(components).toHaveLength(2);
       expect(components[0]).toEqual({
-        id: '123:456',
-        name: 'DS Button',
-        type: 'COMPONENT_SET',
-        included: true
+        id: "123:456",
+        name: "DS Button",
+        type: "COMPONENT_SET",
+        included: true,
       });
       expect(components[1]).toEqual({
-        id: '789:012',
-        name: 'DS Alert',
-        type: 'COMPONENT',
-        included: true
+        id: "789:012",
+        name: "DS Alert",
+        type: "COMPONENT",
+        included: true,
       });
     });
 
-    it('parses unchecked components as excluded', () => {
+    it("parses unchecked components as excluded", () => {
       const manifest = `- [ ] DS Button (123:456, COMPONENT_SET)`;
       const { components } = ManifestParser.parse(manifest);
 
@@ -113,118 +127,126 @@ describe('parseManifest', () => {
       expect(components[0].included).toBe(false);
     });
 
-    it('handles mixed checked and unchecked', () => {
+    it("handles mixed checked and unchecked", () => {
       const manifest = [
-        '- [x] Button (1:1, COMPONENT_SET)',
-        '- [ ] Alert (2:2, COMPONENT)',
-        '- [x] Modal (3:3, COMPONENT_SET)',
-        '- [ ] Tooltip (4:4, COMPONENT)'
-      ].join('\n');
+        "- [x] Button (1:1, COMPONENT_SET)",
+        "- [ ] Alert (2:2, COMPONENT)",
+        "- [x] Modal (3:3, COMPONENT_SET)",
+        "- [ ] Tooltip (4:4, COMPONENT)",
+      ].join("\n");
 
       const { components } = ManifestParser.parse(manifest);
 
       expect(components).toHaveLength(4);
-      expect(components.filter(c => c.included)).toHaveLength(2);
-      expect(components.filter(c => !c.included)).toHaveLength(2);
+      expect(components.filter((c) => c.included)).toHaveLength(2);
+      expect(components.filter((c) => !c.included)).toHaveLength(2);
     });
 
-    it('returns empty array for content with no checkbox lines', () => {
+    it("returns empty array for content with no checkbox lines", () => {
       const manifest = `# Just a heading\nSome text without checkboxes`;
       const { components } = ManifestParser.parse(manifest);
       expect(components).toHaveLength(0);
     });
 
-    it('ignores lines that do not match component format', () => {
+    it("ignores lines that do not match component format", () => {
       const manifest = [
-        '# Components',
-        '- [x] DS Button (123:456, COMPONENT_SET)',
-        '- Some regular bullet',
-        '- [x] Has no parens',
-        '  - [x] Indented checkbox (nested, COMPONENT)',
-        '- [x] DS Alert (789:012, COMPONENT)'
-      ].join('\n');
+        "# Components",
+        "- [x] DS Button (123:456, COMPONENT_SET)",
+        "- Some regular bullet",
+        "- [x] Has no parens",
+        "  - [x] Indented checkbox (nested, COMPONENT)",
+        "- [x] DS Alert (789:012, COMPONENT)",
+      ].join("\n");
 
       const { components } = ManifestParser.parse(manifest);
       // Only lines matching full format are parsed
       expect(components).toHaveLength(2);
-      expect(components[0].name).toBe('DS Button');
-      expect(components[1].name).toBe('DS Alert');
+      expect(components[0].name).toBe("DS Button");
+      expect(components[1].name).toBe("DS Alert");
     });
 
-    it('handles COMPONENT_SET type case-insensitively', () => {
+    it("handles COMPONENT_SET type case-insensitively", () => {
       const manifest = `- [x] Button (1:1, component_set)`;
       const { components } = ManifestParser.parse(manifest);
 
-      expect(components[0].type).toBe('COMPONENT_SET');
+      expect(components[0].type).toBe("COMPONENT_SET");
     });
 
-    it('handles COMPONENT type case-insensitively', () => {
+    it("handles COMPONENT type case-insensitively", () => {
       const manifest = `- [x] Icon (1:1, component)`;
       const { components } = ManifestParser.parse(manifest);
 
-      expect(components[0].type).toBe('COMPONENT');
+      expect(components[0].type).toBe("COMPONENT");
     });
 
-    it('extracts component names with special characters', () => {
+    it("extracts component names with special characters", () => {
       const manifest = `- [x] DS Button/Primary (123:456, COMPONENT_SET)`;
       const { components } = ManifestParser.parse(manifest);
 
-      expect(components[0].name).toBe('DS Button/Primary');
+      expect(components[0].name).toBe("DS Button/Primary");
     });
   });
 
-  describe('metadata extraction', () => {
-    it('extracts File metadata from header', () => {
+  describe("metadata extraction", () => {
+    it("extracts File metadata from header", () => {
       const manifest = [
-        '# Component Manifest',
-        '**File:** data/library.file.json',
-        '',
-        '- [x] Button (1:1, COMPONENT_SET)'
-      ].join('\n');
+        "# Component Manifest",
+        "**File:** data/library.file.json",
+        "",
+        "- [x] Button (1:1, COMPONENT_SET)",
+      ].join("\n");
 
       const { metadata } = ManifestParser.parse(manifest);
-      expect(metadata.file).toBe('data/library.file.json');
+      expect(metadata.file).toBe("data/library.file.json");
     });
 
-    it('trims whitespace from File metadata', () => {
+    it("trims whitespace from File metadata", () => {
       const manifest = `**File:**   data/library.file.json   \n- [x] Button (1:1, COMPONENT_SET)`;
       const { metadata } = ManifestParser.parse(manifest);
-      expect(metadata.file).toBe('data/library.file.json');
+      expect(metadata.file).toBe("data/library.file.json");
     });
 
-    it('returns undefined file when no File header present', () => {
+    it("returns undefined file when no File header present", () => {
       const manifest = `- [x] Button (1:1, COMPONENT_SET)`;
       const { metadata } = ManifestParser.parse(manifest);
       expect(metadata.file).toBeUndefined();
     });
   });
 
-  describe('realistic manifest', () => {
-    it('parses a full audit-generated manifest', () => {
+  describe("realistic manifest", () => {
+    it("parses a full audit-generated manifest", () => {
       const manifest = [
-        '# Component Audit',
-        '',
-        '**File:** data/library.file.json',
-        '**Generated:** 2026-03-21',
-        '',
-        '## Components (5 total)',
-        '',
-        '- [x] DS Accordion (5507:100, COMPONENT_SET)',
-        '- [x] DS Alert (5507:200, COMPONENT_SET)',
-        '- [ ] DS Avatar (5507:300, COMPONENT_SET)',
-        '- [x] DS Button (5507:400, COMPONENT_SET)',
-        '- [ ] DS Card (5507:500, COMPONENT_SET)',
-      ].join('\n');
+        "# Component Audit",
+        "",
+        "**File:** data/library.file.json",
+        "**Generated:** 2026-03-21",
+        "",
+        "## Components (5 total)",
+        "",
+        "- [x] DS Accordion (5507:100, COMPONENT_SET)",
+        "- [x] DS Alert (5507:200, COMPONENT_SET)",
+        "- [ ] DS Avatar (5507:300, COMPONENT_SET)",
+        "- [x] DS Button (5507:400, COMPONENT_SET)",
+        "- [ ] DS Card (5507:500, COMPONENT_SET)",
+      ].join("\n");
 
       const { components, metadata } = ManifestParser.parse(manifest);
 
       expect(components).toHaveLength(5);
-      expect(components.filter(c => c.included)).toHaveLength(3);
-      expect(metadata.file).toBe('data/library.file.json');
+      expect(components.filter((c) => c.included)).toHaveLength(3);
+      expect(metadata.file).toBe("data/library.file.json");
 
-      const selected = components.filter(c => c.included);
-      expect(selected.map(c => c.name)).toEqual(['DS Accordion', 'DS Alert', 'DS Button']);
-      expect(selected.map(c => c.id)).toEqual(['5507:100', '5507:200', '5507:400']);
+      const selected = components.filter((c) => c.included);
+      expect(selected.map((c) => c.name)).toEqual([
+        "DS Accordion",
+        "DS Alert",
+        "DS Button",
+      ]);
+      expect(selected.map((c) => c.id)).toEqual([
+        "5507:100",
+        "5507:200",
+        "5507:400",
+      ]);
     });
   });
 });
@@ -233,45 +255,93 @@ describe('parseManifest', () => {
 // SOURCE AUTO-DETECTION (T01)
 // ============================================================================
 
-describe('source auto-detection', () => {
-  // These test the detection logic as documented:
-  // - JSON content (starts with `{`) → file mode
-  // - Markdown with `- [` → manifest mode
-  // The actual detection happens in the action handler, but we can verify
-  // the detection criteria by testing the same logic.
+describe("source auto-detection", () => {
+  // These mirror the detection logic in GenerateCommand:
+  //   isJson         = trimmed.startsWith('{')
+  //   isV2Manifest   = ManifestParserV2.isV2(content)
+  //   isV1Manifest   = !isV2Manifest && isV1Manifest(content)
+  //   isManifest     = isV2Manifest || isV1Manifest
 
-  it('JSON content is detected by leading brace', () => {
-    const jsonContent = '{ "name": "test" }';
-    const trimmed = jsonContent.trimStart();
-    expect(trimmed.startsWith('{')).toBe(true);
-    expect(trimmed.includes('- [')).toBe(false);
+  function detect(content: string) {
+    const trimmed = content.trimStart();
+    const isJson = trimmed.startsWith("{");
+    const isV2 = ManifestParserV2.isV2(content);
+    const isV1 = !isV2 && isV1Manifest(content);
+    const isManifest = isV2 || isV1;
+    return { isJson, isV2, isV1, isManifest };
+  }
+
+  it("JSON content is detected by leading brace", () => {
+    const { isJson, isManifest } = detect('{ "name": "test" }');
+    expect(isJson).toBe(true);
+    expect(isManifest).toBe(false);
   });
 
-  it('manifest content is detected by checkbox pattern', () => {
-    const manifestContent = '# Manifest\n- [x] Button (1:1, COMPONENT_SET)';
-    const trimmed = manifestContent.trimStart();
-    expect(trimmed.includes('- [')).toBe(true);
-    expect(trimmed.startsWith('{')).toBe(false);
+  it("v1 manifest is detected via isV1Manifest", () => {
+    const v1 = "# Manifest\n- [x] Button (1:1, COMPONENT_SET)";
+    const { isJson, isV1, isV2, isManifest } = detect(v1);
+    expect(isJson).toBe(false);
+    expect(isV1).toBe(true);
+    expect(isV2).toBe(false);
+    expect(isManifest).toBe(true);
   });
 
-  it('JSON with leading whitespace is still detected', () => {
-    const jsonContent = '  \n  { "name": "test" }';
-    const trimmed = jsonContent.trimStart();
-    expect(trimmed.startsWith('{')).toBe(true);
+  it("v2 manifest (scan table) is detected via ManifestParserV2.isV2", () => {
+    const v2 = [
+      "# Component Manifest",
+      "",
+      "**Scan format version:** 2",
+      "**File:** data/library.file.json",
+      "",
+      "## Components",
+      "",
+      "| ✓ | Name | ID | Type | Dev Status |",
+      "|---|---|---|---|---|",
+      "| [x] | Button | 1:23 | COMPONENT_SET | NONE |",
+    ].join("\n");
+    const { isJson, isV1, isV2, isManifest } = detect(v2);
+    expect(isJson).toBe(false);
+    expect(isV2).toBe(true);
+    expect(isV1).toBe(false);
+    expect(isManifest).toBe(true);
   });
 
-  it('plain text is neither JSON nor manifest', () => {
-    const plainText = 'Hello world, this is plain text.';
-    const trimmed = plainText.trimStart();
-    expect(trimmed.startsWith('{')).toBe(false);
-    expect(trimmed.includes('- [')).toBe(false);
+  it("v2 manifest still routes through ManifestParserV2.parse", () => {
+    const v2 = [
+      "**Scan format version:** 2",
+      "**File:** data/library.file.json",
+      "",
+      "## Components",
+      "",
+      "| ✓ | Name | ID | Type | Dev Status |",
+      "|---|---|---|---|---|",
+      "| [x] | DS Button | 5507:400 | COMPONENT_SET | NONE |",
+      "| [ ] | DS Card | 5507:500 | COMPONENT | NONE |",
+    ].join("\n");
+    const { components, metadata } = ManifestParserV2.parse(v2);
+    expect(metadata.file).toBe("data/library.file.json");
+    expect(components.filter((c) => c.included).map((c) => c.id)).toEqual([
+      "5507:400",
+    ]);
   });
 
-  it('YAML is neither JSON nor manifest', () => {
-    const yamlContent = 'components:\n  button:\n    title: Button';
-    const trimmed = yamlContent.trimStart();
-    expect(trimmed.startsWith('{')).toBe(false);
-    expect(trimmed.includes('- [')).toBe(false);
+  it("JSON with leading whitespace is still detected", () => {
+    const { isJson } = detect('  \n  { "name": "test" }');
+    expect(isJson).toBe(true);
+  });
+
+  it("plain text is neither JSON nor manifest", () => {
+    const { isJson, isManifest } = detect("Hello world, this is plain text.");
+    expect(isJson).toBe(false);
+    expect(isManifest).toBe(false);
+  });
+
+  it("YAML is neither JSON nor manifest", () => {
+    const { isJson, isManifest } = detect(
+      "components:\n  button:\n    title: Button",
+    );
+    expect(isJson).toBe(false);
+    expect(isManifest).toBe(false);
   });
 });
 
@@ -279,35 +349,39 @@ describe('source auto-detection', () => {
 // LICENSE KEY RESOLUTION (T04)
 // ============================================================================
 
-describe('license key resolution', () => {
+describe("license key resolution", () => {
   // The resolution logic in GenerateCommand:
   //   const licenseKey = options.license || process.env.ANOVA_LICENSE_KEY;
   //   const licenseInput = licenseKey ? { key: licenseKey } : undefined;
 
-  it('--license flag produces license input', () => {
-    const optionsLicense = 'lic_abc';
+  it("--license flag produces license input", () => {
+    const optionsLicense = "lic_abc";
     const envKey = undefined;
     const licenseKey = optionsLicense || envKey;
-    expect(licenseKey).toBe('lic_abc');
-    expect(licenseKey ? { key: licenseKey } : undefined).toEqual({ key: 'lic_abc' });
+    expect(licenseKey).toBe("lic_abc");
+    expect(licenseKey ? { key: licenseKey } : undefined).toEqual({
+      key: "lic_abc",
+    });
   });
 
-  it('env var produces license input when no flag', () => {
+  it("env var produces license input when no flag", () => {
     const optionsLicense = undefined;
-    const envKey = 'lic_env';
+    const envKey = "lic_env";
     const licenseKey = optionsLicense || envKey;
-    expect(licenseKey).toBe('lic_env');
-    expect(licenseKey ? { key: licenseKey } : undefined).toEqual({ key: 'lic_env' });
+    expect(licenseKey).toBe("lic_env");
+    expect(licenseKey ? { key: licenseKey } : undefined).toEqual({
+      key: "lic_env",
+    });
   });
 
-  it('--license flag wins over env var', () => {
-    const optionsLicense = 'lic_flag';
-    const envKey = 'lic_env';
+  it("--license flag wins over env var", () => {
+    const optionsLicense = "lic_flag";
+    const envKey = "lic_env";
     const licenseKey = optionsLicense || envKey;
-    expect(licenseKey).toBe('lic_flag');
+    expect(licenseKey).toBe("lic_flag");
   });
 
-  it('neither flag nor env var produces undefined', () => {
+  it("neither flag nor env var produces undefined", () => {
     const optionsLicense = undefined;
     const envKey = undefined;
     const licenseKey = optionsLicense || envKey;
@@ -320,74 +394,83 @@ describe('license key resolution', () => {
 // LICENSE STATUS DISPLAY (T05)
 // ============================================================================
 
-describe('displayLicenseStatus', () => {
+describe("displayLicenseStatus", () => {
   let logSpy: MockInstance;
 
   beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
   afterEach(() => {
     logSpy.mockRestore();
   });
 
-  function makeResult(licenseLevel: string, licenseStatus: string): ComponentsData[] {
-    return [{
-      name: 'Button',
-      component: {
-        title: 'Button',
-        metadata: {
-          generator: {
-            license: { level: licenseLevel, status: licenseStatus }
-          }
-        }
-      }
-    }] as any;
+  function makeResult(
+    licenseLevel: string,
+    licenseStatus: string,
+  ): ComponentsData[] {
+    return [
+      {
+        name: "Button",
+        component: {
+          title: "Button",
+          metadata: {
+            generator: {
+              license: { level: licenseLevel, status: licenseStatus },
+            },
+          },
+        },
+      },
+    ] as any;
   }
 
-  it('displays PRO (active) for active PRO license', () => {
-    LicenseStatus.display(makeResult('PRO', 'active'), true);
+  it("displays PRO (active) for active PRO license", () => {
+    LicenseStatus.display(makeResult("PRO", "active"), true);
 
-    expect(logSpy).toHaveBeenCalledWith('License: PRO (active)');
+    expect(logSpy).toHaveBeenCalledWith("License: PRO (active)");
   });
 
-  it('displays FREE (invalid) for invalid key', () => {
-    LicenseStatus.display(makeResult('FREE', 'invalid'), true);
-
-    expect(logSpy).toHaveBeenCalledWith('License: FREE (invalid — key not recognized)');
-  });
-
-  it('displays FREE (expired) for expired key', () => {
-    LicenseStatus.display(makeResult('FREE', 'expired'), true);
-
-    expect(logSpy).toHaveBeenCalledWith('License: FREE (expired — key expired)');
-  });
-
-  it('displays FREE (activation-limit-reached) for exhausted seats', () => {
-    LicenseStatus.display(makeResult('FREE', 'activation-limit-reached'), true);
+  it("displays FREE (invalid) for invalid key", () => {
+    LicenseStatus.display(makeResult("FREE", "invalid"), true);
 
     expect(logSpy).toHaveBeenCalledWith(
-      'License: FREE (activation-limit-reached — all seats consumed for this key)'
+      "License: FREE (invalid — key not recognized)",
     );
   });
 
-  it('displays FREE (network-error) for license server failure', () => {
-    LicenseStatus.display(makeResult('FREE', 'network-error'), true);
+  it("displays FREE (expired) for expired key", () => {
+    LicenseStatus.display(makeResult("FREE", "expired"), true);
 
     expect(logSpy).toHaveBeenCalledWith(
-      'License: FREE (network-error — could not reach license server)'
+      "License: FREE (expired — key expired)",
     );
   });
 
-  it('displays nothing when no license key was provided', () => {
-    LicenseStatus.display(makeResult('FREE', 'active'), false);
+  it("displays FREE (activation-limit-reached) for exhausted seats", () => {
+    LicenseStatus.display(makeResult("FREE", "activation-limit-reached"), true);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "License: FREE (activation-limit-reached — all seats consumed for this key)",
+    );
+  });
+
+  it("displays FREE (network-error) for license server failure", () => {
+    LicenseStatus.display(makeResult("FREE", "network-error"), true);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "License: FREE (network-error — could not reach license server)",
+    );
+  });
+
+  it("displays nothing when no license key was provided", () => {
+    LicenseStatus.display(makeResult("FREE", "active"), false);
 
     expect(logSpy).not.toHaveBeenCalled();
   });
 
-  it('displays nothing when results have no successful components', () => {
+  it("displays nothing when results have no successful components", () => {
     const errorResults: ComponentsData[] = [
-      { name: 'Button', error: 'Component not found' } as any
+      { name: "Button", error: "Component not found" } as any,
     ];
 
     LicenseStatus.display(errorResults, true);
@@ -395,58 +478,68 @@ describe('displayLicenseStatus', () => {
     expect(logSpy).not.toHaveBeenCalled();
   });
 
-  it('displays nothing when component has no generator metadata', () => {
-    const results: ComponentsData[] = [{
-      name: 'Button',
-      component: { title: 'Button', metadata: {} }
-    }] as any;
-
-    LicenseStatus.display(results, true);
-
-    expect(logSpy).not.toHaveBeenCalled();
-  });
-
-  it('displays nothing when component has no license in generator', () => {
-    const results: ComponentsData[] = [{
-      name: 'Button',
-      component: { title: 'Button', metadata: { generator: {} } }
-    }] as any;
-
-    LicenseStatus.display(results, true);
-
-    expect(logSpy).not.toHaveBeenCalled();
-  });
-
-  it('uses first successful result for license info (multiple results)', () => {
+  it("displays nothing when component has no generator metadata", () => {
     const results: ComponentsData[] = [
-      { name: 'Button', error: 'failed' } as any,
       {
-        name: 'Alert',
+        name: "Button",
+        component: { title: "Button", metadata: {} },
+      },
+    ] as any;
+
+    LicenseStatus.display(results, true);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("displays nothing when component has no license in generator", () => {
+    const results: ComponentsData[] = [
+      {
+        name: "Button",
+        component: { title: "Button", metadata: { generator: {} } },
+      },
+    ] as any;
+
+    LicenseStatus.display(results, true);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses first successful result for license info (multiple results)", () => {
+    const results: ComponentsData[] = [
+      { name: "Button", error: "failed" } as any,
+      {
+        name: "Alert",
         component: {
-          title: 'Alert',
-          metadata: { generator: { license: { level: 'PRO', status: 'active' } } }
-        }
+          title: "Alert",
+          metadata: {
+            generator: { license: { level: "PRO", status: "active" } },
+          },
+        },
       } as any,
       {
-        name: 'Modal',
+        name: "Modal",
         component: {
-          title: 'Modal',
-          metadata: { generator: { license: { level: 'PRO', status: 'active' } } }
-        }
-      } as any
+          title: "Modal",
+          metadata: {
+            generator: { license: { level: "PRO", status: "active" } },
+          },
+        },
+      } as any,
     ];
 
     LicenseStatus.display(results, true);
 
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith('License: PRO (active)');
+    expect(logSpy).toHaveBeenCalledWith("License: PRO (active)");
   });
 
-  it('handles unknown status gracefully', () => {
-    LicenseStatus.display(makeResult('FREE', 'some-future-status'), true);
+  it("handles unknown status gracefully", () => {
+    LicenseStatus.display(makeResult("FREE", "some-future-status"), true);
 
     // Falls through to default: uses status as its own description
-    expect(logSpy).toHaveBeenCalledWith('License: FREE (some-future-status — some-future-status)');
+    expect(logSpy).toHaveBeenCalledWith(
+      "License: FREE (some-future-status — some-future-status)",
+    );
   });
 });
 
@@ -454,62 +547,66 @@ describe('displayLicenseStatus', () => {
 // OUTPUT PATH RESOLUTION (#34)
 // ============================================================================
 
-describe('output path resolution', () => {
+describe("output path resolution", () => {
   // Tests the logic that prevents EISDIR when outputDirectory is an existing
   // directory in single-file mode. The fix appends `library.{format}` when
   // outputPath is an existing directory and no split mode is active.
 
-  it('appends default filename when outputPath is a directory in single-file mode', () => {
+  it("appends default filename when outputPath is a directory in single-file mode", () => {
     // Simulates the fix logic from GenerateCommand
     const isSingleFileMode = true;
     const isDirectory = true;
-    const outputPath = '/project/specs';
-    const resolvedFormat = 'yaml';
+    const outputPath = "/project/specs";
+    const resolvedFormat = "yaml";
 
-    const result = (isSingleFileMode && isDirectory)
-      ? `${outputPath}/library.${resolvedFormat}`
-      : outputPath;
+    const result =
+      isSingleFileMode && isDirectory
+        ? `${outputPath}/library.${resolvedFormat}`
+        : outputPath;
 
-    expect(result).toBe('/project/specs/library.yaml');
+    expect(result).toBe("/project/specs/library.yaml");
   });
 
-  it('appends library.json when format is json', () => {
+  it("appends library.json when format is json", () => {
     const isSingleFileMode = true;
     const isDirectory = true;
-    const outputPath = '/project/specs';
-    const resolvedFormat = 'json';
+    const outputPath = "/project/specs";
+    const resolvedFormat = "json";
 
-    const result = (isSingleFileMode && isDirectory)
-      ? `${outputPath}/library.${resolvedFormat}`
-      : outputPath;
+    const result =
+      isSingleFileMode && isDirectory
+        ? `${outputPath}/library.${resolvedFormat}`
+        : outputPath;
 
-    expect(result).toBe('/project/specs/library.json');
+    expect(result).toBe("/project/specs/library.json");
   });
 
-  it('does not modify outputPath in split-components mode even if path is a directory', () => {
+  it("does not modify outputPath in split-components mode even if path is a directory", () => {
     const isSingleFileMode = false; // splitComponents is true
     const isDirectory = true;
-    const outputPath = '/project/specs';
-    const resolvedFormat = 'yaml';
+    const outputPath = "/project/specs";
+    const resolvedFormat = "yaml";
 
-    const result = (isSingleFileMode && isDirectory)
-      ? `${outputPath}/library.${resolvedFormat}`
-      : outputPath;
+    const result =
+      isSingleFileMode && isDirectory
+        ? `${outputPath}/library.${resolvedFormat}`
+        : outputPath;
 
-    expect(result).toBe('/project/specs');
+    expect(result).toBe("/project/specs");
   });
 
-  it('does not modify outputPath when path is a file (not a directory)', () => {
+  it("does not modify outputPath when path is a file (not a directory)", () => {
     const isSingleFileMode = true;
     const isDirectory = false;
-    const outputPath = '/project/specs.yaml';
-    const resolvedFormat = 'yaml';
+    const outputPath = "/project/specs.yaml";
+    const resolvedFormat = "yaml";
 
-    const result = (isSingleFileMode && isDirectory)
-      ? `${outputPath}/library.${resolvedFormat}`
-      : outputPath;
+    const result =
+      isSingleFileMode && isDirectory
+        ? `${outputPath}/library.${resolvedFormat}`
+        : outputPath;
 
-    expect(result).toBe('/project/specs.yaml');
+    expect(result).toBe("/project/specs.yaml");
   });
 });
 
@@ -517,45 +614,45 @@ describe('output path resolution', () => {
 // RESULT DISCRIMINATION
 // ============================================================================
 
-describe('result discrimination', () => {
+describe("result discrimination", () => {
   // Tests the pattern used in GenerateCommand to separate successes from errors:
   //   for (const result of results) {
   //     if ('component' in result) { ... success ... }
   //     else { ... error ... }
   //   }
 
-  it('success results have component property', () => {
+  it("success results have component property", () => {
     const success: ComponentsData = {
-      name: 'Button',
-      component: { title: 'Button' }
+      name: "Button",
+      component: { title: "Button" },
     } as any;
 
-    expect('component' in success).toBe(true);
-    expect('error' in success).toBe(false);
+    expect("component" in success).toBe(true);
+    expect("error" in success).toBe(false);
   });
 
-  it('error results have error property', () => {
+  it("error results have error property", () => {
     const error: ComponentsData = {
-      name: 'Button',
-      error: 'Component not found'
+      name: "Button",
+      error: "Component not found",
     } as any;
 
-    expect('error' in error).toBe(true);
-    expect('component' in error).toBe(false);
+    expect("error" in error).toBe(true);
+    expect("component" in error).toBe(false);
   });
 
-  it('mixed results are separated correctly', () => {
+  it("mixed results are separated correctly", () => {
     const results: ComponentsData[] = [
-      { name: 'Button', component: { title: 'Button' } } as any,
-      { name: 'Alert', error: 'Component not found' } as any,
-      { name: 'Modal', component: { title: 'Modal' } } as any,
+      { name: "Button", component: { title: "Button" } } as any,
+      { name: "Alert", error: "Component not found" } as any,
+      { name: "Modal", component: { title: "Modal" } } as any,
     ];
 
-    const successes = results.filter(r => 'component' in r);
-    const errors = results.filter(r => 'error' in r);
+    const successes = results.filter((r) => "component" in r);
+    const errors = results.filter((r) => "error" in r);
 
     expect(successes).toHaveLength(2);
     expect(errors).toHaveLength(1);
-    expect(errors[0]).toHaveProperty('name', 'Alert');
+    expect(errors[0]).toHaveProperty("name", "Alert");
   });
 });

--- a/packages/cli/tests/unit/utilities/ManifestParserV2.test.ts
+++ b/packages/cli/tests/unit/utilities/ManifestParserV2.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { ManifestParserV2 } from '../../../src/utilities/ManifestParserV2.js';
+import { describe, it, expect } from "vitest";
+import { ManifestParserV2 } from "../../../src/utilities/ManifestParserV2.js";
 
 const V2_FIXTURE = `# Component Manifest
 
@@ -20,47 +20,76 @@ const V2_FIXTURE = `# Component Manifest
 | [x] | Card | 1:45 | COMPONENT | NONE |
 `;
 
-describe('ManifestParserV2', () => {
-  it('detects v2 from header', () => {
+describe("ManifestParserV2", () => {
+  it("detects v2 from header", () => {
     expect(ManifestParserV2.isV2(V2_FIXTURE)).toBe(true);
   });
 
-  it('does not detect v1 (checkbox-list) as v2', () => {
-    const v1 = '# Component Manifest\n\n**File:** x.json\n\n- [x] Button (1:23, COMPONENT_SET)\n';
+  it("does not detect v1 (checkbox-list) as v2", () => {
+    const v1 =
+      "# Component Manifest\n\n**File:** x.json\n\n- [x] Button (1:23, COMPONENT_SET)\n";
     expect(ManifestParserV2.isV2(v1)).toBe(false);
   });
 
-  it('parses metadata fields', () => {
+  it("parses metadata fields", () => {
     const { metadata } = ManifestParserV2.parse(V2_FIXTURE);
     expect(metadata.scanFormatVersion).toBe(2);
-    expect(metadata.file).toBe('data/specs-testing.file.json');
-    expect(metadata.variables).toBe('data/specs-testing.variables.json');
-    expect(metadata.fileLastModified).toBe('2026-05-08T17:48:26Z');
+    expect(metadata.file).toBe("data/specs-testing.file.json");
+    expect(metadata.variables).toBe("data/specs-testing.variables.json");
+    expect(metadata.fileLastModified).toBe("2026-05-08T17:48:26Z");
   });
 
-  it('parses rows with checkbox, type and devStatus', () => {
+  it("parses rows with checkbox, type and devStatus", () => {
     const { components } = ManifestParserV2.parse(V2_FIXTURE);
     expect(components).toHaveLength(3);
     expect(components[0]).toEqual({
-      id: '397:37',
-      name: 'TEST PropBinding 1',
-      type: 'COMPONENT_SET',
+      id: "397:37",
+      name: "TEST PropBinding 1",
+      type: "COMPONENT_SET",
       included: true,
-      devStatus: 'READY_FOR_DEV'
+      devStatus: "READY_FOR_DEV",
     });
     expect(components[1].included).toBe(false);
-    expect(components[1].devStatus).toBe('NONE');
-    expect(components[2]).toMatchObject({ id: '1:45', type: 'COMPONENT', included: true, devStatus: 'NONE' });
+    expect(components[1].devStatus).toBe("NONE");
+    expect(components[2]).toMatchObject({
+      id: "1:45",
+      type: "COMPONENT",
+      included: true,
+      devStatus: "NONE",
+    });
   });
 
-  it('ignores non-row lines (header separator, prose)', () => {
+  it("ignores non-row lines (header separator, prose)", () => {
     const { components } = ManifestParserV2.parse(V2_FIXTURE);
-    expect(components.every(c => /^\d+:\d+$/.test(c.id))).toBe(true);
+    expect(components.every((c) => /^\d+:\d+$/.test(c.id))).toBe(true);
   });
 
-  it('returns empty components when no table rows present', () => {
-    const empty = '**Scan format version:** 2\n\n## Components\n\n| ✓ | Name | ID | Type | Dev Status |\n|---|---|---|---|---|\n';
+  it("returns empty components when no table rows present", () => {
+    const empty =
+      "**Scan format version:** 2\n\n## Components\n\n| ✓ | Name | ID | Type | Dev Status |\n|---|---|---|---|---|\n";
     const { components } = ManifestParserV2.parse(empty);
     expect(components).toEqual([]);
+  });
+
+  it("honors escaped pipes inside component names", () => {
+    const fixture = `**Scan format version:** 2
+
+## Components
+
+| ✓ | Name | ID | Type | Dev Status |
+|------|------|------|------|------------|
+| [x] | Toggle \\| On/Off | 99:1 | COMPONENT | NONE |
+| [x] | .base button | 12719:50050 | COMPONENT_SET | NONE |
+`;
+    const { components } = ManifestParserV2.parse(fixture);
+    expect(components).toHaveLength(2);
+    expect(components[0]).toEqual({
+      id: "99:1",
+      name: "Toggle | On/Off",
+      type: "COMPONENT",
+      included: true,
+      devStatus: "NONE",
+    });
+    expect(components[1].name).toBe(".base button");
   });
 });


### PR DESCRIPTION
## Summary

`specs scan` writes a v2 markdown-table manifest, but `specs generate` only detected the legacy v1 checkbox-list format (`- [`) and failed the documented `scan && generate` round-trip with `Error: Unrecognized source format`. This PR wires the existing `ManifestParserV2` into `GenerateCommand` and fixes a parser bug where escaped pipes (`\|`) emitted by `ScanCommand`'s `escapeCell` were not honored on the read side — the backslash was leaking literally into the parsed component name.

## Changes

- **`GenerateCommand`** — detect v2 manifests via `ManifestParserV2.isV2`, v1 via `isV1Manifest`, JSON unchanged. Parse dispatch now picks the right parser. Error message and exit code are preserved.
- **`ManifestParserV2`** — replaced the combined `ROW_REGEX` with a recognition regex plus an escape-aware `splitRow` walker. Public `ManifestResultV2` shape is unchanged.
- **Tests** — v1 / v2 / JSON / unrecognized detection regressions, plus a v2 escaped-pipe fixture: `Toggle \| On/Off` parses to `Toggle | On/Off`.
- **OpenSpec** — change `generate-v2-manifest-support` (proposal, design, tasks, spec delta) and adds `openspec/config.yaml`.

## Why

The `scan && generate` round-trip is part of the documented CLI workflow. Without v2 support in `generate`, any manifest produced by current `scan` was unusable downstream. The escaped-pipe fix ensures component names containing `|` survive the round-trip intact.

## Files touched

- `packages/cli/src/commands/GenerateCommand.ts`
- `packages/cli/src/utilities/ManifestParserV2.ts`
- `packages/cli/tests/unit/commands/GenerateCommand.test.ts`
- `packages/cli/tests/unit/utilities/ManifestParserV2.test.ts`
- `openspec/config.yaml`
- `openspec/changes/generate-v2-manifest-support/` (proposal, design, tasks, spec delta)

## Test plan

- [ ] `npm test --workspace=packages/cli` passes
- [ ] `npm run build` passes
- [ ] Manual round-trip: `specs scan ...` then `specs generate ...` against the produced v2 manifest succeeds
- [ ] Manifest containing a component name with an escaped pipe (e.g. `Toggle \| On/Off`) round-trips to `Toggle | On/Off`
- [ ] v1 checkbox-list manifests still parse (no regression)
- [ ] JSON manifests still parse (no regression)
- [ ] Unrecognized input still errors with the documented message and exit code
