### PR TITLE
fix(analyze): respect format.output for props and styling analyzers (#151)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - Unreleased
+
+### Fixed
+
+- **`analyze` command respects `format.output` for props and styling (#151)** — `props` and `styling` analyzers now write `.json` or `.yaml` output files (and use the matching serializer) based on `config.format.output`. Previously both were hardcoded: `props` always wrote YAML, `styling` always wrote JSON.
+
 ## [0.20.0] - 2026-06-07
 
 Introduces the `specs analyze` command with two analyzers: `props` (cross-library prop governance aggregate) and `styling` (token usage dictionary, moved from transforms). Extends the `css` and `contract` transformers with subcomponent support, a configurable CSS rule pipeline, and the `border-shift-inset-shadow` rule. Refines `css` output: boolean props emit presence selectors and disabled guards wrap hover/active.

--- a/packages/cli/src/Types/Transformer.ts
+++ b/packages/cli/src/Types/Transformer.ts
@@ -7,6 +7,8 @@ export interface TransformerContext {
   componentKey: string;
   /** Token format from config.format.tokens. Drives CSS variable resolution. */
   tokensFormat: string;
+  /** Output format from config.format.output. Drives file extension and serialization for analyzers. */
+  outputFormat: 'JSON' | 'YAML';
   /** Semantic state concept map from config.processing.states. */
   processingStates?: ProcessingStates;
   /** Raw options from the matching config.transformers entry (everything except `name`). */

--- a/packages/cli/src/analyzers/Props.ts
+++ b/packages/cli/src/analyzers/Props.ts
@@ -74,9 +74,11 @@ export class PropsAnalyzer implements Transformer {
   readonly name = 'props';
 
   private readonly _allProps: PropEntry[] = [];
+  private _outputFormat: 'JSON' | 'YAML' = 'JSON';
 
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
-    const { componentKey } = context;
+    const { componentKey, outputFormat } = context;
+    this._outputFormat = outputFormat;
 
     const mainProps = extractProps(componentKey, apiYaml);
     this._allProps.push(...mainProps);
@@ -95,11 +97,11 @@ export class PropsAnalyzer implements Transformer {
     await fs.ensureDir(outDir);
 
     const aggregate = buildAggregate(this._allProps);
-    await fs.writeFile(
-      path.join(outDir, 'props.yaml'),
-      yaml.stringify(aggregate, { lineWidth: 120 }),
-      'utf-8',
-    );
+    const ext = this._outputFormat === 'JSON' ? 'json' : 'yaml';
+    const content = this._outputFormat === 'JSON'
+      ? JSON.stringify(aggregate, null, 2) + '\n'
+      : yaml.stringify(aggregate, { lineWidth: 120 });
+    await fs.writeFile(path.join(outDir, `props.${ext}`), content, 'utf-8');
   }
 }
 

--- a/packages/cli/src/analyzers/Styling.ts
+++ b/packages/cli/src/analyzers/Styling.ts
@@ -50,9 +50,11 @@ export class StylingAnalyzer implements Transformer {
 
   // Flat map: "componentKey" and "componentKey.subName" entries stored together.
   private readonly _componentData = new Map<string, StylingJson>();
+  private _outputFormat: 'JSON' | 'YAML' = 'JSON';
 
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
-    const { outputDir, componentKey } = context;
+    const { outputDir, componentKey, outputFormat } = context;
+    this._outputFormat = outputFormat;
 
     const anatomy = (apiYaml.anatomy ?? {}) as Record<string, unknown>;
     const elementTypes = extractElementTypes(anatomy);
@@ -87,8 +89,12 @@ export class StylingAnalyzer implements Transformer {
       fileOutput[scopeKey] = data;
     }
 
-    const outputPath = path.join(outputDir, 'styling.json');
-    await fs.writeFile(outputPath, JSON.stringify(fileOutput, null, 2) + '\n', 'utf-8');
+    const ext = this._outputFormat === 'YAML' ? 'yaml' : 'json';
+    const outputPath = path.join(outputDir, `styling.${ext}`);
+    const content = this._outputFormat === 'YAML'
+      ? yaml.stringify(fileOutput, { lineWidth: 120 })
+      : JSON.stringify(fileOutput, null, 2) + '\n';
+    await fs.writeFile(outputPath, content, 'utf-8');
   }
 
   async finalize(outputDir: string, analysisDir?: string): Promise<void> {
@@ -106,7 +112,11 @@ export class StylingAnalyzer implements Transformer {
     for (const [key, data] of Array.from(this._componentData.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
       out[key] = stripRawValues(data);
     }
-    await fs.writeFile(path.join(dictDir, 'styling.byComponent.json'), JSON.stringify(out, null, 2) + '\n', 'utf-8');
+    const ext = this._outputFormat === 'YAML' ? 'yaml' : 'json';
+    const content = this._outputFormat === 'YAML'
+      ? yaml.stringify(out, { lineWidth: 120 })
+      : JSON.stringify(out, null, 2) + '\n';
+    await fs.writeFile(path.join(dictDir, `styling.byComponent.${ext}`), content, 'utf-8');
   }
 
   private async _writeByToken(dictDir: string): Promise<void> {
@@ -126,7 +136,11 @@ export class StylingAnalyzer implements Transformer {
       }
     }
 
-    await fs.writeFile(path.join(dictDir, 'styling.byToken.json'), JSON.stringify(out, null, 2) + '\n', 'utf-8');
+    const ext = this._outputFormat === 'YAML' ? 'yaml' : 'json';
+    const content = this._outputFormat === 'YAML'
+      ? yaml.stringify(out, { lineWidth: 120 })
+      : JSON.stringify(out, null, 2) + '\n';
+    await fs.writeFile(path.join(dictDir, `styling.byToken.${ext}`), content, 'utf-8');
   }
 }
 

--- a/packages/cli/src/commands/AnalyzeCommand.ts
+++ b/packages/cli/src/commands/AnalyzeCommand.ts
@@ -90,6 +90,7 @@ export const Analyze = new Command('analyze')
               outputDir: componentDir,
               componentKey,
               tokensFormat: config.config.format.tokens,
+              outputFormat: config.config.format.output,
               processingStates: config.config.processing?.states as ProcessingStates | undefined,
             };
             await analyzer.run(apiYaml, context);

--- a/packages/cli/tests/unit/analyzers/Props.test.ts
+++ b/packages/cli/tests/unit/analyzers/Props.test.ts
@@ -27,32 +27,41 @@ describe('PropsAnalyzer', () => {
     await fs.remove(outputDir);
   });
 
-  async function runAnalyzer(components: Record<string, Record<string, unknown>>) {
+  async function runAnalyzer(components: Record<string, Record<string, unknown>>, outputFormat: 'JSON' | 'YAML' = 'YAML') {
     const a = new PropsAnalyzer();
     for (const [componentKey, apiYaml] of Object.entries(components)) {
       const compDir = path.join(outputDir, componentKey);
       await fs.ensureDir(compDir);
-      await a.run(apiYaml, { outputDir: compDir, componentKey });
+      await a.run(apiYaml, { outputDir: compDir, componentKey, outputFormat });
     }
     await a.finalize!(outputDir, analysisDir);
-    const raw = await fs.readFile(path.join(analysisDir, 'props.yaml'), 'utf-8');
-    return yaml.parse(raw) as AggregateYaml;
+    if (outputFormat === 'JSON') {
+      return JSON.parse(await fs.readFile(path.join(analysisDir, 'props.json'), 'utf-8')) as AggregateYaml;
+    }
+    return yaml.parse(await fs.readFile(path.join(analysisDir, 'props.yaml'), 'utf-8')) as AggregateYaml;
   }
 
   it('has name "props"', () => {
     expect(new PropsAnalyzer().name).toBe('props');
   });
 
-  it('writes _analysis/props.yaml after finalize', async () => {
-    await runAnalyzer({ compA: { props: { label: { type: 'string' } } } });
+  it('writes _analysis/props.yaml when outputFormat is YAML', async () => {
+    await runAnalyzer({ compA: { props: { label: { type: 'string' } } } }, 'YAML');
     expect(fs.existsSync(path.join(analysisDir, 'props.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(analysisDir, 'props.json'))).toBe(false);
+  });
+
+  it('writes _analysis/props.json when outputFormat is JSON', async () => {
+    await runAnalyzer({ compA: { props: { label: { type: 'string' } } } }, 'JSON');
+    expect(fs.existsSync(path.join(analysisDir, 'props.json'))).toBe(true);
+    expect(fs.existsSync(path.join(analysisDir, 'props.yaml'))).toBe(false);
   });
 
   it('does not write per-component files', async () => {
     const compDir = path.join(outputDir, 'compA');
     await fs.ensureDir(compDir);
     const a = new PropsAnalyzer();
-    await a.run({ props: { label: { type: 'string' } } }, { outputDir: compDir, componentKey: 'compA' });
+    await a.run({ props: { label: { type: 'string' } } }, { outputDir: compDir, componentKey: 'compA', outputFormat: 'YAML' });
     expect(fs.existsSync(path.join(compDir, 'props.yaml'))).toBe(false);
   });
 

--- a/packages/cli/tests/unit/analyzers/Styling.test.ts
+++ b/packages/cli/tests/unit/analyzers/Styling.test.ts
@@ -2,16 +2,17 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
+import yaml from 'yaml';
 import { StylingAnalyzer } from '../../../src/analyzers/Styling.js';
 
 const transformer = new StylingAnalyzer();
 
-function makeContext(dir: string, componentKey = 'dsButton') {
-  return { outputDir: dir, componentKey };
+function makeContext(dir: string, componentKey = 'dsButton', outputFormat: 'JSON' | 'YAML' = 'JSON') {
+  return { outputDir: dir, componentKey, outputFormat };
 }
 
 async function run(dir: string, apiYaml: Record<string, unknown>, componentKey = 'dsButton') {
-  await transformer.run(apiYaml, makeContext(dir, componentKey));
+  await transformer.run(apiYaml, makeContext(dir, componentKey, 'JSON'));
   const raw = await fs.readFile(path.join(dir, 'styling.json'), 'utf-8');
   return JSON.parse(raw) as Record<string, {
     variables: Array<{ name: string; appliedAs: string; rawValue?: unknown; appliedTo: Record<string, number> }>;
@@ -303,6 +304,23 @@ describe('StylingAnalyzer', () => {
     expect(out['dsButton.item'].variables[0].name).toBe('Color/On surface');
   });
 
+  it('writes styling.yaml when outputFormat is YAML', async () => {
+    const t = new StylingAnalyzer();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'styling-yaml-'));
+    try {
+      await t.run(
+        { anatomy: { root: { type: 'container' } }, default: { elements: { root: { styles: { backgroundColor: { $token: 'DS Color.Primary', $type: 'color' } } } } } },
+        { outputDir: dir, componentKey: 'dsButton', outputFormat: 'YAML' },
+      );
+      expect(fs.existsSync(path.join(dir, 'styling.yaml'))).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'styling.json'))).toBe(false);
+      const parsed = yaml.parse(await fs.readFile(path.join(dir, 'styling.yaml'), 'utf-8'));
+      expect(parsed.dsButton.variables[0].name).toBe('DS Color.Primary');
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+
   it('subcomponent tokens do not appear in the top-level component scope', async () => {
     const out = await run(tmpDir, {
       anatomy: { root: { type: 'container' } },
@@ -360,20 +378,28 @@ describe('StylingAnalyzer.finalize', () => {
     await fs.remove(outputDir);
   });
 
-  async function runFinalize() {
+  async function runFinalize(outputFormat: 'JSON' | 'YAML' = 'JSON') {
     const t = new StylingAnalyzer();
-    await t.run(COMP_A, { outputDir: compDirA, componentKey: 'compA' });
-    await t.run(COMP_B, { outputDir: compDirB, componentKey: 'compB' });
+    await t.run(COMP_A, { outputDir: compDirA, componentKey: 'compA', outputFormat });
+    await t.run(COMP_B, { outputDir: compDirB, componentKey: 'compB', outputFormat });
     await t.finalize!(outputDir);
-    const byComp = JSON.parse(await fs.readFile(path.join(outputDir, '_analysis', 'styling.byComponent.json'), 'utf-8'));
-    const byToken = JSON.parse(await fs.readFile(path.join(outputDir, '_analysis', 'styling.byToken.json'), 'utf-8'));
-    return { byComp, byToken };
+    const ext = outputFormat === 'YAML' ? 'yaml' : 'json';
+    const byCompRaw = await fs.readFile(path.join(outputDir, '_analysis', `styling.byComponent.${ext}`), 'utf-8');
+    const byTokenRaw = await fs.readFile(path.join(outputDir, '_analysis', `styling.byToken.${ext}`), 'utf-8');
+    const parse = outputFormat === 'YAML' ? (s: string) => yaml.parse(s) : (s: string) => JSON.parse(s);
+    return { byComp: parse(byCompRaw), byToken: parse(byTokenRaw) };
   }
 
-  it('creates _analysis folder with both files', async () => {
-    await runFinalize();
+  it('creates _analysis folder with both .json files when outputFormat is JSON', async () => {
+    await runFinalize('JSON');
     expect(fs.existsSync(path.join(outputDir, '_analysis', 'styling.byComponent.json'))).toBe(true);
     expect(fs.existsSync(path.join(outputDir, '_analysis', 'styling.byToken.json'))).toBe(true);
+  });
+
+  it('creates _analysis folder with both .yaml files when outputFormat is YAML', async () => {
+    await runFinalize('YAML');
+    expect(fs.existsSync(path.join(outputDir, '_analysis', 'styling.byComponent.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, '_analysis', 'styling.byToken.yaml'))).toBe(true);
   });
 
   it('byComponent keys match component names in alphabetical order', async () => {
@@ -397,7 +423,7 @@ describe('StylingAnalyzer.finalize', () => {
     };
     const compDir = path.join(outputDir, 'compRaw');
     await fs.ensureDir(compDir);
-    await t.run(withRaw, { outputDir: compDir, componentKey: 'compRaw' });
+    await t.run(withRaw, { outputDir: compDir, componentKey: 'compRaw', outputFormat: 'JSON' });
     await t.finalize!(outputDir);
     const byComp = JSON.parse(await fs.readFile(path.join(outputDir, '_analysis', 'styling.byComponent.json'), 'utf-8'));
     expect('rawValue' in byComp.compRaw.variables[0]).toBe(false);
@@ -438,7 +464,7 @@ describe('StylingAnalyzer.finalize', () => {
     };
     const compDir = path.join(outputDir, 'compSub');
     await fs.ensureDir(compDir);
-    await t.run(withSub, { outputDir: compDir, componentKey: 'compSub' });
+    await t.run(withSub, { outputDir: compDir, componentKey: 'compSub', outputFormat: 'JSON' });
     await t.finalize!(outputDir);
     const byToken = JSON.parse(await fs.readFile(path.join(outputDir, '_analysis', 'styling.byToken.json'), 'utf-8'));
     const entry = byToken.variables['Color/On surface'][0];


### PR DESCRIPTION
## Summary

`props` and `styling` analyzers both ignored `config.format.output` and always hardcoded their serialization format. `props` always wrote `.yaml`; `styling` always wrote `.json`. Both now write `.yaml` or `.json` based on `format.output`, using the matching serializer (YAML or JSON).

Changes:
- `TransformerContext` gains `outputFormat: 'JSON' | 'YAML'`
- `AnalyzeCommand` passes `config.config.format.output` into context
- `StylingAnalyzer` stores format on instance (needed since `finalize` has no context) and applies it to all three write paths: `styling.<ext>`, `styling.byComponent.<ext>`, `styling.byToken.<ext>`
- `PropsAnalyzer` same pattern for `props.<ext>`

## Test coverage

- Existing tests updated to pass `outputFormat` explicitly, preserving prior behavior
- New test: `StylingAnalyzer` writes `.yaml` (not `.json`) when `outputFormat: 'YAML'`
- New tests: `PropsAnalyzer` writes `.yaml` or `.json` based on format, not `.json` when YAML and vice versa
- New test: `StylingAnalyzer.finalize` writes `.yaml` aggregate files when `outputFormat: 'YAML'`
- All 50 analyzer tests pass

Closes DirectedEdges/specs#151
