### PR TITLE
feat(cli): styling transformer — token inventory per component and subcomponent (#138)

### DIFF
--- a/packages/cli/src/Types/Transformer.ts
+++ b/packages/cli/src/Types/Transformer.ts
@@ -8,4 +8,6 @@ export interface TransformerContext {
 export interface Transformer {
   readonly name: string;
   run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void>;
+  /** Called once after all components have been processed. Use for cross-component aggregate output. */
+  finalize?(outputDir: string): Promise<void>;
 }

--- a/packages/cli/src/commands/TransformCommand.ts
+++ b/packages/cli/src/commands/TransformCommand.ts
@@ -103,6 +103,12 @@ export const Transform = new Command('transform')
         }
       }
 
+      for (const transformer of transformers) {
+        if (transformer.finalize) {
+          await transformer.finalize(outputPath);
+        }
+      }
+
       console.log('');
       console.log(`✓ Transform complete`);
       console.log(`  ${succeeded} succeeded${failed > 0 ? `, ${failed} failed` : ''}`);

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -63,16 +63,16 @@ export class StylingTransformer implements Transformer {
 
     const rows = new Map<string, StylingRow>();
 
-    const defaultSection = source.default as Record<string, unknown> | undefined;
-    if (defaultSection?.elements) {
-      collectElements(defaultSection.elements as Record<string, unknown>, elementTypes, rows);
-    }
+    collectDefaultAndVariants(source, elementTypes, rows);
 
-    const variants = (source.variants ?? []) as Array<Record<string, unknown>>;
-    for (const variant of variants) {
-      if (variant.elements) {
-        collectElements(variant.elements as Record<string, unknown>, elementTypes, rows);
-      }
+    // Subcomponents have their own default/variants and anatomy (from api.yaml).
+    const apiSubcomponents = (apiYaml.subcomponents ?? {}) as Record<string, unknown>;
+    const sourceSubcomponents = (source.subcomponents ?? {}) as Record<string, unknown>;
+    for (const [subName, subSource] of Object.entries(sourceSubcomponents)) {
+      const subApiEntry = apiSubcomponents[subName] as Record<string, unknown> | undefined;
+      const subAnatomy = (subApiEntry?.anatomy ?? {}) as Record<string, unknown>;
+      const subElementTypes = extractElementTypes(subAnatomy);
+      collectDefaultAndVariants(subSource as Record<string, unknown>, subElementTypes, rows);
     }
 
     const sorted = Array.from(rows.values()).sort(compareRows);
@@ -160,6 +160,23 @@ function extractElementTypes(anatomy: Record<string, unknown>): Map<string, stri
     }
   }
   return types;
+}
+
+function collectDefaultAndVariants(
+  source: Record<string, unknown>,
+  elementTypes: Map<string, string>,
+  rows: Map<string, StylingRow>
+): void {
+  const defaultSection = source.default as Record<string, unknown> | undefined;
+  if (defaultSection?.elements) {
+    collectElements(defaultSection.elements as Record<string, unknown>, elementTypes, rows);
+  }
+  const variants = (source.variants ?? []) as Array<Record<string, unknown>>;
+  for (const variant of variants) {
+    if (variant.elements) {
+      collectElements(variant.elements as Record<string, unknown>, elementTypes, rows);
+    }
+  }
 }
 
 function collectElements(

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -48,6 +48,7 @@ const CATEGORY_KEY: Record<StylingCategory, keyof StylingJson> = {
 export class StylingTransformer implements Transformer {
   readonly name = 'styling';
 
+  // Flat map: "componentKey" and "componentKey.subName" entries stored together.
   private readonly _componentData = new Map<string, StylingJson>();
 
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
@@ -61,37 +62,33 @@ export class StylingTransformer implements Transformer {
     const variantsYaml = await loadVariantsYaml(outputDir);
     const source = variantsYaml ?? apiYaml;
 
-    const rows = new Map<string, StylingRow>();
+    // Build one StylingJson per scope: top-level component + each subcomponent.
+    const scopes = new Map<string, StylingJson>();
 
-    collectDefaultAndVariants(source, elementTypes, rows);
+    const topRows = new Map<string, StylingRow>();
+    collectDefaultAndVariants(source, elementTypes, topRows);
+    scopes.set(componentKey, buildStylingJson(topRows));
 
-    // Subcomponents have their own default/variants and anatomy (from api.yaml).
     const apiSubcomponents = (apiYaml.subcomponents ?? {}) as Record<string, unknown>;
     const sourceSubcomponents = (source.subcomponents ?? {}) as Record<string, unknown>;
     for (const [subName, subSource] of Object.entries(sourceSubcomponents)) {
       const subApiEntry = apiSubcomponents[subName] as Record<string, unknown> | undefined;
       const subAnatomy = (subApiEntry?.anatomy ?? {}) as Record<string, unknown>;
       const subElementTypes = extractElementTypes(subAnatomy);
-      collectDefaultAndVariants(subSource as Record<string, unknown>, subElementTypes, rows);
+      const subRows = new Map<string, StylingRow>();
+      collectDefaultAndVariants(subSource as Record<string, unknown>, subElementTypes, subRows);
+      scopes.set(`${componentKey}.${subName}`, buildStylingJson(subRows));
     }
 
-    const sorted = Array.from(rows.values()).sort(compareRows);
-
-    const output: StylingJson = { variables: [], colorStyles: [], textStyles: [], effectStyles: [] };
-
-    for (const row of sorted) {
-      const appliedTo: Record<string, number> = Object.fromEntries(
-        Array.from(row.appliedTo.entries()).sort((a, b) => a[0].localeCompare(b[0]))
-      );
-      const jsonRow: StylingRowJson = { name: row.name, appliedAs: row.appliedAs, appliedTo };
-      if (row.rawValue !== undefined) jsonRow.rawValue = row.rawValue;
-      output[CATEGORY_KEY[row.category]].push(jsonRow);
+    // Persist each scope to _componentData and write the per-component file.
+    const fileOutput: Record<string, StylingJson> = {};
+    for (const [scopeKey, data] of scopes) {
+      this._componentData.set(scopeKey, data);
+      fileOutput[scopeKey] = data;
     }
-
-    this._componentData.set(componentKey, output);
 
     const outputPath = path.join(outputDir, 'styling.json');
-    await fs.writeFile(outputPath, JSON.stringify(output, null, 2) + '\n', 'utf-8');
+    await fs.writeFile(outputPath, JSON.stringify(fileOutput, null, 2) + '\n', 'utf-8');
   }
 
   async finalize(outputDir: string): Promise<void> {
@@ -106,8 +103,8 @@ export class StylingTransformer implements Transformer {
 
   private async _writeByComponent(dictDir: string): Promise<void> {
     const out: Record<string, StylingJson> = {};
-    for (const [componentKey, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
-      out[componentKey] = stripRawValues(data);
+    for (const [key, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+      out[key] = stripRawValues(data);
     }
     await fs.writeFile(path.join(dictDir, 'styling.byComponent.json'), JSON.stringify(out, null, 2) + '\n', 'utf-8');
   }
@@ -120,17 +117,31 @@ export class StylingTransformer implements Transformer {
       effectStyles: {},
     };
 
-    for (const [componentKey, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+    for (const [scopeKey, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
       for (const groupKey of CATEGORY_KEYS) {
         for (const row of data[groupKey]) {
           const entries = out[groupKey][row.name] ?? (out[groupKey][row.name] = []);
-          entries.push({ component: componentKey, appliedAs: row.appliedAs, appliedTo: row.appliedTo });
+          entries.push({ component: scopeKey, appliedAs: row.appliedAs, appliedTo: row.appliedTo });
         }
       }
     }
 
     await fs.writeFile(path.join(dictDir, 'styling.byToken.json'), JSON.stringify(out, null, 2) + '\n', 'utf-8');
   }
+}
+
+function buildStylingJson(rows: Map<string, StylingRow>): StylingJson {
+  const sorted = Array.from(rows.values()).sort(compareRows);
+  const output: StylingJson = { variables: [], colorStyles: [], textStyles: [], effectStyles: [] };
+  for (const row of sorted) {
+    const appliedTo: Record<string, number> = Object.fromEntries(
+      Array.from(row.appliedTo.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+    );
+    const jsonRow: StylingRowJson = { name: row.name, appliedAs: row.appliedAs, appliedTo };
+    if (row.rawValue !== undefined) jsonRow.rawValue = row.rawValue;
+    output[CATEGORY_KEY[row.category]].push(jsonRow);
+  }
+  return output;
 }
 
 function stripRawValues(data: StylingJson): StylingJson {

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -118,27 +118,45 @@ function collectElements(
     const elementType = elementTypes.get(elementName) ?? 'container';
 
     for (const [styleKey, styleValue] of Object.entries(styles)) {
-      if (styleValue === null || styleValue === undefined) continue;
+      collectTokens(elementName, [styleKey], styleValue, elementType, rows);
+    }
+  }
+}
 
-      const tokenRef = asTokenReference(styleValue);
-      if (tokenRef) {
-        const { name, rawValue, category } = resolveToken(tokenRef);
-        const appliedAs = appliedAsForKey(styleKey, elementType);
-        const rowKey = `${category}\x00${name}\x00${appliedAs}`;
+function collectTokens(
+  elementName: string,
+  keyPath: string[],
+  value: unknown,
+  elementType: string,
+  rows: Map<string, StylingRow>
+): void {
+  if (value === null || value === undefined) return;
 
-        const existing = rows.get(rowKey);
-        if (existing) {
-          existing.appliedTo.set(elementName, (existing.appliedTo.get(elementName) ?? 0) + 1);
-        } else {
-          rows.set(rowKey, {
-            category,
-            name,
-            appliedAs,
-            rawValue,
-            appliedTo: new Map([[elementName, 1]]),
-          });
-        }
-      }
+  const tokenRef = asTokenReference(value);
+  if (tokenRef) {
+    const appliedAs = appliedAsForPath(keyPath, elementType);
+    const { name, rawValue, category } = resolveToken(tokenRef);
+    const rowKey = `${category}\x00${name}\x00${appliedAs}`;
+    const existing = rows.get(rowKey);
+    if (existing) {
+      existing.appliedTo.set(elementName, (existing.appliedTo.get(elementName) ?? 0) + 1);
+    } else {
+      rows.set(rowKey, { category, name, appliedAs, rawValue, appliedTo: new Map([[elementName, 1]]) });
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    // Don't push array index into keyPath — sibling items share the same path.
+    for (const item of value) {
+      collectTokens(elementName, keyPath, item, elementType, rows);
+    }
+    return;
+  }
+
+  if (typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      collectTokens(elementName, [...keyPath, key], child, elementType, rows);
     }
   }
 }
@@ -168,6 +186,15 @@ function categoryForType(type: string): StylingCategory {
   if (type === 'typography') return 'TEXT_STYLES';
   if (type === 'shadow' || type === 'blur' || type === 'effects') return 'EFFECT_STYLES';
   return 'VARIABLES';
+}
+
+function appliedAsForPath(keyPath: string[], elementType: string): string {
+  if (keyPath.length === 0) return 'Unknown';
+  const [root, ...rest] = keyPath;
+  const base = appliedAsForKey(root, elementType);
+  if (rest.length === 0) return base;
+  const suffix = rest.map(k => humanize(k).toLowerCase()).join(' ');
+  return `${base} ${suffix}`;
 }
 
 function appliedAsForKey(key: string, elementType: string): string {

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import yaml from 'yaml';
 import type { Transformer, TransformerContext } from '../Types/Transformer.js';
 
 type StylingCategory = 'VARIABLES' | 'COLOR_STYLES' | 'TEXT_STYLES' | 'EFFECT_STYLES';
@@ -25,14 +26,19 @@ export class StylingTransformer implements Transformer {
     const anatomy = (apiYaml.anatomy ?? {}) as Record<string, unknown>;
     const elementTypes = extractElementTypes(anatomy);
 
+    // In split-concerns output, variant/default element styling lives in variants.yaml.
+    // Fall back to apiYaml itself for single-file format.
+    const variantsYaml = await loadVariantsYaml(outputDir);
+    const source = variantsYaml ?? apiYaml;
+
     const rows = new Map<string, StylingRow>();
 
-    const defaultSection = apiYaml.default as Record<string, unknown> | undefined;
+    const defaultSection = source.default as Record<string, unknown> | undefined;
     if (defaultSection?.elements) {
       collectElements(defaultSection.elements as Record<string, unknown>, elementTypes, rows);
     }
 
-    const variants = (apiYaml.variants ?? []) as Array<Record<string, unknown>>;
+    const variants = (source.variants ?? []) as Array<Record<string, unknown>>;
     for (const variant of variants) {
       if (variant.elements) {
         collectElements(variant.elements as Record<string, unknown>, elementTypes, rows);
@@ -79,6 +85,13 @@ export class StylingTransformer implements Transformer {
     const outputPath = path.join(outputDir, 'styling.ts');
     await fs.writeFile(outputPath, lines.join('\n'), 'utf-8');
   }
+}
+
+async function loadVariantsYaml(outputDir: string): Promise<Record<string, unknown> | null> {
+  const variantsPath = path.join(outputDir, 'variants.yaml');
+  if (!fs.existsSync(variantsPath)) return null;
+  const raw = await fs.readFile(variantsPath, 'utf-8');
+  return yaml.parse(raw) as Record<string, unknown>;
 }
 
 function extractElementTypes(anatomy: Record<string, unknown>): Map<string, string> {
@@ -153,7 +166,7 @@ function resolveToken(ref: { $token: string; $type: string }): {
 
 function categoryForType(type: string): StylingCategory {
   if (type === 'typography') return 'TEXT_STYLES';
-  if (type === 'shadow' || type === 'blur') return 'EFFECT_STYLES';
+  if (type === 'shadow' || type === 'blur' || type === 'effects') return 'EFFECT_STYLES';
   return 'VARIABLES';
 }
 

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -4,24 +4,44 @@ import yaml from 'yaml';
 import type { Transformer, TransformerContext } from '../Types/Transformer.js';
 
 type StylingCategory = 'VARIABLES' | 'COLOR_STYLES' | 'TEXT_STYLES' | 'EFFECT_STYLES';
-type RawValue = string | number | boolean | null;
+type RawValue = string | number | boolean;
 
 interface StylingRow {
   category: StylingCategory;
   name: string;
   appliedAs: string;
-  rawValue: RawValue;
+  rawValue?: RawValue;
   appliedTo: Map<string, number>;
 }
 
+interface StylingRowJson {
+  name: string;
+  appliedAs: string;
+  rawValue?: RawValue;
+  appliedTo: Record<string, number>;
+}
+
+interface StylingJson {
+  variables: StylingRowJson[];
+  colorStyles: StylingRowJson[];
+  textStyles: StylingRowJson[];
+  effectStyles: StylingRowJson[];
+}
+
 const CATEGORY_ORDER: StylingCategory[] = ['VARIABLES', 'COLOR_STYLES', 'TEXT_STYLES', 'EFFECT_STYLES'];
+
+const CATEGORY_KEY: Record<StylingCategory, keyof StylingJson> = {
+  VARIABLES: 'variables',
+  COLOR_STYLES: 'colorStyles',
+  TEXT_STYLES: 'textStyles',
+  EFFECT_STYLES: 'effectStyles',
+};
 
 export class StylingTransformer implements Transformer {
   readonly name = 'styling';
 
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
-    const { outputDir, componentKey } = context;
-    const prefix = toPascalCase(componentKey);
+    const { outputDir } = context;
 
     const anatomy = (apiYaml.anatomy ?? {}) as Record<string, unknown>;
     const elementTypes = extractElementTypes(anatomy);
@@ -47,43 +67,19 @@ export class StylingTransformer implements Transformer {
 
     const sorted = Array.from(rows.values()).sort(compareRows);
 
-    const lines: string[] = [
-      '// Generated. Do not edit — regenerate with `specs transform`.',
-      '',
-      "export type StylingCategory = 'VARIABLES' | 'COLOR_STYLES' | 'TEXT_STYLES' | 'EFFECT_STYLES';",
-      '',
-      'export interface StylingRow {',
-      '  category: StylingCategory;',
-      '  name: string;',
-      '  appliedAs: string;',
-      '  rawValue: string | number | boolean | null;',
-      '  appliedTo: Record<string, number>;',
-      '}',
-      '',
-    ];
-
-    lines.push(`export const ${prefix}Styling: readonly StylingRow[] = [`);
+    const output: StylingJson = { variables: [], colorStyles: [], textStyles: [], effectStyles: [] };
 
     for (const row of sorted) {
-      const appliedToEntries = Array.from(row.appliedTo.entries())
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([k, v]) => `'${escapeSingleQuote(k)}': ${v}`)
-        .join(', ');
-
-      lines.push('  {');
-      lines.push(`    category: '${row.category}',`);
-      lines.push(`    name: '${escapeSingleQuote(row.name)}',`);
-      lines.push(`    appliedAs: '${escapeSingleQuote(row.appliedAs)}',`);
-      lines.push(`    rawValue: ${serializeRawValue(row.rawValue)},`);
-      lines.push(`    appliedTo: { ${appliedToEntries} },`);
-      lines.push('  },');
+      const appliedTo: Record<string, number> = Object.fromEntries(
+        Array.from(row.appliedTo.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+      );
+      const jsonRow: StylingRowJson = { name: row.name, appliedAs: row.appliedAs, appliedTo };
+      if (row.rawValue !== undefined) jsonRow.rawValue = row.rawValue;
+      output[CATEGORY_KEY[row.category]].push(jsonRow);
     }
 
-    lines.push('];');
-    lines.push('');
-
-    const outputPath = path.join(outputDir, 'styling.ts');
-    await fs.writeFile(outputPath, lines.join('\n'), 'utf-8');
+    const outputPath = path.join(outputDir, 'styling.json');
+    await fs.writeFile(outputPath, JSON.stringify(output, null, 2) + '\n', 'utf-8');
   }
 }
 
@@ -134,8 +130,8 @@ function collectTokens(
 
   const tokenRef = asTokenReference(value);
   if (tokenRef) {
-    const appliedAs = appliedAsForPath(keyPath, elementType);
-    const { name, rawValue, category } = resolveToken(tokenRef);
+    const appliedAs = keyPath.join('.');
+    const { name, rawValue, category } = resolveToken(tokenRef, keyPath, elementType);
     const rowKey = `${category}\x00${name}\x00${appliedAs}`;
     const existing = rows.get(rowKey);
     if (existing) {
@@ -147,7 +143,7 @@ function collectTokens(
   }
 
   if (Array.isArray(value)) {
-    // Don't push array index into keyPath — sibling items share the same path.
+    // Don't push array index into keyPath — sibling items share the same appliedAs.
     for (const item of value) {
       collectTokens(elementName, keyPath, item, elementType, rows);
     }
@@ -161,70 +157,38 @@ function collectTokens(
   }
 }
 
-function asTokenReference(value: unknown): { $token: string; $type: string } | null {
+interface TokenRef {
+  $token: string;
+  $type: string;
+  $extensions?: { 'com.figma'?: { rawValue?: RawValue } };
+}
+
+function asTokenReference(value: unknown): TokenRef | null {
   if (
     value !== null &&
     typeof value === 'object' &&
     '$token' in (value as object) &&
     '$type' in (value as object)
   ) {
-    return value as { $token: string; $type: string };
+    return value as TokenRef;
   }
   return null;
 }
 
-function resolveToken(ref: { $token: string; $type: string }): {
-  name: string;
-  rawValue: RawValue;
-  category: StylingCategory;
-} {
-  const category = categoryForType(ref.$type);
-  return { name: ref.$token, rawValue: null, category };
+function resolveToken(
+  ref: TokenRef,
+  keyPath: string[],
+  elementType: string
+): { name: string; rawValue: RawValue | undefined; category: StylingCategory } {
+  const category = categoryForType(ref.$type, keyPath, elementType);
+  const rawValue = ref.$extensions?.['com.figma']?.rawValue;
+  return { name: ref.$token, rawValue, category };
 }
 
-function categoryForType(type: string): StylingCategory {
+function categoryForType(type: string, keyPath: string[], elementType: string): StylingCategory {
   if (type === 'typography') return 'TEXT_STYLES';
   if (type === 'shadow' || type === 'blur' || type === 'effects') return 'EFFECT_STYLES';
   return 'VARIABLES';
-}
-
-function appliedAsForPath(keyPath: string[], elementType: string): string {
-  if (keyPath.length === 0) return 'Unknown';
-  const [root, ...rest] = keyPath;
-  const base = appliedAsForKey(root, elementType);
-  if (rest.length === 0) return base;
-  const suffix = rest.map(k => humanize(k).toLowerCase()).join(' ');
-  return `${base} ${suffix}`;
-}
-
-function appliedAsForKey(key: string, elementType: string): string {
-  switch (key) {
-    case 'fills':
-    case 'backgroundColor':
-      if (elementType === 'text') return 'Text color';
-      if (elementType === 'glyph' || elementType === 'vector') return 'Fill color';
-      return 'Background color';
-    case 'fillColor':
-      return 'Fill color';
-    case 'strokes':
-    case 'strokeColor':
-      return 'Stroke color';
-    case 'borderColor':
-      return 'Border color';
-    case 'typography':
-    case 'textStyleId':
-      return 'Text style';
-    case 'effects':
-    case 'effectStyleId':
-      return 'Effect style';
-    default:
-      return humanize(key);
-  }
-}
-
-function humanize(key: string): string {
-  const spaced = key.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
 function compareRows(a: StylingRow, b: StylingRow): number {
@@ -233,18 +197,4 @@ function compareRows(a: StylingRow, b: StylingRow): number {
   if (catA !== catB) return catA - catB;
   if (a.name !== b.name) return a.name.localeCompare(b.name);
   return a.appliedAs.localeCompare(b.appliedAs);
-}
-
-function escapeSingleQuote(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-}
-
-function serializeRawValue(v: RawValue): string {
-  if (v === null) return 'null';
-  if (typeof v === 'string') return `'${escapeSingleQuote(v)}'`;
-  return String(v);
-}
-
-function toPascalCase(str: string): string {
-  return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -28,7 +28,15 @@ interface StylingJson {
   effectStyles: StylingRowJson[];
 }
 
+interface ByTokenEntry {
+  component: string;
+  appliedAs: string;
+  appliedTo: Record<string, number>;
+}
+
 const CATEGORY_ORDER: StylingCategory[] = ['VARIABLES', 'COLOR_STYLES', 'TEXT_STYLES', 'EFFECT_STYLES'];
+
+const CATEGORY_KEYS: Array<keyof StylingJson> = ['variables', 'colorStyles', 'textStyles', 'effectStyles'];
 
 const CATEGORY_KEY: Record<StylingCategory, keyof StylingJson> = {
   VARIABLES: 'variables',
@@ -40,8 +48,10 @@ const CATEGORY_KEY: Record<StylingCategory, keyof StylingJson> = {
 export class StylingTransformer implements Transformer {
   readonly name = 'styling';
 
+  private readonly _componentData = new Map<string, StylingJson>();
+
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
-    const { outputDir } = context;
+    const { outputDir, componentKey } = context;
 
     const anatomy = (apiYaml.anatomy ?? {}) as Record<string, unknown>;
     const elementTypes = extractElementTypes(anatomy);
@@ -78,9 +88,60 @@ export class StylingTransformer implements Transformer {
       output[CATEGORY_KEY[row.category]].push(jsonRow);
     }
 
+    this._componentData.set(componentKey, output);
+
     const outputPath = path.join(outputDir, 'styling.json');
     await fs.writeFile(outputPath, JSON.stringify(output, null, 2) + '\n', 'utf-8');
   }
+
+  async finalize(outputDir: string): Promise<void> {
+    if (this._componentData.size === 0) return;
+
+    const dictDir = path.join(outputDir, '_dictionary');
+    await fs.ensureDir(dictDir);
+
+    await this._writeByComponent(dictDir);
+    await this._writeByToken(dictDir);
+  }
+
+  private async _writeByComponent(dictDir: string): Promise<void> {
+    const out: Record<string, StylingJson> = {};
+    for (const [componentKey, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+      out[componentKey] = stripRawValues(data);
+    }
+    await fs.writeFile(path.join(dictDir, 'styling.byComponent.json'), JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  }
+
+  private async _writeByToken(dictDir: string): Promise<void> {
+    const out: Record<keyof StylingJson, Record<string, ByTokenEntry[]>> = {
+      variables: {},
+      colorStyles: {},
+      textStyles: {},
+      effectStyles: {},
+    };
+
+    for (const [componentKey, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+      for (const groupKey of CATEGORY_KEYS) {
+        for (const row of data[groupKey]) {
+          const entries = out[groupKey][row.name] ?? (out[groupKey][row.name] = []);
+          entries.push({ component: componentKey, appliedAs: row.appliedAs, appliedTo: row.appliedTo });
+        }
+      }
+    }
+
+    await fs.writeFile(path.join(dictDir, 'styling.byToken.json'), JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  }
+}
+
+function stripRawValues(data: StylingJson): StylingJson {
+  const strip = (rows: StylingRowJson[]): StylingRowJson[] =>
+    rows.map(({ rawValue: _omit, ...rest }) => rest);
+  return {
+    variables: strip(data.variables),
+    colorStyles: strip(data.colorStyles),
+    textStyles: strip(data.textStyles),
+    effectStyles: strip(data.effectStyles),
+  };
 }
 
 async function loadVariantsYaml(outputDir: string): Promise<Record<string, unknown> | null> {

--- a/packages/cli/src/transforms/Styling.ts
+++ b/packages/cli/src/transforms/Styling.ts
@@ -1,0 +1,210 @@
+import fs from 'fs-extra';
+import path from 'path';
+import type { Transformer, TransformerContext } from '../Types/Transformer.js';
+
+type StylingCategory = 'VARIABLES' | 'COLOR_STYLES' | 'TEXT_STYLES' | 'EFFECT_STYLES';
+type RawValue = string | number | boolean | null;
+
+interface StylingRow {
+  category: StylingCategory;
+  name: string;
+  appliedAs: string;
+  rawValue: RawValue;
+  appliedTo: Map<string, number>;
+}
+
+const CATEGORY_ORDER: StylingCategory[] = ['VARIABLES', 'COLOR_STYLES', 'TEXT_STYLES', 'EFFECT_STYLES'];
+
+export class StylingTransformer implements Transformer {
+  readonly name = 'styling';
+
+  async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
+    const { outputDir, componentKey } = context;
+    const prefix = toPascalCase(componentKey);
+
+    const anatomy = (apiYaml.anatomy ?? {}) as Record<string, unknown>;
+    const elementTypes = extractElementTypes(anatomy);
+
+    const rows = new Map<string, StylingRow>();
+
+    const defaultSection = apiYaml.default as Record<string, unknown> | undefined;
+    if (defaultSection?.elements) {
+      collectElements(defaultSection.elements as Record<string, unknown>, elementTypes, rows);
+    }
+
+    const variants = (apiYaml.variants ?? []) as Array<Record<string, unknown>>;
+    for (const variant of variants) {
+      if (variant.elements) {
+        collectElements(variant.elements as Record<string, unknown>, elementTypes, rows);
+      }
+    }
+
+    const sorted = Array.from(rows.values()).sort(compareRows);
+
+    const lines: string[] = [
+      '// Generated. Do not edit — regenerate with `specs transform`.',
+      '',
+      "export type StylingCategory = 'VARIABLES' | 'COLOR_STYLES' | 'TEXT_STYLES' | 'EFFECT_STYLES';",
+      '',
+      'export interface StylingRow {',
+      '  category: StylingCategory;',
+      '  name: string;',
+      '  appliedAs: string;',
+      '  rawValue: string | number | boolean | null;',
+      '  appliedTo: Record<string, number>;',
+      '}',
+      '',
+    ];
+
+    lines.push(`export const ${prefix}Styling: readonly StylingRow[] = [`);
+
+    for (const row of sorted) {
+      const appliedToEntries = Array.from(row.appliedTo.entries())
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([k, v]) => `'${escapeSingleQuote(k)}': ${v}`)
+        .join(', ');
+
+      lines.push('  {');
+      lines.push(`    category: '${row.category}',`);
+      lines.push(`    name: '${escapeSingleQuote(row.name)}',`);
+      lines.push(`    appliedAs: '${escapeSingleQuote(row.appliedAs)}',`);
+      lines.push(`    rawValue: ${serializeRawValue(row.rawValue)},`);
+      lines.push(`    appliedTo: { ${appliedToEntries} },`);
+      lines.push('  },');
+    }
+
+    lines.push('];');
+    lines.push('');
+
+    const outputPath = path.join(outputDir, 'styling.ts');
+    await fs.writeFile(outputPath, lines.join('\n'), 'utf-8');
+  }
+}
+
+function extractElementTypes(anatomy: Record<string, unknown>): Map<string, string> {
+  const types = new Map<string, string>();
+  for (const [name, raw] of Object.entries(anatomy)) {
+    const entry = raw as Record<string, unknown>;
+    if (typeof entry.type === 'string') {
+      types.set(name, entry.type);
+    }
+  }
+  return types;
+}
+
+function collectElements(
+  elements: Record<string, unknown>,
+  elementTypes: Map<string, string>,
+  rows: Map<string, StylingRow>
+): void {
+  for (const [elementName, raw] of Object.entries(elements)) {
+    const element = raw as Record<string, unknown>;
+    const styles = element.styles as Record<string, unknown> | undefined;
+    if (!styles) continue;
+
+    const elementType = elementTypes.get(elementName) ?? 'container';
+
+    for (const [styleKey, styleValue] of Object.entries(styles)) {
+      if (styleValue === null || styleValue === undefined) continue;
+
+      const tokenRef = asTokenReference(styleValue);
+      if (tokenRef) {
+        const { name, rawValue, category } = resolveToken(tokenRef);
+        const appliedAs = appliedAsForKey(styleKey, elementType);
+        const rowKey = `${category}\x00${name}\x00${appliedAs}`;
+
+        const existing = rows.get(rowKey);
+        if (existing) {
+          existing.appliedTo.set(elementName, (existing.appliedTo.get(elementName) ?? 0) + 1);
+        } else {
+          rows.set(rowKey, {
+            category,
+            name,
+            appliedAs,
+            rawValue,
+            appliedTo: new Map([[elementName, 1]]),
+          });
+        }
+      }
+    }
+  }
+}
+
+function asTokenReference(value: unknown): { $token: string; $type: string } | null {
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    '$token' in (value as object) &&
+    '$type' in (value as object)
+  ) {
+    return value as { $token: string; $type: string };
+  }
+  return null;
+}
+
+function resolveToken(ref: { $token: string; $type: string }): {
+  name: string;
+  rawValue: RawValue;
+  category: StylingCategory;
+} {
+  const category = categoryForType(ref.$type);
+  return { name: ref.$token, rawValue: null, category };
+}
+
+function categoryForType(type: string): StylingCategory {
+  if (type === 'typography') return 'TEXT_STYLES';
+  if (type === 'shadow' || type === 'blur') return 'EFFECT_STYLES';
+  return 'VARIABLES';
+}
+
+function appliedAsForKey(key: string, elementType: string): string {
+  switch (key) {
+    case 'fills':
+    case 'backgroundColor':
+      if (elementType === 'text') return 'Text color';
+      if (elementType === 'glyph' || elementType === 'vector') return 'Fill color';
+      return 'Background color';
+    case 'fillColor':
+      return 'Fill color';
+    case 'strokes':
+    case 'strokeColor':
+      return 'Stroke color';
+    case 'borderColor':
+      return 'Border color';
+    case 'typography':
+    case 'textStyleId':
+      return 'Text style';
+    case 'effects':
+    case 'effectStyleId':
+      return 'Effect style';
+    default:
+      return humanize(key);
+  }
+}
+
+function humanize(key: string): string {
+  const spaced = key.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function compareRows(a: StylingRow, b: StylingRow): number {
+  const catA = CATEGORY_ORDER.indexOf(a.category);
+  const catB = CATEGORY_ORDER.indexOf(b.category);
+  if (catA !== catB) return catA - catB;
+  if (a.name !== b.name) return a.name.localeCompare(b.name);
+  return a.appliedAs.localeCompare(b.appliedAs);
+}
+
+function escapeSingleQuote(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function serializeRawValue(v: RawValue): string {
+  if (v === null) return 'null';
+  if (typeof v === 'string') return `'${escapeSingleQuote(v)}'`;
+  return String(v);
+}
+
+function toPascalCase(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/cli/src/transforms/index.ts
+++ b/packages/cli/src/transforms/index.ts
@@ -1,8 +1,10 @@
 import type { Transformer } from '../Types/Transformer.js';
 import { ContractTransformer } from './Contract.js';
+import { StylingTransformer } from './Styling.js';
 
 const ALL_TRANSFORMERS: Transformer[] = [
   new ContractTransformer(),
+  new StylingTransformer(),
 ];
 
 const BY_NAME = new Map(ALL_TRANSFORMERS.map(t => [t.name, t]));

--- a/packages/cli/tests/unit/transforms/Styling.test.ts
+++ b/packages/cli/tests/unit/transforms/Styling.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { StylingTransformer } from '../../../src/transforms/Styling.js';
+
+const transformer = new StylingTransformer();
+
+function makeContext(dir: string) {
+  return { outputDir: dir, componentKey: 'dsButton' };
+}
+
+async function run(dir: string, apiYaml: Record<string, unknown>): Promise<string> {
+  await transformer.run(apiYaml, makeContext(dir));
+  return fs.readFile(path.join(dir, 'styling.ts'), 'utf-8');
+}
+
+describe('StylingTransformer', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'styling-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('has name "styling"', () => {
+    expect(transformer.name).toBe('styling');
+  });
+
+  it('writes a styling.ts with header and type declarations', async () => {
+    const out = await run(tmpDir, {});
+    expect(out).toContain('// Generated. Do not edit');
+    expect(out).toContain("export type StylingCategory =");
+    expect(out).toContain('export interface StylingRow {');
+    expect(out).toContain('DsButtonStyling');
+  });
+
+  it('collects variable tokens from default elements', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' },
+            },
+          },
+        },
+      },
+    });
+    expect(out).toContain("category: 'VARIABLES'");
+    expect(out).toContain("name: 'DS Color.Surface.Primary'");
+    expect(out).toContain("appliedAs: 'Background color'");
+    expect(out).toContain("'root': 1");
+  });
+
+  it('classifies typography tokens as TEXT_STYLES', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { label: { type: 'text' } },
+      default: {
+        elements: {
+          label: {
+            styles: {
+              typography: { $token: 'DS Type.Body.Default', $type: 'typography' },
+            },
+          },
+        },
+      },
+    });
+    expect(out).toContain("category: 'TEXT_STYLES'");
+    expect(out).toContain("name: 'DS Type.Body.Default'");
+    expect(out).toContain("appliedAs: 'Text style'");
+  });
+
+  it('classifies shadow tokens as EFFECT_STYLES', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              effects: { $token: 'DS Shadow.Elevation.1', $type: 'shadow' },
+            },
+          },
+        },
+      },
+    });
+    expect(out).toContain("category: 'EFFECT_STYLES'");
+    expect(out).toContain("name: 'DS Shadow.Elevation.1'");
+    expect(out).toContain("appliedAs: 'Effect style'");
+  });
+
+  it('accumulates appliedTo counts across variants', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' },
+            },
+          },
+        },
+      },
+      variants: [
+        {
+          configuration: { appearance: 'secondary' },
+          elements: {
+            root: {
+              styles: {
+                backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' },
+              },
+            },
+          },
+        },
+      ],
+    });
+    expect(out).toContain("'root': 2");
+  });
+
+  it('deduplicates the same token applied across multiple variants', async () => {
+    await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } },
+        },
+      },
+      variants: [
+        {
+          elements: {
+            root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } },
+          },
+        },
+        {
+          elements: {
+            root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } },
+          },
+        },
+      ],
+    });
+    const out = await fs.readFile(path.join(tmpDir, 'styling.ts'), 'utf-8');
+    const occurrences = (out.match(/DS Color\.Surface\.Primary/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('uses fillColor appliedAs for glyph elements', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { icon: { type: 'glyph' } },
+      default: {
+        elements: {
+          icon: {
+            styles: {
+              backgroundColor: { $token: 'DS Color.Icon.Primary', $type: 'color' },
+            },
+          },
+        },
+      },
+    });
+    expect(out).toContain("appliedAs: 'Fill color'");
+  });
+
+  it('uses Text color for text elements with fills/backgroundColor', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { label: { type: 'text' } },
+      default: {
+        elements: {
+          label: {
+            styles: {
+              backgroundColor: { $token: 'DS Color.Text.Primary', $type: 'color' },
+            },
+          },
+        },
+      },
+    });
+    expect(out).toContain("appliedAs: 'Text color'");
+  });
+
+  it('humanizes unknown style keys', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              cornerRadius: { $token: 'DS Shape.Radius.Medium', $type: 'dimension' },
+            },
+          },
+        },
+      },
+    });
+    expect(out).toContain("appliedAs: 'Corner radius'");
+  });
+
+  it('skips non-token style values', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              visible: true,
+              width: 48,
+              strokes: '#FF0000',
+            },
+          },
+        },
+      },
+    });
+    expect(out).toMatch(/DsButtonStyling: readonly StylingRow\[\] = \[\s*\];/);
+  });
+
+  it('output is deterministic for the same input', async () => {
+    const apiYaml = {
+      anatomy: { root: { type: 'container' }, label: { type: 'text' } },
+      default: {
+        elements: {
+          root: { styles: { backgroundColor: { $token: 'DS Color.B', $type: 'color' } } },
+          label: { styles: { backgroundColor: { $token: 'DS Color.A', $type: 'color' } } },
+        },
+      },
+    };
+    const tmpDir2 = await fs.mkdtemp(path.join(os.tmpdir(), 'styling-det-'));
+    try {
+      const out1 = await run(tmpDir, apiYaml);
+      const out2 = await run(tmpDir2, apiYaml);
+      expect(out1).toBe(out2);
+    } finally {
+      await fs.remove(tmpDir2);
+    }
+  });
+
+  it('sorts rows: VARIABLES before TEXT_STYLES, then alphabetical by name', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' }, label: { type: 'text' } },
+      default: {
+        elements: {
+          root: { styles: { backgroundColor: { $token: 'DS Color.Zebra', $type: 'color' } } },
+          label: { styles: { typography: { $token: 'DS Type.Body', $type: 'typography' } } },
+        },
+      },
+    });
+    const varIdx = out.indexOf("'VARIABLES'");
+    const textIdx = out.indexOf("'TEXT_STYLES'");
+    expect(varIdx).toBeGreaterThan(-1);
+    expect(textIdx).toBeGreaterThan(varIdx);
+  });
+});

--- a/packages/cli/tests/unit/transforms/Styling.test.ts
+++ b/packages/cli/tests/unit/transforms/Styling.test.ts
@@ -278,3 +278,109 @@ describe('StylingTransformer', () => {
     expect(names).toEqual([...names].sort());
   });
 });
+
+describe('StylingTransformer.finalize', () => {
+  const TOKEN_A = { $token: 'Color/Primary', $type: 'color' };
+  const TOKEN_B = { $token: 'Typography/Body', $type: 'typography' };
+
+  const COMP_A = {
+    anatomy: { root: { type: 'container' } },
+    default: { elements: { root: { styles: { backgroundColor: TOKEN_A } } } },
+  };
+  const COMP_B = {
+    anatomy: { root: { type: 'container' }, label: { type: 'text' } },
+    default: {
+      elements: {
+        root: { styles: { backgroundColor: TOKEN_A } },
+        label: { styles: { typography: TOKEN_B } },
+      },
+    },
+  };
+
+  let outputDir: string;
+  let compDirA: string;
+  let compDirB: string;
+
+  beforeEach(async () => {
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'styling-dict-'));
+    compDirA = path.join(outputDir, 'compA');
+    compDirB = path.join(outputDir, 'compB');
+    await fs.ensureDir(compDirA);
+    await fs.ensureDir(compDirB);
+  });
+
+  afterEach(async () => {
+    await fs.remove(outputDir);
+  });
+
+  async function runFinalize() {
+    const t = new StylingTransformer();
+    await t.run(COMP_A, { outputDir: compDirA, componentKey: 'compA' });
+    await t.run(COMP_B, { outputDir: compDirB, componentKey: 'compB' });
+    await t.finalize!(outputDir);
+    const byComp = JSON.parse(await fs.readFile(path.join(outputDir, '_dictionary', 'styling.byComponent.json'), 'utf-8'));
+    const byToken = JSON.parse(await fs.readFile(path.join(outputDir, '_dictionary', 'styling.byToken.json'), 'utf-8'));
+    return { byComp, byToken };
+  }
+
+  it('creates _dictionary folder with both files', async () => {
+    await runFinalize();
+    expect(fs.existsSync(path.join(outputDir, '_dictionary', 'styling.byComponent.json'))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, '_dictionary', 'styling.byToken.json'))).toBe(true);
+  });
+
+  it('byComponent keys match component names in alphabetical order', async () => {
+    const { byComp } = await runFinalize();
+    expect(Object.keys(byComp)).toEqual(['compA', 'compB']);
+  });
+
+  it('byComponent entries mirror per-component file structure', async () => {
+    const { byComp } = await runFinalize();
+    expect(byComp.compA.variables).toHaveLength(1);
+    expect(byComp.compA.variables[0].name).toBe('Color/Primary');
+    expect(byComp.compB.textStyles).toHaveLength(1);
+    expect(byComp.compB.textStyles[0].name).toBe('Typography/Body');
+  });
+
+  it('byComponent omits rawValue even when present in per-component file', async () => {
+    const t = new StylingTransformer();
+    const withRaw = {
+      anatomy: { root: { type: 'container' } },
+      default: { elements: { root: { styles: { backgroundColor: { $token: 'DS/X', $type: 'color', $extensions: { 'com.figma': { rawValue: '#FF0000' } } } } } } },
+    };
+    const compDir = path.join(outputDir, 'compRaw');
+    await fs.ensureDir(compDir);
+    await t.run(withRaw, { outputDir: compDir, componentKey: 'compRaw' });
+    await t.finalize!(outputDir);
+    const byComp = JSON.parse(await fs.readFile(path.join(outputDir, '_dictionary', 'styling.byComponent.json'), 'utf-8'));
+    expect('rawValue' in byComp.compRaw.variables[0]).toBe(false);
+  });
+
+  it('byToken groups usages by token name across components', async () => {
+    const { byToken } = await runFinalize();
+    expect(byToken.variables['Color/Primary']).toHaveLength(2);
+    const components = byToken.variables['Color/Primary'].map((e: { component: string }) => e.component).sort();
+    expect(components).toEqual(['compA', 'compB']);
+  });
+
+  it('byToken entries have component, appliedAs, appliedTo — no rawValue', async () => {
+    const { byToken } = await runFinalize();
+    const entry = byToken.variables['Color/Primary'][0];
+    expect(entry).toHaveProperty('component');
+    expect(entry).toHaveProperty('appliedAs');
+    expect(entry).toHaveProperty('appliedTo');
+    expect(entry).not.toHaveProperty('rawValue');
+  });
+
+  it('byToken textStyles contains token from only the component that uses it', async () => {
+    const { byToken } = await runFinalize();
+    expect(byToken.textStyles['Typography/Body']).toHaveLength(1);
+    expect(byToken.textStyles['Typography/Body'][0].component).toBe('compB');
+  });
+
+  it('does nothing when no components were processed', async () => {
+    const t = new StylingTransformer();
+    await t.finalize!(outputDir);
+    expect(fs.existsSync(path.join(outputDir, '_dictionary'))).toBe(false);
+  });
+});

--- a/packages/cli/tests/unit/transforms/Styling.test.ts
+++ b/packages/cli/tests/unit/transforms/Styling.test.ts
@@ -82,7 +82,7 @@ describe('StylingTransformer', () => {
         elements: {
           root: {
             styles: {
-              effects: { $token: 'DS Shadow.Elevation.1', $type: 'shadow' },
+              effects: { $token: 'DS Shadow.Elevation.1', $type: 'effects' },
             },
           },
         },

--- a/packages/cli/tests/unit/transforms/Styling.test.ts
+++ b/packages/cli/tests/unit/transforms/Styling.test.ts
@@ -6,19 +6,19 @@ import { StylingTransformer } from '../../../src/transforms/Styling.js';
 
 const transformer = new StylingTransformer();
 
-function makeContext(dir: string) {
-  return { outputDir: dir, componentKey: 'dsButton' };
+function makeContext(dir: string, componentKey = 'dsButton') {
+  return { outputDir: dir, componentKey };
 }
 
-async function run(dir: string, apiYaml: Record<string, unknown>) {
-  await transformer.run(apiYaml, makeContext(dir));
+async function run(dir: string, apiYaml: Record<string, unknown>, componentKey = 'dsButton') {
+  await transformer.run(apiYaml, makeContext(dir, componentKey));
   const raw = await fs.readFile(path.join(dir, 'styling.json'), 'utf-8');
-  return JSON.parse(raw) as {
+  return JSON.parse(raw) as Record<string, {
     variables: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
     colorStyles: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
     textStyles: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
     effectStyles: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
-  };
+  }>;
 }
 
 describe('StylingTransformer', () => {
@@ -36,12 +36,13 @@ describe('StylingTransformer', () => {
     expect(transformer.name).toBe('styling');
   });
 
-  it('writes styling.json with all four category groups', async () => {
+  it('writes styling.json keyed by componentKey with all four category groups', async () => {
     const out = await run(tmpDir, {});
-    expect(out).toHaveProperty('variables');
-    expect(out).toHaveProperty('colorStyles');
-    expect(out).toHaveProperty('textStyles');
-    expect(out).toHaveProperty('effectStyles');
+    expect(out).toHaveProperty('dsButton');
+    expect(out.dsButton).toHaveProperty('variables');
+    expect(out.dsButton).toHaveProperty('colorStyles');
+    expect(out.dsButton).toHaveProperty('textStyles');
+    expect(out.dsButton).toHaveProperty('effectStyles');
   });
 
   it('collects variable tokens from default elements', async () => {
@@ -57,10 +58,10 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out.variables).toHaveLength(1);
-    expect(out.variables[0].name).toBe('DS Color.Surface.Primary');
-    expect(out.variables[0].appliedAs).toBe('backgroundColor');
-    expect(out.variables[0].appliedTo).toEqual({ root: 1 });
+    expect(out.dsButton.variables).toHaveLength(1);
+    expect(out.dsButton.variables[0].name).toBe('DS Color.Surface.Primary');
+    expect(out.dsButton.variables[0].appliedAs).toBe('backgroundColor');
+    expect(out.dsButton.variables[0].appliedTo).toEqual({ root: 1 });
   });
 
   it('classifies typography tokens as textStyles', async () => {
@@ -76,9 +77,9 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out.textStyles).toHaveLength(1);
-    expect(out.textStyles[0].name).toBe('DS Type.Body.Default');
-    expect(out.textStyles[0].appliedAs).toBe('typography');
+    expect(out.dsButton.textStyles).toHaveLength(1);
+    expect(out.dsButton.textStyles[0].name).toBe('DS Type.Body.Default');
+    expect(out.dsButton.textStyles[0].appliedAs).toBe('typography');
   });
 
   it('classifies effects tokens as effectStyles', async () => {
@@ -94,9 +95,9 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out.effectStyles).toHaveLength(1);
-    expect(out.effectStyles[0].name).toBe('DS Shadow.Elevation.1');
-    expect(out.effectStyles[0].appliedAs).toBe('effects');
+    expect(out.dsButton.effectStyles).toHaveLength(1);
+    expect(out.dsButton.effectStyles[0].name).toBe('DS Shadow.Elevation.1');
+    expect(out.dsButton.effectStyles[0].appliedAs).toBe('effects');
   });
 
   it('accumulates appliedTo counts across variants', async () => {
@@ -124,7 +125,7 @@ describe('StylingTransformer', () => {
         },
       ],
     });
-    expect(out.variables[0].appliedTo).toEqual({ root: 2 });
+    expect(out.dsButton.variables[0].appliedTo).toEqual({ root: 2 });
   });
 
   it('deduplicates the same token applied across multiple variants', async () => {
@@ -140,7 +141,7 @@ describe('StylingTransformer', () => {
         { elements: { root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } } } },
       ],
     });
-    expect(out.variables).toHaveLength(1);
+    expect(out.dsButton.variables).toHaveLength(1);
   });
 
   it('uses the dot-joined key path as appliedAs for nested tokens', async () => {
@@ -161,7 +162,7 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    const appliedAs = out.variables.map(r => r.appliedAs).sort();
+    const appliedAs = out.dsButton.variables.map(r => r.appliedAs).sort();
     expect(appliedAs).toEqual(['padding.end', 'padding.start']);
   });
 
@@ -183,7 +184,7 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    const appliedAs = out.variables.map(r => r.appliedAs).sort();
+    const appliedAs = out.dsButton.variables.map(r => r.appliedAs).sort();
     expect(appliedAs).toEqual(['cornerRadius.topEnd', 'cornerRadius.topStart']);
   });
 
@@ -198,10 +199,10 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out.variables).toHaveLength(0);
-    expect(out.colorStyles).toHaveLength(0);
-    expect(out.textStyles).toHaveLength(0);
-    expect(out.effectStyles).toHaveLength(0);
+    expect(out.dsButton.variables).toHaveLength(0);
+    expect(out.dsButton.colorStyles).toHaveLength(0);
+    expect(out.dsButton.textStyles).toHaveLength(0);
+    expect(out.dsButton.effectStyles).toHaveLength(0);
   });
 
   it('includes rawValue when present in $extensions', async () => {
@@ -221,7 +222,7 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out.variables[0].rawValue).toBe('#FF0000');
+    expect(out.dsButton.variables[0].rawValue).toBe('#FF0000');
   });
 
   it('omits rawValue when $extensions are absent', async () => {
@@ -237,7 +238,7 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect('rawValue' in out.variables[0]).toBe(false);
+    expect('rawValue' in out.dsButton.variables[0]).toBe(false);
   });
 
   it('output is deterministic for the same input', async () => {
@@ -274,8 +275,54 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    const names = out.variables.map(r => r.name);
+    const names = out.dsButton.variables.map(r => r.name);
     expect(names).toEqual([...names].sort());
+  });
+
+  it('emits separate keys for component and subcomponent', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: { styles: { backgroundColor: { $token: 'Color/Primary', $type: 'color' } } },
+        },
+      },
+      subcomponents: {
+        item: {
+          default: {
+            elements: {
+              icon: { styles: { fillColor: { $token: 'Color/On surface', $type: 'color' } } },
+            },
+          },
+        },
+      },
+    }, 'dsButton');
+    expect(out).toHaveProperty('dsButton');
+    expect(out).toHaveProperty('dsButton.item');
+    expect(out['dsButton'].variables[0].name).toBe('Color/Primary');
+    expect(out['dsButton.item'].variables[0].name).toBe('Color/On surface');
+  });
+
+  it('subcomponent tokens do not appear in the top-level component scope', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: { styles: { backgroundColor: { $token: 'Color/Primary', $type: 'color' } } },
+        },
+      },
+      subcomponents: {
+        item: {
+          default: {
+            elements: {
+              icon: { styles: { fillColor: { $token: 'Color/On surface', $type: 'color' } } },
+            },
+          },
+        },
+      },
+    });
+    const topNames = out.dsButton.variables.map(r => r.name);
+    expect(topNames).not.toContain('Color/On surface');
   });
 });
 
@@ -376,6 +423,26 @@ describe('StylingTransformer.finalize', () => {
     const { byToken } = await runFinalize();
     expect(byToken.textStyles['Typography/Body']).toHaveLength(1);
     expect(byToken.textStyles['Typography/Body'][0].component).toBe('compB');
+  });
+
+  it('byToken uses dot-path key for subcomponent entries', async () => {
+    const t = new StylingTransformer();
+    const withSub = {
+      anatomy: { root: { type: 'container' } },
+      default: { elements: { root: { styles: { backgroundColor: { $token: 'Color/Primary', $type: 'color' } } } } },
+      subcomponents: {
+        item: {
+          default: { elements: { icon: { styles: { fillColor: { $token: 'Color/On surface', $type: 'color' } } } } },
+        },
+      },
+    };
+    const compDir = path.join(outputDir, 'compSub');
+    await fs.ensureDir(compDir);
+    await t.run(withSub, { outputDir: compDir, componentKey: 'compSub' });
+    await t.finalize!(outputDir);
+    const byToken = JSON.parse(await fs.readFile(path.join(outputDir, '_dictionary', 'styling.byToken.json'), 'utf-8'));
+    const entry = byToken.variables['Color/On surface'][0];
+    expect(entry.component).toBe('compSub.item');
   });
 
   it('does nothing when no components were processed', async () => {

--- a/packages/cli/tests/unit/transforms/Styling.test.ts
+++ b/packages/cli/tests/unit/transforms/Styling.test.ts
@@ -10,9 +10,15 @@ function makeContext(dir: string) {
   return { outputDir: dir, componentKey: 'dsButton' };
 }
 
-async function run(dir: string, apiYaml: Record<string, unknown>): Promise<string> {
+async function run(dir: string, apiYaml: Record<string, unknown>) {
   await transformer.run(apiYaml, makeContext(dir));
-  return fs.readFile(path.join(dir, 'styling.ts'), 'utf-8');
+  const raw = await fs.readFile(path.join(dir, 'styling.json'), 'utf-8');
+  return JSON.parse(raw) as {
+    variables: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
+    colorStyles: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
+    textStyles: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
+    effectStyles: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
+  };
 }
 
 describe('StylingTransformer', () => {
@@ -30,12 +36,12 @@ describe('StylingTransformer', () => {
     expect(transformer.name).toBe('styling');
   });
 
-  it('writes a styling.ts with header and type declarations', async () => {
+  it('writes styling.json with all four category groups', async () => {
     const out = await run(tmpDir, {});
-    expect(out).toContain('// Generated. Do not edit');
-    expect(out).toContain("export type StylingCategory =");
-    expect(out).toContain('export interface StylingRow {');
-    expect(out).toContain('DsButtonStyling');
+    expect(out).toHaveProperty('variables');
+    expect(out).toHaveProperty('colorStyles');
+    expect(out).toHaveProperty('textStyles');
+    expect(out).toHaveProperty('effectStyles');
   });
 
   it('collects variable tokens from default elements', async () => {
@@ -51,13 +57,13 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out).toContain("category: 'VARIABLES'");
-    expect(out).toContain("name: 'DS Color.Surface.Primary'");
-    expect(out).toContain("appliedAs: 'Background color'");
-    expect(out).toContain("'root': 1");
+    expect(out.variables).toHaveLength(1);
+    expect(out.variables[0].name).toBe('DS Color.Surface.Primary');
+    expect(out.variables[0].appliedAs).toBe('backgroundColor');
+    expect(out.variables[0].appliedTo).toEqual({ root: 1 });
   });
 
-  it('classifies typography tokens as TEXT_STYLES', async () => {
+  it('classifies typography tokens as textStyles', async () => {
     const out = await run(tmpDir, {
       anatomy: { label: { type: 'text' } },
       default: {
@@ -70,12 +76,12 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out).toContain("category: 'TEXT_STYLES'");
-    expect(out).toContain("name: 'DS Type.Body.Default'");
-    expect(out).toContain("appliedAs: 'Text style'");
+    expect(out.textStyles).toHaveLength(1);
+    expect(out.textStyles[0].name).toBe('DS Type.Body.Default');
+    expect(out.textStyles[0].appliedAs).toBe('typography');
   });
 
-  it('classifies shadow tokens as EFFECT_STYLES', async () => {
+  it('classifies effects tokens as effectStyles', async () => {
     const out = await run(tmpDir, {
       anatomy: { root: { type: 'container' } },
       default: {
@@ -88,9 +94,9 @@ describe('StylingTransformer', () => {
         },
       },
     });
-    expect(out).toContain("category: 'EFFECT_STYLES'");
-    expect(out).toContain("name: 'DS Shadow.Elevation.1'");
-    expect(out).toContain("appliedAs: 'Effect style'");
+    expect(out.effectStyles).toHaveLength(1);
+    expect(out.effectStyles[0].name).toBe('DS Shadow.Elevation.1');
+    expect(out.effectStyles[0].appliedAs).toBe('effects');
   });
 
   it('accumulates appliedTo counts across variants', async () => {
@@ -118,11 +124,11 @@ describe('StylingTransformer', () => {
         },
       ],
     });
-    expect(out).toContain("'root': 2");
+    expect(out.variables[0].appliedTo).toEqual({ root: 2 });
   });
 
   it('deduplicates the same token applied across multiple variants', async () => {
-    await run(tmpDir, {
+    const out = await run(tmpDir, {
       anatomy: { root: { type: 'container' } },
       default: {
         elements: {
@@ -130,69 +136,55 @@ describe('StylingTransformer', () => {
         },
       },
       variants: [
-        {
-          elements: {
-            root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } },
-          },
-        },
-        {
-          elements: {
-            root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } },
-          },
-        },
+        { elements: { root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } } } },
+        { elements: { root: { styles: { backgroundColor: { $token: 'DS Color.Surface.Primary', $type: 'color' } } } } },
       ],
     });
-    const out = await fs.readFile(path.join(tmpDir, 'styling.ts'), 'utf-8');
-    const occurrences = (out.match(/DS Color\.Surface\.Primary/g) ?? []).length;
-    expect(occurrences).toBe(1);
+    expect(out.variables).toHaveLength(1);
   });
 
-  it('uses fillColor appliedAs for glyph elements', async () => {
-    const out = await run(tmpDir, {
-      anatomy: { icon: { type: 'glyph' } },
-      default: {
-        elements: {
-          icon: {
-            styles: {
-              backgroundColor: { $token: 'DS Color.Icon.Primary', $type: 'color' },
-            },
-          },
-        },
-      },
-    });
-    expect(out).toContain("appliedAs: 'Fill color'");
-  });
-
-  it('uses Text color for text elements with fills/backgroundColor', async () => {
-    const out = await run(tmpDir, {
-      anatomy: { label: { type: 'text' } },
-      default: {
-        elements: {
-          label: {
-            styles: {
-              backgroundColor: { $token: 'DS Color.Text.Primary', $type: 'color' },
-            },
-          },
-        },
-      },
-    });
-    expect(out).toContain("appliedAs: 'Text color'");
-  });
-
-  it('humanizes unknown style keys', async () => {
+  it('uses the dot-joined key path as appliedAs for nested tokens', async () => {
     const out = await run(tmpDir, {
       anatomy: { root: { type: 'container' } },
       default: {
         elements: {
           root: {
             styles: {
-              cornerRadius: { $token: 'DS Shape.Radius.Medium', $type: 'dimension' },
+              padding: {
+                start: { $token: 'DS Space.3x', $type: 'dimension' },
+                end: { $token: 'DS Space.3x', $type: 'dimension' },
+                top: 0,
+                bottom: 0,
+              },
             },
           },
         },
       },
     });
-    expect(out).toContain("appliedAs: 'Corner radius'");
+    const appliedAs = out.variables.map(r => r.appliedAs).sort();
+    expect(appliedAs).toEqual(['padding.end', 'padding.start']);
+  });
+
+  it('uses dot-joined path for per-corner radii', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              cornerRadius: {
+                topStart: { $token: 'DS Shape.Radius.XL', $type: 'dimension' },
+                topEnd: { $token: 'DS Shape.Radius.XL', $type: 'dimension' },
+                bottomStart: 0,
+                bottomEnd: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+    const appliedAs = out.variables.map(r => r.appliedAs).sort();
+    expect(appliedAs).toEqual(['cornerRadius.topEnd', 'cornerRadius.topStart']);
   });
 
   it('skips non-token style values', async () => {
@@ -201,16 +193,51 @@ describe('StylingTransformer', () => {
       default: {
         elements: {
           root: {
+            styles: { visible: true, width: 48, strokes: '#FF0000' },
+          },
+        },
+      },
+    });
+    expect(out.variables).toHaveLength(0);
+    expect(out.colorStyles).toHaveLength(0);
+    expect(out.textStyles).toHaveLength(0);
+    expect(out.effectStyles).toHaveLength(0);
+  });
+
+  it('includes rawValue when present in $extensions', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
             styles: {
-              visible: true,
-              width: 48,
-              strokes: '#FF0000',
+              backgroundColor: {
+                $token: 'DS Color.Primary',
+                $type: 'color',
+                $extensions: { 'com.figma': { rawValue: '#FF0000' } },
+              },
             },
           },
         },
       },
     });
-    expect(out).toMatch(/DsButtonStyling: readonly StylingRow\[\] = \[\s*\];/);
+    expect(out.variables[0].rawValue).toBe('#FF0000');
+  });
+
+  it('omits rawValue when $extensions are absent', async () => {
+    const out = await run(tmpDir, {
+      anatomy: { root: { type: 'container' } },
+      default: {
+        elements: {
+          root: {
+            styles: {
+              backgroundColor: { $token: 'DS Color.Primary', $type: 'color' },
+            },
+          },
+        },
+      },
+    });
+    expect('rawValue' in out.variables[0]).toBe(false);
   });
 
   it('output is deterministic for the same input', async () => {
@@ -227,25 +254,27 @@ describe('StylingTransformer', () => {
     try {
       const out1 = await run(tmpDir, apiYaml);
       const out2 = await run(tmpDir2, apiYaml);
-      expect(out1).toBe(out2);
+      expect(JSON.stringify(out1)).toBe(JSON.stringify(out2));
     } finally {
       await fs.remove(tmpDir2);
     }
   });
 
-  it('sorts rows: VARIABLES before TEXT_STYLES, then alphabetical by name', async () => {
+  it('sorts rows alphabetically by name within each category', async () => {
     const out = await run(tmpDir, {
-      anatomy: { root: { type: 'container' }, label: { type: 'text' } },
+      anatomy: { root: { type: 'container' } },
       default: {
         elements: {
-          root: { styles: { backgroundColor: { $token: 'DS Color.Zebra', $type: 'color' } } },
-          label: { styles: { typography: { $token: 'DS Type.Body', $type: 'typography' } } },
+          root: {
+            styles: {
+              backgroundColor: { $token: 'DS Color.Zebra', $type: 'color' },
+              strokes: { $token: 'DS Color.Alpha', $type: 'color' },
+            },
+          },
         },
       },
     });
-    const varIdx = out.indexOf("'VARIABLES'");
-    const textIdx = out.indexOf("'TEXT_STYLES'");
-    expect(varIdx).toBeGreaterThan(-1);
-    expect(textIdx).toBeGreaterThan(varIdx);
+    const names = out.variables.map(r => r.name);
+    expect(names).toEqual([...names].sort());
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `styling` transformer that projects a validated component contract into a structured token inventory (`styling.json`) per component
- Output is grouped by category (`variables`, `colorStyles`, `textStyles`, `effectStyles`) and scoped by component/subcomponent key (`"egdsButton"`, `"egdsButton.startVisualL"`)
- Recursively walks nested token structures: padding sides, corner radii, gradient stops, typography sub-props, effect parts
- `appliedAs` uses the raw spec key path, dot-joined for nested values (`"padding.start"`, `"cornerRadius.topEnd"`)
- `appliedTo` tracks element names and occurrence counts, scoped to their component/subcomponent so top-level and subcomponent elements do not collide
- `rawValue` included only when present in `$extensions['com.figma'].rawValue`; omitted entirely otherwise
- Adds `finalize()` hook to the `Transformer` interface; `TransformCommand` calls it after all components are processed
- Emits two cross-component dictionary files under `_dictionary/`: `styling.byComponent.json` (flat map of all scopes, rawValue stripped) and `styling.byToken.json` (grouped by token name with component, appliedAs, appliedTo)

## Test plan

- [ ] 22 unit tests in `Styling.test.ts`: category classification, nested appliedAs, rawValue presence/absence, deduplication, accumulation, subcomponent scoping, finalize dictionary output, byToken dot-path keys for subcomponents
- [ ] `npm test` passes (281 tests)
- [ ] Run `specs transform styling -o eg/specs` against 66 real components in specs-testing; zero components with token references produce empty output
- [ ] Spot-check `egdsActionList/styling.json`: `egdsActionList` key empty (no top-level tokens), `egdsActionList.item` has 14 entries
- [ ] Spot-check `egdsButton/styling.json`: `egdsButton` has 41 entries, four `startVisual*` subcomponent keys have 2 entries each

Closes DirectedEdges/specs#138

Generated with [Claude Code](https://claude.com/claude-code)
