### PR TITLE
feat(cli): specs transform command + contract transformer (#137)

### DIFF
--- a/packages/cli/src/Types/Transformer.ts
+++ b/packages/cli/src/Types/Transformer.ts
@@ -1,0 +1,11 @@
+export interface TransformerContext {
+  /** Absolute path to the component's output subfolder. */
+  outputDir: string;
+  /** camelCase component folder name (e.g. `egdsButton`). */
+  componentKey: string;
+}
+
+export interface Transformer {
+  readonly name: string;
+  run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void>;
+}

--- a/packages/cli/src/commands/TransformCommand.ts
+++ b/packages/cli/src/commands/TransformCommand.ts
@@ -1,0 +1,116 @@
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import path from 'path';
+import yaml from 'yaml';
+import { ConfigLoader } from '../Config/ConfigLoader.js';
+import { resolveTransformers, DEFAULT_TRANSFORMERS } from '../transforms/index.js';
+import type { TransformerContext } from '../Types/Transformer.js';
+
+const ERROR_CODES = { SUCCESS: 0, INVALID_ARGS: 2, FILE_ERROR: 3, GENERAL_ERROR: 1 };
+
+interface TransformOptions {
+  output?: string;
+  config?: string;
+  verbose: boolean;
+}
+
+export const Transform = new Command('transform')
+  .description('Project component contracts into derived files (contract, css, tokens, …)')
+  .argument('[transformers...]', 'Transformer names to run (default: contract)')
+  .option('-o, --output <path>', 'Path to the specs directory (input and output)')
+  .option('--config <path>', 'Path to config file (specs.config.yaml)')
+  .option('--verbose', 'Enable detailed logging', false)
+  .action(async (transformerNames: string[], options: TransformOptions) => {
+    try {
+      const configLoader = new ConfigLoader();
+      const config = configLoader.load(options.config);
+
+      // Resolve output/input directory: flag → config → cwd
+      const outputPath = options.output
+        ? path.resolve(options.output)
+        : config.outputDirectory
+          ? path.resolve(config.outputDirectory)
+          : path.resolve(process.cwd());
+
+      if (!fs.existsSync(outputPath)) {
+        console.error(`Error: specs directory not found: ${outputPath}`);
+        console.error('Tip: run `specs generate --split-components --split-concerns --use-subfolders` first');
+        process.exit(ERROR_CODES.INVALID_ARGS);
+      }
+
+      // Resolve transformer names: positionals → config.transform → defaults
+      const configTransformers = (config.config?.transform?.transformers ?? []).map(
+        (e: { name: string }) => e.name
+      );
+      const names = transformerNames.length > 0
+        ? transformerNames
+        : configTransformers.length > 0
+          ? configTransformers
+          : DEFAULT_TRANSFORMERS;
+
+      const transformers = resolveTransformers(names);
+      if (transformers.length === 0) {
+        console.error('Error: no valid transformers to run');
+        process.exit(ERROR_CODES.INVALID_ARGS);
+      }
+
+      if (options.verbose) {
+        console.log(`[transform] directory: ${outputPath}`);
+        console.log(`[transform] transformers: ${transformers.map(t => t.name).join(', ')}`);
+      }
+
+      // Discover component subfolders — each must contain api.yaml
+      const entries = await fs.readdir(outputPath, { withFileTypes: true });
+      const componentDirs = entries
+        .filter(e => e.isDirectory())
+        .map(e => e.name)
+        .filter(name => fs.existsSync(path.join(outputPath, name, 'api.yaml')));
+
+      if (componentDirs.length === 0) {
+        console.error(`Error: no component directories with api.yaml found in ${outputPath}`);
+        console.error('Tip: run `specs generate --split-components --split-concerns --use-subfolders` first');
+        process.exit(ERROR_CODES.FILE_ERROR);
+      }
+
+      console.log(`⏳ Transforming ${componentDirs.length} components (${transformers.map(t => t.name).join(', ')})…`);
+      console.log('');
+
+      let succeeded = 0;
+      let failed = 0;
+
+      for (const componentKey of componentDirs) {
+        const componentDir = path.join(outputPath, componentKey);
+        const apiPath = path.join(componentDir, 'api.yaml');
+
+        try {
+          const raw = await fs.readFile(apiPath, 'utf-8');
+          const apiYaml = yaml.parse(raw) as Record<string, unknown>;
+
+          const context: TransformerContext = { outputDir: componentDir, componentKey };
+
+          for (const transformer of transformers) {
+            await transformer.run(apiYaml, context);
+          }
+
+          if (options.verbose) {
+            console.log(`  ✓ ${componentKey}`);
+          }
+          succeeded++;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`  ✗ ${componentKey}: ${msg}`);
+          failed++;
+        }
+      }
+
+      console.log('');
+      console.log(`✓ Transform complete`);
+      console.log(`  ${succeeded} succeeded${failed > 0 ? `, ${failed} failed` : ''}`);
+
+      process.exit(failed > 0 ? ERROR_CODES.GENERAL_ERROR : ERROR_CODES.SUCCESS);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Error: ${message}`);
+      process.exit(ERROR_CODES.GENERAL_ERROR);
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,20 +26,22 @@ import { Scan } from './commands/ScanCommand.js';
 import { Fetch } from './commands/FetchCommand.js';
 import { Init } from './commands/InitCommand.js';
 import { ApplyCustomTokens } from './commands/ApplyCustomTokensCommand.js';
+import { Transform } from './commands/TransformCommand.js';
 
 declare const __SPECS_CLI_VERSION__;
 
 // Backward compatibility: export Scan also as Audit
 export const Audit = Scan;
 
-export { Generate, Scan, Fetch, Init, ApplyCustomTokens };
+export { Generate, Scan, Fetch, Init, ApplyCustomTokens, Transform };
 
 export const commands = {
   Init,
   Generate,
   Scan,
   Fetch,
-  ApplyCustomTokens
+  ApplyCustomTokens,
+  Transform,
 };
 
 export function createProgram(): Command {
@@ -55,6 +57,7 @@ export function createProgram(): Command {
   program.addCommand(Scan);
   program.addCommand(Fetch);
   program.addCommand(ApplyCustomTokens);
+  program.addCommand(Transform);
 
   // Deprecated alias: 'audit' → 'scan'
   const auditAlias = new Command('audit')

--- a/packages/cli/src/transforms/Contract.ts
+++ b/packages/cli/src/transforms/Contract.ts
@@ -1,0 +1,87 @@
+import fs from 'fs-extra';
+import path from 'path';
+import type { Transformer, TransformerContext } from '../Types/Transformer.js';
+
+export class ContractTransformer implements Transformer {
+  readonly name = 'contract';
+
+  async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
+    const { outputDir, componentKey } = context;
+    const title = (apiYaml.title as string) ?? componentKey;
+    const prefix = toPascalCase(componentKey);
+    const props = (apiYaml.props ?? {}) as Record<string, unknown>;
+
+    const lines: string[] = [
+      '// Generated. Do not edit — regenerate with `specs transform`.',
+      '',
+    ];
+
+    // Collect prop metadata in one pass
+    const enumTypes: Array<{ typeName: string; values: string[] }> = [];
+    const propEntries: Array<{ key: string; tsType: string; hasDefault: boolean; defaultValue: unknown }> = [];
+
+    for (const [key, raw] of Object.entries(props)) {
+      const prop = raw as Record<string, unknown>;
+      const type = prop.type as string;
+
+      if (type === 'slot') continue; // slots deferred
+
+      const isNullable = prop.nullable === true || prop.default === null;
+      const hasDefault = 'default' in prop;
+      const defaultValue = prop.default;
+
+      let tsType: string;
+
+      if (type === 'boolean') {
+        tsType = 'boolean';
+      } else if (type === 'number') {
+        tsType = 'number';
+      } else if (type === 'string' && Array.isArray(prop.enum)) {
+        const typeName = `${prefix}${toPascalCase(key)}`;
+        const values = prop.enum as string[];
+        enumTypes.push({ typeName, values });
+        tsType = isNullable ? `${typeName} | null` : typeName;
+      } else {
+        tsType = isNullable ? 'string | null' : 'string';
+      }
+
+      propEntries.push({ key, tsType, hasDefault, defaultValue });
+    }
+
+    // Emit enum types
+    for (const { typeName, values } of enumTypes) {
+      lines.push(`export type ${typeName} =`);
+      for (const v of values) {
+        lines.push(`  | '${v}'`);
+      }
+      lines[lines.length - 1] += ';';
+    }
+    if (enumTypes.length > 0) lines.push('');
+
+    // Emit Props interface
+    lines.push(`export interface ${prefix}Props {`);
+    for (const { key, tsType } of propEntries) {
+      lines.push(`  ${key}?: ${tsType};`);
+    }
+    lines.push('}');
+    lines.push('');
+
+    // Emit Defaults — only props with a declared default
+    const defaultEntries = propEntries.filter(p => p.hasDefault);
+    if (defaultEntries.length > 0) {
+      lines.push(`export const ${prefix}Defaults = {`);
+      for (const { key, defaultValue } of defaultEntries) {
+        lines.push(`  ${key}: ${JSON.stringify(defaultValue)},`);
+      }
+      lines.push(`} satisfies ${prefix}Props;`);
+      lines.push('');
+    }
+
+    const outputPath = path.join(outputDir, 'contract.ts');
+    await fs.writeFile(outputPath, lines.join('\n'), 'utf-8');
+  }
+}
+
+function toPascalCase(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/cli/src/transforms/index.ts
+++ b/packages/cli/src/transforms/index.ts
@@ -1,0 +1,23 @@
+import type { Transformer } from '../Types/Transformer.js';
+import { ContractTransformer } from './Contract.js';
+
+const ALL_TRANSFORMERS: Transformer[] = [
+  new ContractTransformer(),
+];
+
+const BY_NAME = new Map(ALL_TRANSFORMERS.map(t => [t.name, t]));
+
+export const DEFAULT_TRANSFORMERS = ['contract'];
+
+export function resolveTransformers(names: string[]): Transformer[] {
+  const resolved: Transformer[] = [];
+  for (const name of names) {
+    const t = BY_NAME.get(name);
+    if (t) {
+      resolved.push(t);
+    } else {
+      console.warn(`Warning: unknown transformer "${name}" — skipping`);
+    }
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary

- Adds `specs transform` command — discovers component subfolders with `api.yaml` and runs named transformers
- Adds `contract` transformer — emits `contract.ts` per component with enum union types, Props interface, and Defaults constant
- Transformer resolution: positional args → `config.transform.transformers` → defaults (`contract`)
- Output dir resolution: `-o` flag → `config.outputDirectory` → cwd
- Slot props deferred to a future transformer pass

## Test plan

- [ ] `specs transform -o ./specs` in `specs-testing/eg/` — 66 components, 66 succeeded
- [ ] `egdsButton/contract.ts` — enum types, Props interface, Defaults with `satisfies EgdsButtonProps`
- [ ] Components with no defaults (`egdsDivider`) — empty interface, no Defaults block
- [ ] Components with nullable props (`egdsAlert.icon`) — `string | null` type, `null` default

Closes DirectedEdges/specs#137

🤖 Generated with [Claude Code](https://claude.com/claude-code)