### PR TITLE
feat(css): configurable rule pipeline with border-shift-inset-shadow

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`contract` transformer: subcomponent support** — For each entry in `api.yaml`'s `subcomponents` map, emits a `contract.ts` inside a dedicated subfolder named after the subcomponent key (e.g. `dsActionList/group/contract.ts`). Interface and enum type names are prefixed with both the component and subcomponent name (e.g. `DsActionListGroupProps`). Subcomponent subdirs are created automatically.
 
+- **`css` transformer: configurable rule pipeline** — The `css` transformer now accepts a `rules` list under its transformer options. Rules run as pre-passes on the structured variants data before CSS emission, enabling semantic rewrites that require cross-variant context. Configure per-component in `specs.config.yaml`:
+  ```yaml
+  transformers:
+    - name: css
+      rules:
+        - border-shift-inset-shadow
+  ```
+
+- **`css` transformer: `border-shift-inset-shadow` rule** — Eliminates layout shift from border-width changes across variants. Detects elements whose `strokeWeight` or `strokes` change in any variant (INSIDE strokes only), rewrites the default block to reserve space with a transparent border (`border: Npx solid transparent`), and rewrites variant stroke changes to `box-shadow: inset 0 0 0 Npx <color>`. OUTSIDE and CENTER strokes are unaffected (they use `outline`, which is already layout-safe).
+
 ### Changed
 
 - **`css` transformer: presence selectors for boolean props** — Data attribute selectors for variant props whose value is a JS boolean `true` now emit `[data-x]` (presence) instead of `[data-x="true"]` (value). String-valued props (e.g. `checked: "checked"`, `checked: "indeterminate"`) continue to emit value selectors. Matches the TSX idiom `data-x={value || undefined}`.

--- a/packages/cli/src/transforms/Css.ts
+++ b/packages/cli/src/transforms/Css.ts
@@ -6,6 +6,7 @@ import { styleToCSS } from './css/styleToCSS.js';
 import { layoutToCSS } from './css/layoutToCSS.js';
 import { toKebab } from './css/values.js';
 import { CONCEPT_TABLE, buildStateLookup } from './states.js';
+import { resolveRules } from './css/rules/index.js';
 
 export class CssTransformer implements Transformer {
   readonly name = 'css';
@@ -45,6 +46,13 @@ function buildCssLines(
   tokensFormat: string | undefined,
   context: TransformerContext,
 ): string[] {
+  // Apply configured rules as pre-passes on the structured variants data
+  const ruleNames = (context.transformerOptions?.rules as string[] | undefined) ?? [];
+  const rules = resolveRules(ruleNames);
+  for (const rule of rules) {
+    variantsYaml = rule.apply(variantsYaml, { tokensFormat });
+  }
+
   const lines: string[] = [
     '/* Generated. Do not edit — regenerate with `specs transform`. */',
     '',

--- a/packages/cli/src/transforms/css/CssRule.ts
+++ b/packages/cli/src/transforms/css/CssRule.ts
@@ -1,0 +1,7 @@
+export interface CssRule {
+  name: string;
+  apply(
+    variantsYaml: Record<string, unknown>,
+    context: { tokensFormat: string | undefined },
+  ): Record<string, unknown>;
+}

--- a/packages/cli/src/transforms/css/rules/borderShiftInsetShadow.ts
+++ b/packages/cli/src/transforms/css/rules/borderShiftInsetShadow.ts
@@ -1,0 +1,96 @@
+import type { CssRule } from '../CssRule.js';
+import { colorValue, dimensionValue } from '../values.js';
+
+type Styles = Record<string, unknown>;
+type ElementMap = Record<string, { styles?: Styles }>;
+
+export const borderShiftInsetShadow: CssRule = {
+  name: 'border-shift-inset-shadow',
+
+  apply(variantsYaml, { tokensFormat }) {
+    const data = JSON.parse(JSON.stringify(variantsYaml)) as Record<string, unknown>;
+
+    const variants = (data.variants ?? []) as Array<Record<string, unknown>>;
+    const defaultBlock = (data.default ?? {}) as Record<string, unknown>;
+    const defaultElements = (defaultBlock.elements ?? {}) as ElementMap;
+
+    // Collect element keys whose strokeWeight or strokes change in any variant.
+    // Only INSIDE strokes affect layout — OUTSIDE/CENTER use outline, skip those.
+    const shiftable = new Set<string>();
+    for (const variant of variants) {
+      const elements = (variant.elements ?? {}) as ElementMap;
+      for (const [elemKey, elem] of Object.entries(elements)) {
+        const styles = elem.styles ?? {};
+        const align = (styles.strokeAlign ?? defaultElements[elemKey]?.styles?.strokeAlign) as string | undefined;
+        if (align === 'OUTSIDE' || align === 'CENTER') continue;
+        if ('strokeWeight' in styles || 'strokes' in styles) {
+          shiftable.add(elemKey);
+        }
+      }
+    }
+
+    if (shiftable.size === 0) return data;
+
+    for (const elemKey of shiftable) {
+      // Find the reservation width: use default's strokeWeight if present,
+      // otherwise use the first variant that declares one.
+      const defaultStyles = (defaultElements[elemKey]?.styles ?? {}) as Styles;
+      let reservationWeight: unknown =
+        'strokeWeight' in defaultStyles ? defaultStyles.strokeWeight : undefined;
+
+      if (reservationWeight === undefined) {
+        for (const variant of variants) {
+          const elements = (variant.elements ?? {}) as ElementMap;
+          const s = elements[elemKey]?.styles ?? {};
+          if ('strokeWeight' in s && s.strokeWeight != null) {
+            reservationWeight = s.strokeWeight;
+            break;
+          }
+        }
+      }
+
+      // Ensure the default element exists and has a transparent border reservation.
+      if (!defaultElements[elemKey]) defaultElements[elemKey] = {};
+      const defStyles: Styles = { ...(defaultElements[elemKey].styles ?? {}) };
+      if (reservationWeight != null) defStyles.strokeWeight = reservationWeight;
+      defStyles.strokes = null; // transparent — reserves space without showing
+      defStyles.strokeAlign = 'INSIDE';
+      // border-style: solid is required for border-width to occupy layout space.
+      // styleToCSS only emits it when strokes has a color, so inject it directly.
+      const rawCssBase = (defStyles._rawCss as string[] | undefined) ?? [];
+      if (!rawCssBase.includes('border-style: solid')) rawCssBase.push('border-style: solid');
+      defStyles._rawCss = rawCssBase;
+      defaultElements[elemKey].styles = defStyles;
+
+      // Rewrite each variant that changes this element's stroke to box-shadow.
+      for (const variant of variants) {
+        const elements = (variant.elements ?? {}) as ElementMap;
+        if (!elements[elemKey]) continue;
+        const styles = (elements[elemKey].styles ?? {}) as Styles;
+        if (!('strokeWeight' in styles) && !('strokes' in styles)) continue;
+
+        const weight = 'strokeWeight' in styles ? styles.strokeWeight : reservationWeight;
+        const color = 'strokes' in styles ? styles.strokes : defStyles.strokes;
+
+        const widthVal = dimensionValue(weight, tokensFormat ?? 'TOKEN') ?? '0px';
+        const colorVal = colorValue(color, tokensFormat ?? 'TOKEN');
+
+        if (colorVal && colorVal !== 'transparent') {
+          const rawCss = (styles._rawCss as string[] | undefined) ?? [];
+          rawCss.push(`box-shadow: inset 0 0 0 ${widthVal} ${colorVal}`);
+          styles._rawCss = rawCss;
+        }
+
+        delete styles.strokeWeight;
+        delete styles.strokes;
+        delete styles.strokeAlign;
+        elements[elemKey].styles = styles;
+      }
+    }
+
+    defaultBlock.elements = defaultElements;
+    data.default = defaultBlock;
+    data.variants = variants;
+    return data;
+  },
+};

--- a/packages/cli/src/transforms/css/rules/index.ts
+++ b/packages/cli/src/transforms/css/rules/index.ts
@@ -1,0 +1,14 @@
+import type { CssRule } from '../CssRule.js';
+import { borderShiftInsetShadow } from './borderShiftInsetShadow.js';
+
+const RULE_REGISTRY: Record<string, CssRule> = {
+  'border-shift-inset-shadow': borderShiftInsetShadow,
+};
+
+export function resolveRules(names: string[]): CssRule[] {
+  return names.map(name => {
+    const rule = RULE_REGISTRY[name];
+    if (!rule) throw new Error(`Unknown CSS rule: "${name}"`);
+    return rule;
+  });
+}

--- a/packages/cli/src/transforms/css/styleToCSS.ts
+++ b/packages/cli/src/transforms/css/styleToCSS.ts
@@ -279,6 +279,12 @@ export function styleToCSS(styles: Record<string, unknown>, tokensFormat = 'TOKE
     else if (typeof v === 'number' && v !== 0) decls.push(`transform: rotate(${v}deg)`);
   }
 
+  // ── Raw CSS pass-through (injected by CssRule pre-passes) ────────────────────
+
+  if ('_rawCss' in styles && Array.isArray(styles._rawCss)) {
+    for (const line of styles._rawCss as string[]) decls.push(line);
+  }
+
   // ── Position & offsets ───────────────────────────────────────────────────────
   //
   // position: ABSOLUTE is emitted on the element that carries it in the spec.

--- a/packages/cli/tests/unit/transforms/Css.test.ts
+++ b/packages/cli/tests/unit/transforms/Css.test.ts
@@ -17,9 +17,9 @@ async function writeVariants(dir: string, data: Record<string, unknown>) {
   await fs.writeFile(path.join(dir, 'variants.yaml'), yaml.stringify(data), 'utf-8');
 }
 
-async function run(dir: string, variantsData: Record<string, unknown>, componentKey = 'dsButton', tokensFormat = 'TOKEN', processingStates?: ProcessingStates) {
+async function run(dir: string, variantsData: Record<string, unknown>, componentKey = 'dsButton', tokensFormat = 'TOKEN', processingStates?: ProcessingStates, transformerOptions?: Record<string, unknown>) {
   await writeVariants(dir, variantsData);
-  await transformer.run({}, makeContext(dir, componentKey, tokensFormat, processingStates));
+  await transformer.run({}, { ...makeContext(dir, componentKey, tokensFormat, processingStates), transformerOptions });
   return fs.readFile(path.join(dir, 'styles.css'), 'utf-8');
 }
 
@@ -495,5 +495,135 @@ describe('CssTransformer', () => {
       },
     });
     expect(out).not.toContain('.ds-button {');
+  });
+
+  describe('border-shift-inset-shadow rule', () => {
+    const rules = { rules: ['border-shift-inset-shadow'] };
+
+    it('is a no-op when no variants change strokeWeight or strokes', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        variants: [
+          { configuration: { size: 'lg' }, elements: { root: { styles: { layoutMode: 'VERTICAL' } } } },
+        ],
+      }, 'dsButton', 'TOKEN', undefined, rules);
+      expect(out).not.toContain('box-shadow');
+      expect(out).not.toContain('border-color: transparent');
+    });
+
+    it('replaces variant strokeWeight+strokes with box-shadow: inset, not border-width in the variant block', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        variants: [
+          {
+            configuration: { selected: true },
+            elements: { root: { styles: { strokeWeight: 2, strokes: tokenRef('Color/Border/Selected') } } },
+          },
+        ],
+      }, 'dsButton', 'TOKEN', undefined, rules);
+      expect(out).toContain('box-shadow: inset 0 0 0 2px var(--color-border-selected)');
+      // Variant block should not re-declare border-width (it's handled by box-shadow)
+      const variantBlock = out.split('.ds-button[data-selected]')[1] ?? '';
+      expect(variantBlock).not.toContain('border-width');
+    });
+
+    it('reserves space in the default block with a transparent border at the variant width', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        variants: [
+          {
+            configuration: { selected: true },
+            elements: { root: { styles: { strokeWeight: 2, strokes: tokenRef('Color/Border/Selected') } } },
+          },
+        ],
+      }, 'dsButton', 'TOKEN', undefined, rules);
+      expect(out).toContain('border-width: 2px');
+      expect(out).toContain('border-color: transparent');
+      expect(out).toContain('border-style: solid');
+    });
+
+    it('uses the default strokeWeight as reservation when already present in default', async () => {
+      const out = await run(tmpDir, {
+        default: {
+          elements: {
+            root: { styles: { strokeWeight: 1, strokes: tokenRef('Color/Border/Default') } },
+          },
+        },
+        variants: [
+          {
+            configuration: { selected: true },
+            elements: { root: { styles: { strokes: tokenRef('Color/Border/Selected') } } },
+          },
+        ],
+      }, 'dsButton', 'TOKEN', undefined, rules);
+      expect(out).toContain('border-width: 1px');
+      expect(out).toContain('border-color: transparent');
+      expect(out).toContain('box-shadow: inset 0 0 0 1px var(--color-border-selected)');
+    });
+
+    it('resolves token refs for both weight and color in the box-shadow value', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: { root: { styles: {} } } },
+        variants: [
+          {
+            configuration: { selected: true },
+            elements: {
+              root: {
+                styles: {
+                  strokeWeight: tokenRef('Border/Width/Focus', 'dimension'),
+                  strokes: tokenRef('Color/Focus/Ring'),
+                },
+              },
+            },
+          },
+        ],
+      }, 'dsButton', 'TOKEN', undefined, rules);
+      expect(out).toContain('box-shadow: inset 0 0 0 var(--border-width-focus) var(--color-focus-ring)');
+    });
+
+    it('does not apply to OUTSIDE strokes (those use outline, not border)', async () => {
+      const out = await run(tmpDir, {
+        default: { elements: { root: { styles: {} } } },
+        variants: [
+          {
+            configuration: { focused: true },
+            elements: {
+              root: { styles: { strokeWeight: 2, strokes: tokenRef('Color/Border/Focus'), strokeAlign: 'OUTSIDE' } },
+            },
+          },
+        ],
+      }, 'dsButton', 'TOKEN', undefined, rules);
+      expect(out).not.toContain('box-shadow: inset');
+      expect(out).toContain('outline-width: 2px');
+    });
+
+    it('throws for unknown rule names', async () => {
+      await expect(
+        run(tmpDir, { default: { elements: {} }, variants: [] }, 'dsButton', 'TOKEN', undefined, { rules: ['nonexistent-rule'] })
+      ).rejects.toThrow('Unknown CSS rule: "nonexistent-rule"');
+    });
+
+    it('applies the rule to subcomponent styles.css', async () => {
+      await writeVariants(tmpDir, {
+        subcomponents: {
+          item: {
+            default: { elements: { root: { styles: {} } } },
+            variants: [
+              {
+                configuration: { selected: true },
+                elements: { root: { styles: { strokeWeight: 2, strokes: tokenRef('Color/Border/Selected') } } },
+              },
+            ],
+          },
+        },
+      });
+      await transformer.run({}, {
+        ...makeContext(tmpDir, 'dsActionList'),
+        transformerOptions: rules,
+      });
+      const subOut = await fs.readFile(path.join(tmpDir, 'item', 'styles.css'), 'utf-8');
+      expect(subOut).toContain('box-shadow: inset 0 0 0 2px var(--color-border-selected)');
+      expect(subOut).toContain('border-color: transparent');
+    });
   });
 });

--- a/site/src/content/docs/cli/transforms/contract.md
+++ b/site/src/content/docs/cli/transforms/contract.md
@@ -23,7 +23,7 @@ This is the CLI default — running `specs transform` with no arguments runs `co
 
 ## Output
 
-Each component subfolder receives a `contract.ts` file.
+Each component subfolder receives a `contract.ts` file. When subcomponents are present, each also receives a `contract.ts` inside its own named subfolder — see [Subcomponent Contracts](#subcomponent-contracts) below.
 
 ## Example Output
 
@@ -71,6 +71,21 @@ config:
 ```
 
 When `processing.states` is absent, all props from `api.yaml` appear in the generated interface. When present, props mapped to browser-driven concepts (`hover`, `active`, `focus`, `focus-within`, etc.) are omitted — the browser fires these without the application setting them.
+
+## Subcomponent Contracts
+
+When subcomponents are present in `api.yaml`, each receives a `contract.ts` inside its own named subfolder. The subfolder name is the subcomponent's key in the spec (e.g. `group`, `item`). Interface and enum type names are prefixed by both component and subcomponent.
+
+```
+dsActionList/
+  contract.ts           ← parent (DsActionListProps, DsActionListDefaults)
+  group/
+    contract.ts         ← subcomponent (DsActionListGroupProps, DsActionListGroupDefaults)
+  item/
+    contract.ts         ← subcomponent (DsActionListItemProps, DsActionListItemDefaults)
+```
+
+The parent `contract.ts` only includes the parent component's own types — subcomponent types do not appear in it. Configure subcomponent discovery in [`config.processing.subcomponents`](/specs/config/subcomponents/).
 
 ## See Also
 

--- a/site/src/content/docs/cli/transforms/css.md
+++ b/site/src/content/docs/cli/transforms/css.md
@@ -5,7 +5,7 @@ description: "Emit a CSS file with custom property rules per component element"
 
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
 
-Emits a `styles.css` file for each component. Each anatomy element becomes a CSS selector; token references become `var(--)` declarations; variant props become `[data-*]` attribute selectors.
+Emits a `styles.css` file for each component. Each anatomy element becomes a CSS selector; token references become `var(--)` declarations; variant props become `[data-*]` attribute selectors. Boolean props use presence selectors (`[data-prop]`); string-valued props use value selectors (`[data-prop="value"]`).
 
 ## Use When
 
@@ -21,7 +21,7 @@ specs transform css
 
 ## Output
 
-Each component subfolder receives a `styles.css` file.
+Each component subfolder receives a `styles.css` file. When subcomponents are present, each also receives a `styles.css` inside its own named subfolder — see [Subcomponent Output](#subcomponent-output) below.
 
 ## Example Output
 
@@ -73,18 +73,18 @@ An Alert component with `severity` and `dismissible` variant props, and anatomy 
 
 /* Variant: dismissible */
 
-.ds-alert[data-dismissible="true"] {
+.ds-alert[data-dismissible] {
   padding-inline-end: var(--space-10);
 }
 
 /* Compound variant: severity + dismissible */
 
-.ds-alert[data-severity="error"][data-dismissible="true"] .ds-alert__icon {
+.ds-alert[data-severity="error"][data-dismissible] .ds-alert__icon {
   fill: var(--color-icon-error-strong);
 }
 ```
 
-Root element selectors use the component's kebab-cased name. Child elements use the `__element` BEM suffix. Variants use `[data-propName="value"]` attribute selectors, with camelCase prop names kebabized. Compound selectors combine multiple variant attributes for intersection overrides.
+Root element selectors use the component's kebab-cased name. Child elements use the `__element` BEM suffix. Variants use `[data-propName]` presence selectors for boolean props and `[data-propName="value"]` value selectors for string enum props, with camelCase prop names kebabized. Compound selectors combine multiple variant attributes for intersection overrides.
 
 ## Token Resolution
 
@@ -117,6 +117,59 @@ config:
 ```
 
 When `processing.states` is absent, all variant props produce `[data-*]` selectors (the default shown in the example above). When present, classified props emit semantic CSS pseudo-classes and ARIA attribute selectors instead.
+
+### Disabled guard on hover and active
+
+When the `disabled` concept is configured in `processing.states`, the transformer automatically appends `:not(:disabled):not([aria-disabled="true"])` to every `:hover` and `:active` selector — including compound variants that mix a data attribute with `:hover` or `:active`. This prevents hover and active styles from firing on disabled elements without any extra CSS to write.
+
+```css
+/* disabled concept configured → hover and active are guarded */
+.ds-button:hover:not(:disabled):not([aria-disabled="true"]) { … }
+.ds-button:active:not(:disabled):not([aria-disabled="true"]) { … }
+
+/* data attribute + :hover compound variant also receives the guard */
+.ds-button[data-variant="primary"]:hover:not(:disabled):not([aria-disabled="true"]) { … }
+```
+
+Selectors that are not `:hover` or `:active` (e.g. `:focus-within`, `:disabled` itself) are never guarded.
+
+## Subcomponent Output
+
+When subcomponents are present in `variants.yaml`, each subcomponent gets its own `styles.css` inside a named subfolder. The subfolder name is the subcomponent's key in the spec (e.g. `group`, `item`). The BEM root class is scoped to the subcomponent's kebab-cased key, not the parent component.
+
+```
+dsActionList/
+  styles.css          ← parent component stylesheet (.ds-action-list)
+  group/
+    styles.css        ← subcomponent stylesheet (.ds-action-list-group)
+  item/
+    styles.css        ← subcomponent stylesheet (.ds-action-list-item)
+```
+
+The subcomponent `styles.css` follows the same structure as the parent — default element blocks first, then variant blocks — but scoped entirely to the subcomponent class:
+
+```css
+/* Generated. Do not edit — regenerate with `specs transform`. */
+
+.ds-action-list-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.ds-action-list-group__label {
+  color: var(--color-text-secondary);
+  font: var(--font-label-xs);
+}
+
+/* Variant: divider */
+
+.ds-action-list-group[data-divider] {
+  border-top: 1px solid var(--color-border-subtle);
+}
+```
+
+Subcomponent stylesheets are fully self-contained — elements and variants from the parent component never appear in them. Configure subcomponent discovery in [`config.processing.subcomponents`](/specs/config/subcomponents/).
 
 ## See Also
 

--- a/site/src/content/docs/cli/transforms/css.md
+++ b/site/src/content/docs/cli/transforms/css.md
@@ -141,30 +141,30 @@ When subcomponents are present in `variants.yaml`, each subcomponent gets its ow
 dsActionList/
   styles.css          ← parent component stylesheet (.ds-action-list)
   group/
-    styles.css        ← subcomponent stylesheet (.ds-action-list-group)
+    styles.css        ← subcomponent stylesheet (.group)
   item/
-    styles.css        ← subcomponent stylesheet (.ds-action-list-item)
+    styles.css        ← subcomponent stylesheet (.item)
 ```
 
-The subcomponent `styles.css` follows the same structure as the parent — default element blocks first, then variant blocks — but scoped entirely to the subcomponent class:
+The subcomponent `styles.css` follows the same structure as the parent — default element blocks first, then variant blocks — but BEM selectors are scoped to the subcomponent's own kebab-cased key, not the parent component name:
 
 ```css
 /* Generated. Do not edit — regenerate with `specs transform`. */
 
-.ds-action-list-group {
+.group {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
 }
 
-.ds-action-list-group__label {
+.group__label {
   color: var(--color-text-secondary);
   font: var(--font-label-xs);
 }
 
 /* Variant: divider */
 
-.ds-action-list-group[data-divider] {
+.group[data-divider] {
   border-top: 1px solid var(--color-border-subtle);
 }
 ```

--- a/site/src/content/docs/config/states.md
+++ b/site/src/content/docs/config/states.md
@@ -93,15 +93,15 @@ Without `states` config, all variant props produce `data-*` attribute selectors:
 ```css
 /* Without states config */
 .ds-text-input[data-state="hover"] { … }
-.ds-text-input[data-is-disabled="true"] { … }
-.ds-text-input[data-focused="true"] { … }
+.ds-text-input[data-is-disabled] { … }       /* boolean prop → presence selector */
+.ds-text-input[data-focused] { … }            /* boolean prop → presence selector */
 ```
 
 With `states` config, classified props produce semantic selectors:
 
 ```css
-/* With states config */
-.ds-text-input:hover { … }
+/* With states config — disabled concept configured */
+.ds-text-input:hover:not(:disabled):not([aria-disabled="true"]) { … }
 .ds-text-input:disabled,
 .ds-text-input[aria-disabled="true"] { … }
 .ds-text-input:focus-within { … }


### PR DESCRIPTION
## Summary

- Adds a `CssRule` interface for configurable pre-pass transformations on variants data before CSS emission
- Implements `border-shift-inset-shadow` as the first rule — detects elements whose `strokeWeight`/`strokes` change across variants and rewrites them to eliminate layout shift: default block gets a transparent border reservation; variant blocks use `box-shadow: inset` instead
- Adds `_rawCss` pass-through in `styleToCSS` for rule-injected declarations
- Verified against the `egdsPill` component (border changes on selection)
- Docs updates from parallel agent: subcomponent output, presence selectors, disabled hover/active guard — plus one correction to subcomponent BEM class scope

## Configuration

```yaml
transformers:
  - name: css
    rules:
      - border-shift-inset-shadow
```

## Test plan

- [ ] Run `specs transform --config specs.config.yaml` against `specs-testing` — 25/25 succeed (no regressions)
- [ ] Configure `border-shift-inset-shadow` on `egdsPill` — default block gets `border-color: transparent` + `border-width` + `border-style: solid`; `[data-selected]` block gets `box-shadow: inset 0 0 0 …` with no `border-width`
- [ ] Unknown rule name throws a clear error
- [ ] Rule applies to subcomponent `styles.css` files as well
- [ ] OUTSIDE/CENTER strokes are not affected by the rule (they use `outline`, not `border`)
- [ ] 388 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
