### PR TITLE
Release 0.21.0 (staging) — do not merge until release

### DIFF
--- a/adr/051-platform-token-syntax.md
+++ b/adr/051-platform-token-syntax.md
@@ -1,0 +1,209 @@
+# ADR: Platform Code-Syntax Token Profiles
+
+**Branch**: `051-platform-token-syntax`
+**Created**: 2026-05-20
+**Status**: ACCEPTED
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+`format.tokens` is the token-reference serialization profile on `Config` (and its
+resolved counterpart `ResolvedConfig`). It currently accepts:
+
+```yaml
+format:
+  tokens: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM'  # default: TOKEN
+```
+
+`TOKEN` (the default) emits platform-neutral token references (a `$token` path
+plus `$type`). None of the existing profiles expose Figma's **per-platform code
+syntax** — the developer-facing token name a designer assigns for `WEB`,
+`ANDROID`, and `iOS` via Figma's `codeSyntax` API
+([CodeSyntaxPlatform](https://developers.figma.com/docs/plugins/api/CodeSyntaxPlatform/#code-syntax-platform)).
+
+Specs Classic already offered platform code-syntax selection as its
+`CODE_SYNTAX` property. Specs 2 has no equivalent, so the plugin cannot reach
+parity (tracked in [issue #103](https://github.com/DirectedEdges/specs/issues/103)).
+This ADR records the **contract** change needed to close that gap: new
+serialization profiles selecting a platform's code syntax, with a graceful
+fall back to the `TOKEN` default when a token has no code syntax defined for the
+chosen platform.
+
+---
+
+## Decision Drivers
+
+- **Additive only**: Existing `format.tokens` values and the `TOKEN` default must
+  be untouched, so the change is `MINOR` and breaks no downstream consumer.
+- **Type ↔ schema parity**: The enum must change identically in `types/Config.ts`
+  and `schema/component.schema.json` (Constitution I).
+- **No logic in schema (Constitution II)**: The fall-back-to-`TOKEN` behaviour is
+  a transformer responsibility; the schema only enumerates the selectable
+  profiles. `DEFAULT_CONFIG` stays `TOKEN`.
+- **Naming governance (Constitution VI)**: The feature is intrinsically a Figma
+  concept (Figma's `codeSyntax` per `CodeSyntaxPlatform`). No code platform owns
+  the term, and re-modelling it away from Figma's `WEB`/`ANDROID`/`iOS`
+  vocabulary would lose round-trip fidelity — Rule 3 (defer to Figma) applies.
+- **Parity with Specs Classic**: The profiles must map cleanly to Classic's
+  `CODE_SYNTAX` selection so plugin behaviour is equivalent.
+
+---
+
+## Options Considered
+
+### Option A: Add three platform profiles to `format.tokens` *(Selected)*
+
+Extend the existing `format.tokens` enum with `FIGMA_SYNTAX_WEB`,
+`FIGMA_SYNTAX_IOS`, and `FIGMA_SYNTAX_ANDROID`. Each selects the corresponding
+platform's Figma `codeSyntax` value, falling back to the `TOKEN` profile's
+output when that platform has no code syntax defined.
+
+**Pros**:
+- Additive — no existing value or default changes (`MINOR`).
+- Reuses the one knob designers already understand for token serialization.
+- Mirrors the structure of the existing `TOKEN_*` / `FIGMA_NAME` family.
+
+**Cons / Trade-offs**:
+- Couples platform selection into a single enum rather than a dedicated field;
+  acceptable because all values are mutually exclusive serialization profiles.
+
+---
+
+### Option B: New dedicated `format.codeSyntaxPlatform` field *(Rejected)*
+
+Add a separate `format.codeSyntaxPlatform?: 'WEB' | 'IOS' | 'ANDROID'` field
+orthogonal to `format.tokens`.
+
+**Rejected because**: It creates two interacting knobs (which wins when both are
+set?), expanding the contract surface and the fall-back matrix the transformer
+must define — more complexity for no expressive gain over Option A. The values
+are mutually exclusive profiles, which `format.tokens` already models.
+
+---
+
+### Option C: Single `FIGMA_SYNTAX` profile resolving platform at runtime *(Rejected)*
+
+One enum value whose target platform is inferred from environment/context.
+
+**Rejected because**: It pushes platform selection into runtime logic and hides
+intent from the serialized config, undermining the explicit, mechanically
+verifiable contract. Parity with Classic's explicit per-platform selection would
+be lost.
+
+---
+
+## Decision
+
+Add three platform code-syntax profiles to the `format.tokens` enum. The default
+remains `TOKEN`. When the selected platform has no `codeSyntax` for a given
+token, the transformer emits the `TOKEN`-profile output (documented behaviour,
+not a schema constraint).
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Config.ts` | Add `FIGMA_SYNTAX_WEB`, `FIGMA_SYNTAX_IOS`, `FIGMA_SYNTAX_ANDROID` to the `format.tokens` union on `Config` | MINOR |
+| `Config.ts` | Add the same three members to the `format.tokens` union on `ResolvedConfig` | MINOR |
+
+**Example — new shape** (`types/Config.ts`):
+```yaml
+# Before
+format:
+  tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM'
+
+# After
+format:
+  tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM'
+         | 'FIGMA_SYNTAX_WEB' | 'FIGMA_SYNTAX_IOS' | 'FIGMA_SYNTAX_ANDROID'
+# default unchanged: TOKEN
+```
+
+`DEFAULT_CONFIG.format.tokens` stays `'TOKEN'` — unchanged.
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Append `FIGMA_SYNTAX_WEB`, `FIGMA_SYNTAX_IOS`, `FIGMA_SYNTAX_ANDROID` to `#/definitions/Config/.../tokens.enum` | MINOR |
+
+**Example — new shape** (`schema/component.schema.json`, `#/definitions/Config` → `format.tokens`):
+```yaml
+tokens:
+  type: string
+  enum:
+    - TOKEN
+    - TOKEN_NAME
+    - TOKEN_FIGMA_EXTENSIONS
+    - FIGMA_NAME
+    - CUSTOM
+    - FIGMA_SYNTAX_WEB       # new
+    - FIGMA_SYNTAX_IOS       # new
+    - FIGMA_SYNTAX_ANDROID   # new
+  default: TOKEN
+  description: >
+    Token reference serialization profile. Optional; defaults to TOKEN.
+    FIGMA_SYNTAX_WEB | _IOS | _ANDROID emit the platform's Figma codeSyntax,
+    falling back to TOKEN output when the platform has no code syntax defined.
+```
+
+### Notes
+
+- Member naming uses `FIGMA_SYNTAX_<PLATFORM>` in `SCREAMING_CASE`, matching the
+  existing `TOKEN_FIGMA_EXTENSIONS` / `FIGMA_NAME` members and citing
+  Constitution VI Rule 3 (Figma-owned `codeSyntax` concept).
+- `IOS` follows Figma's `iOS` platform key, upper-cased to fit the enum casing
+  convention; `WEB` and `ANDROID` match Figma's keys directly.
+- The empty-code-syntax fall-back is a transformer behaviour, kept out of the
+  schema to honour Constitution II.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — identical three members added to the `format.tokens` union
+  in `Config.ts` (two interfaces) and to the `tokens.enum` array in
+  `component.schema.json`.
+- **Parity check**: `Config.format.tokens` ↔ `#/definitions/Config/properties/format/properties/tokens/enum`.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-schema` | Enum widened; additive `MINOR`-class change | Fold into the in-progress unreleased `0.21.0`, update CHANGELOG |
+| `specs-from-figma` | Must read Figma `codeSyntax` per `CodeSyntaxPlatform` and project tokens for the three new profiles, with fall-back to `TOKEN` output | Implement the new projections; recompile against new types |
+| `specs-cli` | Recompile; surface the new values as selectable token formats | Update config validation/help to accept the new enum values |
+| `specs-plugin-2` | Recompile; expose the three platform profiles in plugin UI to reach Specs Classic `CODE_SYNTAX` parity | Add UI selection mapping to the new enum values |
+
+---
+
+## Semver Decision
+
+**Version**: lands in the in-progress unreleased `0.21.0` (released baseline
+`0.20.0 → 0.21.0`, `MINOR`). No separate bump — `package.json` is already at
+`0.21.0` and this change folds into that release's `Unreleased` CHANGELOG scaffold.
+
+**Justification**: Purely additive — three new optional enum members on an
+existing optional field; no value removed or renamed and the default is
+unchanged. Per Constitution Versioning, additive type/schema changes are `MINOR`;
+the 0.21.0 development cycle already carries that minor bump, so this ADR
+contributes to it rather than opening a new version.
+
+---
+
+## Consequences
+
+- Consumers can select platform-specific code-syntax token serialization
+  (`WEB`, `iOS`, `ANDROID`), bringing Specs 2 to parity with Specs Classic's
+  `CODE_SYNTAX` feature.
+- Tokens without a defined code syntax for the chosen platform degrade gracefully
+  to the existing `TOKEN` output, so the profiles are always safe to select.
+- Tools validating against `component.schema.json` must adopt `0.21.0` to accept
+  the new values.
+- The transformer (`specs-from-figma`) becomes the owner of the documented
+  fall-back semantics; this ADR does not add logic to `specs-schema`.

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -26,6 +26,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 051 | Platform Code-Syntax Token Profiles | Add `FIGMA_SYNTAX_WEB`/`_IOS`/`_ANDROID` to `Config.format.tokens`, emitting per-platform Figma code syntax with fallback to `TOKEN` |
 | 043 | Custom Color Format Configuration | Add `Config.format.color` with 9-format enum (HEX default); rename `ColorValue` → `ColorObject`; widen color types with `string` arm |
 | 041 | Layout Positioning — Constraint-Based Naming | Replace `x`/`y`/`layoutPositioning` with constraint-based `position`, `start`, `end`, `top`, `bottom`, center offsets |
 | 040 | Replace `primaryAxisAlignItems` and `counterAxisAlignItems` with `mainAxisAlignment` and `crossAxisAlignment` | Rename to platform-neutral names; add `MainAxisAlignment` and `CrossAxisAlignment` enums; not token-bindable |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Config.format.tokens` — adds `FIGMA_SYNTAX_WEB`, `FIGMA_SYNTAX_IOS`, `FIGMA_SYNTAX_ANDROID` profiles emitting per-platform Figma code syntax, falling back to `TOKEN`
+
 ### Changed
 
 ### Removed

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -857,10 +857,13 @@
                 "TOKEN_NAME",
                 "TOKEN_FIGMA_EXTENSIONS",
                 "FIGMA_NAME",
-                "CUSTOM"
+                "CUSTOM",
+                "FIGMA_SYNTAX_WEB",
+                "FIGMA_SYNTAX_IOS",
+                "FIGMA_SYNTAX_ANDROID"
               ],
               "default": "TOKEN",
-              "description": "Token reference serialization profile. Optional; defaults to TOKEN. CUSTOM delegates projection entirely to the transformer."
+              "description": "Token reference serialization profile. Optional; defaults to TOKEN. CUSTOM delegates projection entirely to the transformer. FIGMA_SYNTAX_WEB, FIGMA_SYNTAX_IOS, and FIGMA_SYNTAX_ANDROID emit the token's Figma codeSyntax for that platform, falling back to TOKEN output when no code syntax is defined for the platform."
             },
             "color": {
               "type": "string",

--- a/packages/schema/tests/Config.test-d.ts
+++ b/packages/schema/tests/Config.test-d.ts
@@ -151,6 +151,12 @@ const tokenNameConfig: Config = { ...fullConfig, format: { ...fullConfig.format,
 const tokenFigmaExtConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'TOKEN_FIGMA_EXTENSIONS' } };
 const figmaNameConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'FIGMA_NAME' } };
 const customConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'CUSTOM' } };
+const figmaSyntaxWebConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'FIGMA_SYNTAX_WEB' } };
+const figmaSyntaxIosConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'FIGMA_SYNTAX_IOS' } };
+const figmaSyntaxAndroidConfig: Config = { ...fullConfig, format: { ...fullConfig.format, tokens: 'FIGMA_SYNTAX_ANDROID' } };
+
+// @ts-expect-error — invalid tokens profile value
+const _badTokens: Config['format']['tokens'] = 'FIGMA_SYNTAX_DESKTOP';
 
 // ─── DEFAULT_CONFIG is a valid ResolvedConfig ────────────────────────────────
 
@@ -197,7 +203,7 @@ const _kRequired: _KRequired = true;
 type _LRequired = ResolvedConfig['format']['layout'] extends ('LAYOUT' | 'PARENT_CHILDREN' | 'BOTH') ? true : never;
 const _lRequired: _LRequired = true;
 
-type _TRequired = ResolvedConfig['format']['tokens'] extends ('TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM') ? true : never;
+type _TRequired = ResolvedConfig['format']['tokens'] extends ('TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM' | 'FIGMA_SYNTAX_WEB' | 'FIGMA_SYNTAX_IOS' | 'FIGMA_SYNTAX_ANDROID') ? true : never;
 const _tRequired: _TRequired = true;
 
 // include

--- a/packages/schema/types/Config.ts
+++ b/packages/schema/types/Config.ts
@@ -53,8 +53,13 @@ export interface Config {
     keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
     /** Layout representation format. Optional; defaults to LAYOUT. */
     layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
-    /** Token reference serialization profile. Optional; defaults to TOKEN. */
-    tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
+    /**
+     * Token reference serialization profile. Optional; defaults to TOKEN.
+     * `FIGMA_SYNTAX_WEB`, `FIGMA_SYNTAX_IOS`, and `FIGMA_SYNTAX_ANDROID` emit the
+     * token's Figma `codeSyntax` for that platform, falling back to the `TOKEN`
+     * profile's output when no code syntax is defined for the platform. @since 0.21.0
+     */
+    tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM' | 'FIGMA_SYNTAX_WEB' | 'FIGMA_SYNTAX_IOS' | 'FIGMA_SYNTAX_ANDROID';
     /** Color value output format. Optional; defaults to HEX. @since 0.20.0 */
     color?: ColorFormat;
   };
@@ -110,7 +115,7 @@ export interface ResolvedConfig {
     /** Layout representation format. */
     layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /** Token reference serialization profile. */
-    tokens: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
+    tokens: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM' | 'FIGMA_SYNTAX_WEB' | 'FIGMA_SYNTAX_IOS' | 'FIGMA_SYNTAX_ANDROID';
     /** Color value output format. */
     color: ColorFormat;
   };

--- a/site/src/content/docs/config/tokens.md
+++ b/site/src/content/docs/config/tokens.md
@@ -16,6 +16,9 @@ Token reference format profile.
   - `TOKEN_FIGMA_EXTENSIONS` - Token with Figma-specific extension data
   - `FIGMA_NAME` - Raw Figma variable/style names as-is
   - `CUSTOM` - Custom token objects injected via `applyCustomTokens`. Variables/styles with `$custom` use that object verbatim as the property value; those without fall back to `TOKEN_FIGMA_EXTENSIONS` format.
+  - `FIGMA_SYNTAX_WEB` - The token's Figma code syntax for the Web platform. Tokens without a Web code syntax fall back to `TOKEN` output.
+  - `FIGMA_SYNTAX_IOS` - The token's Figma code syntax for the iOS platform. Tokens without an iOS code syntax fall back to `TOKEN` output.
+  - `FIGMA_SYNTAX_ANDROID` - The token's Figma code syntax for the Android platform. Tokens without an Android code syntax fall back to `TOKEN` output.
 
 > **Using CUSTOM**: First run `specs applyCustomTokens <mapping>` to inject `$custom` objects into your fetched data files, then run `batch` or `generate`. The `applyCustomTokens` command auto-discovers variables/styles files from `dataDirectory` and `sources` in this config, or accepts explicit `-v`/`-s` paths. See [applyCustomTokens command](/specs/cli/commands/apply-custom-tokens/) for details.
 

--- a/site/src/content/docs/schema/config.md
+++ b/site/src/content/docs/schema/config.md
@@ -24,7 +24,7 @@ Controls how specs are generated. See the [feature guides](/specs/features/) for
 | `output` | `'JSON' \| 'YAML'` | `'JSON'` | Output file format |
 | `keys` | `'SAFE' \| 'CAMEL' \| 'SNAKE' \| 'KEBAB' \| 'PASCAL' \| 'TRAIN'` | `'SAFE'` | Key casing style |
 | `layout` | `'LAYOUT' \| 'PARENT_CHILDREN' \| 'BOTH'` | `'LAYOUT'` | Element hierarchy representation |
-| `tokens` | `'TOKEN' \| 'TOKEN_NAME' \| 'TOKEN_FIGMA_EXTENSIONS' \| 'FIGMA_NAME' \| 'CUSTOM'` | `'TOKEN'` | Token reference output format |
+| `tokens` | `'TOKEN' \| 'TOKEN_NAME' \| 'TOKEN_FIGMA_EXTENSIONS' \| 'FIGMA_NAME' \| 'CUSTOM' \| 'FIGMA_SYNTAX_WEB' \| 'FIGMA_SYNTAX_IOS' \| 'FIGMA_SYNTAX_ANDROID'` | `'TOKEN'` | Token reference output format — `FIGMA_SYNTAX_*` emit per-platform Figma code syntax, falling back to `TOKEN` |
 | `color` | `ColorFormat` | `'HEX'` | Color value output format — `HEX`, `HEXA`, `RGB`, `RGBA`, `HSLA`, `HSB`, `OKLCH`, `OKLAB`, or `OBJECT` |
 
 ## `include`


### PR DESCRIPTION
**Release-tracking PR for `0.21.0`. Draft — do not merge until the release is cut.**

This PR accumulates the diff of the in-progress `0.21.0` release branch against `main`. It exists for visibility into what 0.21.0 will ship. It should be merged only at release time, after:

- [ ] All ADRs slated for 0.21.0 have landed on `0.21.0`
- [ ] CHANGELOG `## [0.21.0]` heading dated (no longer `Unreleased`)
- [ ] `release: @directededges/specs-schema v0.21.0` commit applied
- [ ] `npm publish` performed (or queued) per the release flow

## ADRs landed so far

- ADR-051 — Platform code-syntax token profiles (#107): adds `FIGMA_SYNTAX_WEB`/`_IOS`/`_ANDROID` to `Config.format.tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)