### PR TITLE
ci(cli): OIDC Trusted Publishing workflow for specs-cli

### DIFF
--- a/.github/agents/CLI.release.agent.md
+++ b/.github/agents/CLI.release.agent.md
@@ -110,6 +110,8 @@ All commands in this agent run from the **CLI package directory**: `packages/cli
       where `$WORKSPACE_ROOT` is the specs-local-workspace directory (typically `../specs-local-workspace` relative to this repo).
       If publish fails with "previously published version", report and ask the user whether to bump the patch version or skip.
 
+      > **Alternative:** instead of publishing locally with the token, you can let CI publish via OIDC Trusted Publishing — see [Trusted Publishing (CI)](#trusted-publishing-ci--alternative-publish-path) below. If you choose CI, **skip this local `npm publish` step** (still commit + tag here, then push the tag in the finalize gate so CI can publish it). Do not do both for the same version, or the second publish fails with "previously published version".
+
 10. **Finalize gate**: Use `AskUserQuestion` with Yes/No options: **"Ready to push, create PR, and GitHub Release for @directededges/specs-cli v[version]?"**
     On Yes:
     1. Push to remote (including the tag):
@@ -154,6 +156,35 @@ All commands in this agent run from the **CLI package directory**: `packages/cli
        gh release view "specs-cli@[version]" --json url --jq '.url'
        ```
     4. Report the PR URL and release URL.
+
+## Trusted Publishing (CI) — alternative publish path
+
+There are **two ways** to publish `@directededges/specs-cli`, and they are mutually exclusive **per version** (publishing once makes the version immutable):
+
+| | Local token publish (default) | CI Trusted Publishing |
+|---|---|---|
+| Where | Your machine, this agent's ship gate | GitHub Actions (`.github/workflows/release-cli.yml`) |
+| Auth | Long-lived token in `$WORKSPACE_ROOT/.npmrc.public` | Short-lived OIDC token minted per run (no stored secret) |
+| Provenance | No | Yes (signed attestation, public repo + public package) |
+| Trigger | Interactive (Yes/No gates here) | `workflow_dispatch` with the tag, gated by the `npm-publish` environment |
+
+This workflow exists **in addition to** the local flow and does not retire it. Trusted Publishing cannot run from a laptop — only from GitHub-hosted runners — so the local token path remains the fallback (and the only option for any urgent hotfix you can't route through CI).
+
+**To release a version via CI instead of locally:**
+
+1. Run this agent's steps 0–8 and the ship gate's commit + tag (steps 9.1–9.2), but **skip the local `npm publish`** (step 9.3).
+2. In the finalize gate, `git push --follow-tags` so the `specs-cli@<version>` tag reaches GitHub.
+3. Trigger the workflow on that tag:
+   ```bash
+   gh workflow run release-cli.yml --repo DirectedEdges/specs -f tag=specs-cli@[version]
+   ```
+4. Approve the run if the `npm-publish` environment requires it, then continue the finalize gate (PR ready + GitHub Release) as usual.
+
+**One-time setup (must be done before CI publish works):**
+
+- On npmjs.com → `@directededges/specs-cli` → Settings → **Trusted Publisher**: register owner `DirectedEdges`, repository `specs`, workflow filename `release-cli.yml`.
+- (Recommended) Create a GitHub **Environment** named `npm-publish` with required reviewers, for a manual-approval gate equivalent to the local ship gate.
+- After CI is verified, you may optionally tighten the package to **"Require two-factor authentication and disallow tokens"** and revoke the automation token — but only do this once you're ready to drop the local token path entirely (it would disable the default flow above).
 
 ## Key rules
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,92 @@
+# Release @directededges/specs-cli to npm via OIDC Trusted Publishing.
+#
+# This is an ALTERNATIVE to the local, token-based publish performed by
+# `.github/agents/CLI.release.agent.md`. It does not replace it. Trusted
+# Publishing cannot run from a laptop — only from GitHub-hosted runners — so
+# this workflow exists for when you want a tokenless, provenance-signed publish.
+#
+# Trigger is manual (workflow_dispatch) on purpose: the local release agent
+# already pushes the `specs-cli@<version>` tag and publishes from your machine.
+# Auto-triggering on that tag would cause a duplicate-publish collision. Run
+# this workflow only when you intend CI to be the publisher for a given version
+# (and skip the agent's local publish step that time).
+#
+# One-time setup before this can succeed:
+#   1. On npmjs.com → @directededges/specs-cli → Settings → Trusted Publisher,
+#      register: Organization/owner = DirectedEdges, Repository = specs,
+#      Workflow filename = release-cli.yml  (must match this file's name).
+#   2. (Recommended) Create a GitHub Environment named `npm-publish` with
+#      required reviewers, so the publish step waits for manual approval.
+#
+# When you are ready to fully retire the local token flow, enable the `push`
+# tag trigger below and remove the `npm publish` step from the release agent.
+
+name: Release specs-cli (Trusted Publishing)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g. specs-cli@0.16.0)'
+        required: true
+        type: string
+  # Enable this only after retiring the agent's local publish, to avoid
+  # publishing the same version twice:
+  # push:
+  #   tags:
+  #     - 'specs-cli@*'
+
+permissions:
+  contents: read
+  id-token: write # required: lets npm mint a short-lived OIDC token
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Manual-approval gate. Configure required reviewers on this environment in
+    # repo Settings → Environments. Remove this line if you don't want a gate.
+    environment: npm-publish
+    steps:
+      - name: Resolve tag
+        id: ref
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22' # Trusted Publishing needs Node >= 22.14.0
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports Trusted Publishing (>= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify tag matches package version
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          EXPECTED="specs-cli@${PKG_VERSION}"
+          if [ "${{ steps.ref.outputs.tag }}" != "$EXPECTED" ]; then
+            echo "::error::Tag '${{ steps.ref.outputs.tag }}' does not match package version ('$EXPECTED')."
+            exit 1
+          fi
+
+      - name: Verify dependency refs are versioned (not file:)
+        run: |
+          if grep -E '"@directededges/[^"]+":\s*"file:' packages/cli/package.json; then
+            echo "::error::package.json has file: dependency refs; release commits must use versioned refs."
+            exit 1
+          fi
+
+      - name: Build
+        run: npm run build --workspace=packages/cli
+
+      - name: Test
+        run: npm run test --workspace=packages/cli
+
+      - name: Publish to npm (OIDC, with provenance)
+        run: npm publish --provenance --access public --workspace=packages/cli


### PR DESCRIPTION
## Summary
Adds an OIDC **Trusted Publishing** path for `@directededges/specs-cli`, in response to npm retiring long-lived automation tokens. **Additive** — the existing local token publish stays the default; nothing is retired.

## What this adds
- **`.github/workflows/release-cli.yml`** — tokenless `npm publish` via GitHub Actions OIDC, with provenance. `workflow_dispatch`-triggered (will not collide with the agent's local tag-push publish) and gated by an `npm-publish` environment.
- **`CLI.release.agent.md`** — new "Trusted Publishing (CI)" section explaining how the two publish paths coexist and how to publish a version via CI instead of locally.

## Required one-time setup (before CI publish works)
1. npmjs.com → `@directededges/specs-cli` → Settings → **Trusted Publisher**: owner `DirectedEdges`, repo `specs`, workflow filename `release-cli.yml`.
2. (Recommended) Create a GitHub **Environment** `npm-publish` with required reviewers (manual-approval gate).

## Not included (by design)
- No change to `specs-schema` (CLI only, per request).
- Local token flow is unchanged; token is not yet disallowed.
- Tag-push auto-trigger is left commented out until you decide to fully migrate.

Review-only — do not merge until you've reviewed the workflow.
