### PR TITLE
fix(css): presence selectors for boolean props and :not(:disabled) guards

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`css` transformer: presence selectors for boolean props** — Data attribute selectors for variant props whose value is a JS boolean `true` now emit `[data-x]` (presence) instead of `[data-x="true"]` (value). String-valued props (e.g. `checked: "checked"`, `checked: "indeterminate"`) continue to emit value selectors. Matches the TSX idiom `data-x={value || undefined}`.
+
+- **`css` transformer: `:not(:disabled)` guard on hover/active** — When the `disabled` concept is configured in `processing.states`, `:hover` and `:active` selectors (including compound variants like `[data-checked="checked"]:hover`) are automatically guarded with `:not(:disabled):not([aria-disabled="true"])` to prevent interaction styles from applying to disabled elements.
+
 ### Removed
 
 

--- a/packages/cli/src/transforms/Css.ts
+++ b/packages/cli/src/transforms/Css.ts
@@ -107,10 +107,20 @@ function buildCssLines(
         }
         stateSelSuffixes = expanded;
       } else {
-        dataAttrs.push(`[data-${toKebab(k)}="${vStr}"]`);
+        // Boolean true → presence selector; string value → value selector
+        dataAttrs.push(v === true ? `[data-${toKebab(k)}]` : `[data-${toKebab(k)}="${vStr}"]`);
       }
     }
     if (skip) continue;
+
+    // Guard :hover and :active against firing when disabled, if disabled is configured
+    if (context.processingStates?.['disabled']) {
+      const disabledSel = CONCEPT_TABLE['disabled']?.selector ?? ':disabled';
+      const notGuard = disabledSel.split(',').map(s => `:not(${s.trim()})`).join('');
+      stateSelSuffixes = stateSelSuffixes.map(s =>
+        (s.includes(':hover') || s.includes(':active')) ? s + notGuard : s
+      );
+    }
 
     const dataAttrStr = dataAttrs.join('');
     const rootBase = `.${componentClass}${dataAttrStr}`;

--- a/packages/cli/tests/unit/transforms/Contract.test.ts
+++ b/packages/cli/tests/unit/transforms/Contract.test.ts
@@ -199,6 +199,86 @@ describe('ContractTransformer', () => {
     });
   });
 
+  describe('subcomponent contracts', () => {
+    async function readSub(dir: string, subKey: string) {
+      return fs.readFile(path.join(dir, subKey, 'contract.ts'), 'utf-8');
+    }
+
+    it('emits contract.ts in a subfolder for each subcomponent', async () => {
+      await transformer.run(
+        { subcomponents: { group: { props: {} } } },
+        makeContext(tmpDir, 'dsActionList'),
+      );
+      expect(fs.existsSync(path.join(tmpDir, 'group', 'contract.ts'))).toBe(true);
+    });
+
+    it('prefixes subcomponent interface with both component and subcomponent names', async () => {
+      await transformer.run(
+        { subcomponents: { group: { props: {} } } },
+        makeContext(tmpDir, 'dsActionList'),
+      );
+      const out = await readSub(tmpDir, 'group');
+      expect(out).toContain('export interface DsActionListGroupProps {');
+    });
+
+    it('prefixes subcomponent enum types with both component and subcomponent names', async () => {
+      await transformer.run(
+        {
+          subcomponents: {
+            item: {
+              props: {
+                size: { type: 'string', enum: ['sm', 'md'], default: 'md' },
+              },
+            },
+          },
+        },
+        makeContext(tmpDir, 'dsActionList'),
+      );
+      const out = await readSub(tmpDir, 'item');
+      expect(out).toContain('export type DsActionListItemSize =');
+      expect(out).toContain("| 'sm'");
+      expect(out).toContain("| 'md';");
+      expect(out).toContain('size?: DsActionListItemSize;');
+      expect(out).toContain('size: "md",');
+    });
+
+    it('emits independent subfolders for multiple subcomponents', async () => {
+      await transformer.run(
+        {
+          subcomponents: {
+            group:  { props: { label: { type: 'string' } } },
+            header: { props: { text:  { type: 'string' } } },
+          },
+        },
+        makeContext(tmpDir, 'dsActionList'),
+      );
+      const groupOut  = await readSub(tmpDir, 'group');
+      const headerOut = await readSub(tmpDir, 'header');
+      expect(groupOut).toContain('export interface DsActionListGroupProps {');
+      expect(groupOut).toContain('label?: string;');
+      expect(headerOut).toContain('export interface DsActionListHeaderProps {');
+      expect(headerOut).toContain('text?: string;');
+    });
+
+    it('does not bleed subcomponent types into the main contract.ts', async () => {
+      const out = await run(tmpDir, {
+        props: { label: { type: 'string' } },
+        subcomponents: { group: { props: { groupProp: { type: 'string' } } } },
+      });
+      expect(out).not.toContain('groupProp');
+      expect(out).not.toContain('Group');
+    });
+
+    it('emits subcomponent contract with generated header', async () => {
+      await transformer.run(
+        { subcomponents: { group: { props: {} } } },
+        makeContext(tmpDir, 'dsActionList'),
+      );
+      const out = await readSub(tmpDir, 'group');
+      expect(out).toContain('// Generated. Do not edit');
+    });
+  });
+
   it('ends with a satisfies clause on the Defaults const', async () => {
     const out = await run(tmpDir, {
       props: { active: { type: 'boolean', default: true } },

--- a/packages/cli/tests/unit/transforms/Css.test.ts
+++ b/packages/cli/tests/unit/transforms/Css.test.ts
@@ -200,14 +200,14 @@ describe('CssTransformer', () => {
       ],
     };
 
-    it('emits :hover selector for hover concept', async () => {
+    it('emits :hover selector for hover concept (with :not(:disabled) guard since disabled is configured)', async () => {
       const out = await run(tmpDir, variantsWithStates, 'dsButton', 'TOKEN', states);
-      expect(out).toContain('.ds-button:hover {');
+      expect(out).toContain('.ds-button:hover:not(:disabled):not([aria-disabled="true"]) {');
     });
 
-    it('emits :active selector for active concept mapped to Figma value "pressed"', async () => {
+    it('emits :active selector for active concept mapped to Figma value "pressed" (with :not(:disabled) guard)', async () => {
       const out = await run(tmpDir, variantsWithStates, 'dsButton', 'TOKEN', states);
-      expect(out).toContain('.ds-button:active {');
+      expect(out).toContain('.ds-button:active:not(:disabled):not([aria-disabled="true"]) {');
     });
 
     it('skips the base/rest value — no data-state="rest" or :rest selector', async () => {
@@ -249,7 +249,7 @@ describe('CssTransformer', () => {
       expect(out).toContain('[data-size="lg"]');
     });
 
-    it('combines data-* and state selectors in compound variants', async () => {
+    it('combines data-* and state selectors in compound variants (with :not(:disabled) guard since disabled is configured)', async () => {
       const out = await run(tmpDir, {
         default: { elements: {} },
         variants: [
@@ -259,7 +259,7 @@ describe('CssTransformer', () => {
           },
         ],
       }, 'dsButton', 'TOKEN', states);
-      expect(out).toContain('.ds-button[data-appearance="outline"]:hover {');
+      expect(out).toContain('.ds-button[data-appearance="outline"]:hover:not(:disabled):not([aria-disabled="true"]) {');
     });
 
     it('produces no state-related selectors when processingStates is absent', async () => {
@@ -271,6 +271,218 @@ describe('CssTransformer', () => {
       });
       expect(out).toContain('[data-state="hover"]');
       expect(out).not.toContain(':hover');
+    });
+  });
+
+  describe('presence selectors for boolean true variant values', () => {
+    it('emits [data-x] presence selector when variant value is boolean true', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          {
+            configuration: { disabled: true },
+            elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+          },
+        ],
+      });
+      expect(out).toContain('[data-disabled]');
+      expect(out).not.toContain('[data-disabled="');
+    });
+
+    it('emits [data-x="value"] value selector when variant value is a string', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          {
+            configuration: { checked: 'checked' },
+            elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+          },
+        ],
+      });
+      expect(out).toContain('[data-checked="checked"]');
+    });
+
+    it('emits distinct value selectors for multi-value string props', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          {
+            configuration: { checked: 'checked' },
+            elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+          },
+          {
+            configuration: { checked: 'indeterminate' },
+            elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+          },
+        ],
+      });
+      expect(out).toContain('[data-checked="checked"]');
+      expect(out).toContain('[data-checked="indeterminate"]');
+      expect(out).not.toContain('[data-checked]');
+    });
+
+    it('emits presence selector for boolean true alongside a string data-attr in compound variants', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          {
+            configuration: { appearance: 'outline', selected: true },
+            elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+          },
+        ],
+      });
+      expect(out).toContain('[data-appearance="outline"][data-selected]');
+    });
+  });
+
+  describe(':not(:disabled) guard on hover and active', () => {
+    const statesWithDisabled: ProcessingStates = {
+      hover:    { prop: 'state', value: 'hover' },
+      active:   { prop: 'state', value: 'pressed' },
+      disabled: { prop: 'isDisabled' },
+    };
+
+    it('appends :not(:disabled):not([aria-disabled="true"]) to :hover selector', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          { configuration: { state: 'hover' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        ],
+      }, 'dsButton', 'TOKEN', statesWithDisabled);
+      expect(out).toContain('.ds-button:hover:not(:disabled):not([aria-disabled="true"]) {');
+    });
+
+    it('appends :not(:disabled):not([aria-disabled="true"]) to :active selector', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          { configuration: { state: 'pressed' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        ],
+      }, 'dsButton', 'TOKEN', statesWithDisabled);
+      expect(out).toContain('.ds-button:active:not(:disabled):not([aria-disabled="true"]) {');
+    });
+
+    it('does not add the guard when disabled concept is absent from processingStates', async () => {
+      const statesNoDisabled: ProcessingStates = {
+        hover: { prop: 'state', value: 'hover' },
+      };
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          { configuration: { state: 'hover' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        ],
+      }, 'dsButton', 'TOKEN', statesNoDisabled);
+      expect(out).toContain('.ds-button:hover {');
+      expect(out).not.toContain(':not(:disabled)');
+    });
+
+    it('applies the guard to compound variants combining data-attr and :hover', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          {
+            configuration: { appearance: 'outline', state: 'hover' },
+            elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+          },
+        ],
+      }, 'dsButton', 'TOKEN', statesWithDisabled);
+      expect(out).toContain('.ds-button[data-appearance="outline"]:hover:not(:disabled):not([aria-disabled="true"]) {');
+    });
+
+    it('does not add the guard to :focus-within or :disabled selectors', async () => {
+      const statesAll: ProcessingStates = {
+        hover:          { prop: 'state', value: 'hover' },
+        'focus-within': { prop: 'focused' },
+        disabled:       { prop: 'isDisabled' },
+      };
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          { configuration: { focused: 'true' },    elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+          { configuration: { isDisabled: 'true' },  elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        ],
+      }, 'dsButton', 'TOKEN', statesAll);
+      expect(out).not.toContain(':focus-within:not(');
+      expect(out).not.toContain(':disabled:not(');
+    });
+  });
+
+  describe('subcomponent styles', () => {
+    async function runAndReadSub(dir: string, variantsData: Record<string, unknown>, subKey: string, componentKey = 'dsActionList') {
+      await writeVariants(dir, variantsData);
+      await transformer.run({}, makeContext(dir, componentKey));
+      return fs.readFile(path.join(dir, subKey, 'styles.css'), 'utf-8');
+    }
+
+    it('emits styles.css in a subfolder for each subcomponent', async () => {
+      await writeVariants(tmpDir, {
+        subcomponents: {
+          group: {
+            default: { elements: { root: { styles: { layoutMode: 'VERTICAL' } } } },
+            variants: [],
+          },
+        },
+      });
+      await transformer.run({}, makeContext(tmpDir, 'dsActionList'));
+      expect(fs.existsSync(path.join(tmpDir, 'group', 'styles.css'))).toBe(true);
+    });
+
+    it('scopes subcomponent BEM selectors to the subcomponent key, not the parent', async () => {
+      const out = await runAndReadSub(tmpDir, {
+        subcomponents: {
+          group: {
+            default: {
+              elements: {
+                root: { styles: { layoutMode: 'VERTICAL' } },
+                text: { styles: { layoutMode: 'HORIZONTAL' } },
+              },
+            },
+            variants: [],
+          },
+        },
+      }, 'group');
+      expect(out).toContain('.group {');
+      expect(out).toContain('.group__text {');
+      expect(out).not.toContain('ds-action-list');
+    });
+
+    it('emits subcomponent variant selectors scoped to the subcomponent class', async () => {
+      const out = await runAndReadSub(tmpDir, {
+        subcomponents: {
+          item: {
+            default: { elements: {} },
+            variants: [
+              {
+                configuration: { size: 'medium' },
+                elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } },
+              },
+            ],
+          },
+        },
+      }, 'item');
+      expect(out).toContain('.item[data-size="medium"] {');
+    });
+
+    it('emits multiple subcomponent subfolders independently', async () => {
+      await writeVariants(tmpDir, {
+        subcomponents: {
+          group: {
+            default: { elements: { root: { styles: { layoutMode: 'VERTICAL' } } } },
+            variants: [],
+          },
+          header: {
+            default: { elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+            variants: [],
+          },
+        },
+      });
+      await transformer.run({}, makeContext(tmpDir, 'dsActionList'));
+      expect(fs.existsSync(path.join(tmpDir, 'group', 'styles.css'))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, 'header', 'styles.css'))).toBe(true);
+      const groupOut = await fs.readFile(path.join(tmpDir, 'group', 'styles.css'), 'utf-8');
+      const headerOut = await fs.readFile(path.join(tmpDir, 'header', 'styles.css'), 'utf-8');
+      expect(groupOut).toContain('flex-direction: column');
+      expect(headerOut).toContain('flex-direction: row');
     });
   });
 


### PR DESCRIPTION
## Summary

- Boolean `true` variant props now emit CSS presence selectors (`[data-x]`) instead of value selectors (`[data-x="true"]`), matching the TSX idiom `data-x={value || undefined}`
- String-valued props (e.g. `checked: "checked"`, `checked: "indeterminate"`) continue to emit value selectors
- `:hover` and `:active` selectors are guarded with `:not(:disabled):not([aria-disabled="true"])` when the `disabled` concept is configured in `processing.states` — including compound variants like `[data-checked="checked"]:hover`
- Tested against all 25 components in `specs-testing` — 25/25 pass

## Test plan

- [ ] `[data-focus]` presence selector appears instead of `[data-focus="true"]` (e.g. `dsButton/styles.css`)
- [ ] `[data-checked="checked"]` and `[data-checked="indeterminate"]` value selectors unchanged (e.g. `dsCheckbox/styles.css`)
- [ ] `:hover` selectors trail with `:not(:disabled):not([aria-disabled="true"])` (e.g. `dsButton/styles.css`)
- [ ] Compound hover e.g. `[data-checked="checked"]:hover:not(:disabled):not([aria-disabled="true"])` appears in `dsCheckbox/styles.css`
- [ ] Run `specs transform --config specs.config.yaml` against `specs-testing` — 25/25 succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
