### PR TITLE
feat(transform): subcomponent support for contract and css transformers

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`css` transformer: subcomponent support** — For each entry in `variants.yaml`'s `subcomponents` map, emits a `styles.css` inside a dedicated subfolder named after the subcomponent key (e.g. `dsActionList/group/styles.css`). BEM selectors are scoped to the subcomponent's own kebab-case class name (e.g. `.group`, `.group__text`). Subcomponent subdirs are created automatically.
+
 - **`contract` transformer: subcomponent support** — For each entry in `api.yaml`'s `subcomponents` map, emits a `contract.ts` inside a dedicated subfolder named after the subcomponent key (e.g. `dsActionList/group/contract.ts`). Interface and enum type names are prefixed with both the component and subcomponent name (e.g. `DsActionListGroupProps`). Subcomponent subdirs are created automatically.
 
 ### Changed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`contract` transformer: subcomponent support** — For each entry in `api.yaml`'s `subcomponents` map, emits a `contract.ts` inside a dedicated subfolder named after the subcomponent key (e.g. `dsActionList/group/contract.ts`). Interface and enum type names are prefixed with both the component and subcomponent name (e.g. `DsActionListGroupProps`). Subcomponent subdirs are created automatically.
+
 ### Changed
 
 ### Removed

--- a/packages/cli/src/transforms/Contract.ts
+++ b/packages/cli/src/transforms/Contract.ts
@@ -8,81 +8,96 @@ export class ContractTransformer implements Transformer {
 
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
     const { outputDir, componentKey } = context;
-    const title = (apiYaml.title as string) ?? componentKey;
     const prefix = toPascalCase(componentKey);
-    const props = (apiYaml.props ?? {}) as Record<string, unknown>;
     const omittedProps = buildOmittedProps(context.processingStates ?? {});
 
-    const lines: string[] = [
-      '// Generated. Do not edit — regenerate with `specs transform`.',
-      '',
-    ];
+    // Main component
+    const mainLines = buildContractLines(prefix, (apiYaml.props ?? {}) as Record<string, unknown>, omittedProps);
+    await fs.writeFile(path.join(outputDir, 'contract.ts'), mainLines.join('\n'), 'utf-8');
 
-    // Collect prop metadata in one pass
-    const enumTypes: Array<{ typeName: string; values: string[] }> = [];
-    const propEntries: Array<{ key: string; tsType: string; hasDefault: boolean; defaultValue: unknown }> = [];
-
-    for (const [key, raw] of Object.entries(props)) {
-      if (omittedProps.has(key)) continue; // browser-driven state — not a consumer prop
-      const prop = raw as Record<string, unknown>;
-      const type = prop.type as string;
-
-      if (type === 'slot') continue; // slots deferred
-
-      const isNullable = prop.nullable === true || prop.default === null;
-      const hasDefault = 'default' in prop;
-      const defaultValue = prop.default;
-
-      let tsType: string;
-
-      if (type === 'boolean') {
-        tsType = 'boolean';
-      } else if (type === 'number') {
-        tsType = 'number';
-      } else if (type === 'string' && Array.isArray(prop.enum)) {
-        const typeName = `${prefix}${toPascalCase(key)}`;
-        const values = prop.enum as string[];
-        enumTypes.push({ typeName, values });
-        tsType = isNullable ? `${typeName} | null` : typeName;
-      } else {
-        tsType = isNullable ? 'string | null' : 'string';
-      }
-
-      propEntries.push({ key, tsType, hasDefault, defaultValue });
+    // Subcomponents — each gets its own subfolder/contract.ts
+    const subcomponents = (apiYaml.subcomponents ?? {}) as Record<string, unknown>;
+    for (const [subKey, subRaw] of Object.entries(subcomponents)) {
+      const sub = subRaw as Record<string, unknown>;
+      const subPrefix = `${prefix}${toPascalCase(subKey)}`;
+      const subProps = (sub.props ?? {}) as Record<string, unknown>;
+      const subLines = buildContractLines(subPrefix, subProps, omittedProps);
+      const subDir = path.join(outputDir, subKey);
+      await fs.ensureDir(subDir);
+      await fs.writeFile(path.join(subDir, 'contract.ts'), subLines.join('\n'), 'utf-8');
     }
-
-    // Emit enum types
-    for (const { typeName, values } of enumTypes) {
-      lines.push(`export type ${typeName} =`);
-      for (const v of values) {
-        lines.push(`  | '${v}'`);
-      }
-      lines[lines.length - 1] += ';';
-    }
-    if (enumTypes.length > 0) lines.push('');
-
-    // Emit Props interface
-    lines.push(`export interface ${prefix}Props {`);
-    for (const { key, tsType } of propEntries) {
-      lines.push(`  ${key}?: ${tsType};`);
-    }
-    lines.push('}');
-    lines.push('');
-
-    // Emit Defaults — only props with a declared default
-    const defaultEntries = propEntries.filter(p => p.hasDefault);
-    if (defaultEntries.length > 0) {
-      lines.push(`export const ${prefix}Defaults = {`);
-      for (const { key, defaultValue } of defaultEntries) {
-        lines.push(`  ${key}: ${JSON.stringify(defaultValue)},`);
-      }
-      lines.push(`} satisfies ${prefix}Props;`);
-      lines.push('');
-    }
-
-    const outputPath = path.join(outputDir, 'contract.ts');
-    await fs.writeFile(outputPath, lines.join('\n'), 'utf-8');
   }
+}
+
+function buildContractLines(
+  prefix: string,
+  props: Record<string, unknown>,
+  omittedProps: Set<string>,
+): string[] {
+  const lines: string[] = [
+    '// Generated. Do not edit — regenerate with `specs transform`.',
+    '',
+  ];
+
+  const enumTypes: Array<{ typeName: string; values: string[] }> = [];
+  const propEntries: Array<{ key: string; tsType: string; hasDefault: boolean; defaultValue: unknown }> = [];
+
+  for (const [key, raw] of Object.entries(props)) {
+    if (omittedProps.has(key)) continue;
+    const prop = raw as Record<string, unknown>;
+    const type = prop.type as string;
+
+    if (type === 'slot') continue;
+
+    const isNullable = prop.nullable === true || prop.default === null;
+    const hasDefault = 'default' in prop;
+    const defaultValue = prop.default;
+
+    let tsType: string;
+
+    if (type === 'boolean') {
+      tsType = 'boolean';
+    } else if (type === 'number') {
+      tsType = 'number';
+    } else if (type === 'string' && Array.isArray(prop.enum)) {
+      const typeName = `${prefix}${toPascalCase(key)}`;
+      const values = prop.enum as string[];
+      enumTypes.push({ typeName, values });
+      tsType = isNullable ? `${typeName} | null` : typeName;
+    } else {
+      tsType = isNullable ? 'string | null' : 'string';
+    }
+
+    propEntries.push({ key, tsType, hasDefault, defaultValue });
+  }
+
+  for (const { typeName, values } of enumTypes) {
+    lines.push(`export type ${typeName} =`);
+    for (const v of values) {
+      lines.push(`  | '${v}'`);
+    }
+    lines[lines.length - 1] += ';';
+  }
+  if (enumTypes.length > 0) lines.push('');
+
+  lines.push(`export interface ${prefix}Props {`);
+  for (const { key, tsType } of propEntries) {
+    lines.push(`  ${key}?: ${tsType};`);
+  }
+  lines.push('}');
+  lines.push('');
+
+  const defaultEntries = propEntries.filter(p => p.hasDefault);
+  if (defaultEntries.length > 0) {
+    lines.push(`export const ${prefix}Defaults = {`);
+    for (const { key, defaultValue } of defaultEntries) {
+      lines.push(`  ${key}: ${JSON.stringify(defaultValue)},`);
+    }
+    lines.push(`} satisfies ${prefix}Props;`);
+    lines.push('');
+  }
+
+  return lines;
 }
 
 function toPascalCase(str: string): string {

--- a/packages/cli/src/transforms/Css.ts
+++ b/packages/cli/src/transforms/Css.ts
@@ -23,17 +23,105 @@ export class CssTransformer implements Transformer {
     const variantsYaml = yaml.parse(raw) as Record<string, unknown>;
 
     const componentClass = toKebab(componentKey);
-    const lines: string[] = [
-      '/* Generated. Do not edit — regenerate with `specs transform`. */',
-      '',
-    ];
+    const lines = buildCssLines(componentClass, variantsYaml, tokensFormat, context);
+    await fs.writeFile(path.join(outputDir, 'styles.css'), lines.join('\n'), 'utf-8');
 
-    // ── Default styles ─────────────────────────────────────────────────────────
-    const defaultBlock = variantsYaml.default as Record<string, unknown> | undefined;
-    const defaultElements = (defaultBlock?.elements ?? {}) as Record<string, Record<string, unknown>>;
+    // Subcomponents — each gets styles.css in its own subfolder
+    const subcomponents = (variantsYaml.subcomponents ?? {}) as Record<string, unknown>;
+    for (const [subKey, subRaw] of Object.entries(subcomponents)) {
+      const subVariantsYaml = subRaw as Record<string, unknown>;
+      const subClass = toKebab(subKey);
+      const subLines = buildCssLines(subClass, subVariantsYaml, tokensFormat, context);
+      const subDir = path.join(outputDir, subKey);
+      await fs.ensureDir(subDir);
+      await fs.writeFile(path.join(subDir, 'styles.css'), subLines.join('\n'), 'utf-8');
+    }
+  }
+}
 
-    for (const [elemKey, elem] of Object.entries(defaultElements)) {
-      const selector = elemSelector(componentClass, elemKey);
+function buildCssLines(
+  componentClass: string,
+  variantsYaml: Record<string, unknown>,
+  tokensFormat: string | undefined,
+  context: TransformerContext,
+): string[] {
+  const lines: string[] = [
+    '/* Generated. Do not edit — regenerate with `specs transform`. */',
+    '',
+  ];
+
+  // ── Default styles ─────────────────────────────────────────────────────────
+  const defaultBlock = variantsYaml.default as Record<string, unknown> | undefined;
+  const defaultElements = (defaultBlock?.elements ?? {}) as Record<string, Record<string, unknown>>;
+
+  for (const [elemKey, elem] of Object.entries(defaultElements)) {
+    const selector = elemSelector(componentClass, elemKey);
+    const styles = (elem.styles ?? {}) as Record<string, unknown>;
+    const decls = [...layoutToCSS(styles, tokensFormat), ...styleToCSS(styles, tokensFormat)];
+
+    if (decls.length > 0) {
+      lines.push(`${selector} {`);
+      for (const d of decls) lines.push(`  ${d};`);
+      lines.push('}');
+      lines.push('');
+    }
+  }
+
+  // ── State lookup — built from config.processing.states ────────────────────
+  // Each concept maps a (prop, value) pair to a canonical CSS selector.
+  // Props in classifiedProps use real CSS selectors instead of data attributes.
+  // Any classified prop whose variant value doesn't match a known concept is
+  // the base/rest state — the variant is skipped (base block already covers it).
+  const { lookup: stateLookup, classifiedProps } =
+    buildStateLookup(context.processingStates ?? {});
+
+  // ── Variants — in schema order ─────────────────────────────────────────────
+  // variants.yaml variant order is intentional: single-prop variants before
+  // multi-prop compound variants, matching the layering cascade.
+  const variants = (variantsYaml.variants ?? []) as Array<Record<string, unknown>>;
+
+  for (const variant of variants) {
+    const configuration = (variant.configuration ?? {}) as Record<string, unknown>;
+    const configEntries = Object.entries(configuration);
+    if (configEntries.length === 0) continue;
+
+    // Classify each config entry as a state selector or a data attribute.
+    // stateSelSuffixes accumulates the cartesian product of all state selectors —
+    // comma-separated selectors like ':disabled, [aria-disabled="true"]' expand
+    // into multiple suffixes so each gets its own CSS rule.
+    let skip = false;
+    const dataAttrs: string[] = [];
+    let stateSelSuffixes: string[] = [''];
+
+    for (const [k, v] of configEntries) {
+      const vStr = String(v);
+      if (classifiedProps.has(k)) {
+        const concept = stateLookup.get(`${k}::${vStr}`);
+        if (!concept) { skip = true; break; } // unmatched value = base/rest state
+        const conceptEntry = CONCEPT_TABLE[concept];
+        const sel = conceptEntry?.selector ?? `[data-${toKebab(k)}="${vStr}"]`;
+        const parts = sel.split(',').map(s => s.trim());
+        const expanded: string[] = [];
+        for (const existing of stateSelSuffixes) {
+          for (const part of parts) expanded.push(existing + part);
+        }
+        stateSelSuffixes = expanded;
+      } else {
+        dataAttrs.push(`[data-${toKebab(k)}="${vStr}"]`);
+      }
+    }
+    if (skip) continue;
+
+    const dataAttrStr = dataAttrs.join('');
+    const rootBase = `.${componentClass}${dataAttrStr}`;
+    const rootSelectors = stateSelSuffixes.map(s => `${rootBase}${s}`);
+
+    const variantElements = (variant.elements ?? {}) as Record<string, Record<string, unknown>>;
+
+    for (const [elemKey, elem] of Object.entries(variantElements)) {
+      const elemSuffix = elemKey === 'root' ? '' : ` ${elemSelector(componentClass, elemKey)}`;
+      const selector = rootSelectors.map(s => `${s}${elemSuffix}`).join(',\n');
+
       const styles = (elem.styles ?? {}) as Record<string, unknown>;
       const decls = [...layoutToCSS(styles, tokensFormat), ...styleToCSS(styles, tokensFormat)];
 
@@ -44,77 +132,9 @@ export class CssTransformer implements Transformer {
         lines.push('');
       }
     }
-
-    // ── State lookup — built from config.processing.states ────────────────────
-    // Each concept maps a (prop, value) pair to a canonical CSS selector.
-    // Props in classifiedProps use real CSS selectors instead of data attributes.
-    // Any classified prop whose variant value doesn't match a known concept is
-    // the base/rest state — the variant is skipped (base block already covers it).
-    const { lookup: stateLookup, classifiedProps } =
-      buildStateLookup(context.processingStates ?? {});
-
-    // ── Variants — in schema order ─────────────────────────────────────────────
-    // variants.yaml variant order is intentional: single-prop variants before
-    // multi-prop compound variants, matching the layering cascade.
-    const variants = (variantsYaml.variants ?? []) as Array<Record<string, unknown>>;
-
-    for (const variant of variants) {
-      const configuration = (variant.configuration ?? {}) as Record<string, unknown>;
-      const configEntries = Object.entries(configuration);
-      if (configEntries.length === 0) continue;
-
-      // Classify each config entry as a state selector or a data attribute.
-      // stateSelSuffixes accumulates the cartesian product of all state selectors —
-      // comma-separated selectors like ':disabled, [aria-disabled="true"]' expand
-      // into multiple suffixes so each gets its own CSS rule.
-      let skip = false;
-      const dataAttrs: string[] = [];
-      let stateSelSuffixes: string[] = [''];
-
-      for (const [k, v] of configEntries) {
-        const vStr = String(v);
-        if (classifiedProps.has(k)) {
-          const concept = stateLookup.get(`${k}::${vStr}`);
-          if (!concept) { skip = true; break; } // unmatched value = base/rest state
-          const conceptEntry = CONCEPT_TABLE[concept];
-          const sel = conceptEntry?.selector ?? `[data-${toKebab(k)}="${vStr}"]`;
-          const parts = sel.split(',').map(s => s.trim());
-          const expanded: string[] = [];
-          for (const existing of stateSelSuffixes) {
-            for (const part of parts) expanded.push(existing + part);
-          }
-          stateSelSuffixes = expanded;
-        } else {
-          dataAttrs.push(`[data-${toKebab(k)}="${vStr}"]`);
-        }
-      }
-      if (skip) continue;
-
-      const dataAttrStr = dataAttrs.join('');
-      const rootBase = `.${componentClass}${dataAttrStr}`;
-      const rootSelectors = stateSelSuffixes.map(s => `${rootBase}${s}`);
-
-      const variantElements = (variant.elements ?? {}) as Record<string, Record<string, unknown>>;
-
-      for (const [elemKey, elem] of Object.entries(variantElements)) {
-        const elemSuffix = elemKey === 'root' ? '' : ` ${elemSelector(componentClass, elemKey)}`;
-        const selector = rootSelectors.map(s => `${s}${elemSuffix}`).join(',\n');
-
-        const styles = (elem.styles ?? {}) as Record<string, unknown>;
-        const decls = [...layoutToCSS(styles, tokensFormat), ...styleToCSS(styles, tokensFormat)];
-
-        if (decls.length > 0) {
-          lines.push(`${selector} {`);
-          for (const d of decls) lines.push(`  ${d};`);
-          lines.push('}');
-          lines.push('');
-        }
-      }
-    }
-
-    const outputPath = path.join(outputDir, 'styles.css');
-    await fs.writeFile(outputPath, lines.join('\n'), 'utf-8');
   }
+
+  return lines;
 }
 
 function elemSelector(componentClass: string, elemKey: string): string {


### PR DESCRIPTION
## Summary

- `contract` transformer now emits `contract.ts` for each subcomponent into a dedicated subfolder (e.g. `dsActionList/group/contract.ts`), with interface and enum type names prefixed by both component and subcomponent (`DsActionListGroupProps`)
- `css` transformer now emits `styles.css` for each subcomponent into the same subfolder structure, with BEM selectors scoped to the subcomponent's own kebab-case class name (`.group`, `.group__text`)
- Subcomponent subdirs are created automatically by both transformers
- Tested against all 25 components in the `specs-testing` library — 25/25 pass

## Test plan

- [ ] Run `specs transform --config specs.config.yaml` against `specs-testing` — 25/25 succeed
- [ ] Confirm subcomponent subfolders appear for components with subcomponents (e.g. `dsActionList/group/`, `dsRow/memberStatus/`)
- [ ] Confirm `contract.ts` has correct prefixed type names (e.g. `DsActionListGroupProps`)
- [ ] Confirm `styles.css` has BEM selectors scoped to subcomponent class (e.g. `.group`, `.group__text`)
- [ ] Confirm components without subcomponents (e.g. `dsAccordion`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
