### PR TITLE
fix: emit CSS for enum-valued state variants without explicit value (#157)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - Unreleased
+
+### Fixed
+
+- **CSS transform now emits styling for enum-valued state variants** — When a state in `config.processing.states` maps a prop without an explicit `value` (e.g. `selected: { prop: selected }`), variants whose enum value matches the concept name (case-insensitively, like `Selected=Selected`) now produce CSS selectors. Previously these variants were silently skipped, causing selected-state styling to be missing from `styles.css`.
+
 ## [0.20.0] - 2026-06-07
 
 Introduces the `specs analyze` command with two analyzers: `props` (cross-library prop governance aggregate) and `styling` (token usage dictionary, moved from transforms). Extends the `css` and `contract` transformers with subcomponent support, a configurable CSS rule pipeline, and the `border-shift-inset-shadow` rule. Refines `css` output: boolean props emit presence selectors and disabled guards wrap hover/active.

--- a/packages/cli/src/transforms/Css.ts
+++ b/packages/cli/src/transforms/Css.ts
@@ -104,7 +104,7 @@ function buildCssLines(
     for (const [k, v] of configEntries) {
       const vStr = String(v);
       if (classifiedProps.has(k)) {
-        const concept = stateLookup.get(`${k}::${vStr}`);
+        const concept = stateLookup.get(`${k}::${vStr}`) ?? stateLookup.get(`${k}::${vStr.toLowerCase()}`);
         if (!concept) { skip = true; break; } // unmatched value = base/rest state
         const conceptEntry = CONCEPT_TABLE[concept];
         const sel = conceptEntry?.selector ?? `[data-${toKebab(k)}="${vStr}"]`;

--- a/packages/cli/src/transforms/states.ts
+++ b/packages/cli/src/transforms/states.ts
@@ -42,6 +42,12 @@ export function buildStateLookup(states: ProcessingStates): {
   for (const [concept, entry] of Object.entries(states)) {
     const v = entry.value ?? 'true';
     lookup.set(`${entry.prop}::${v}`, concept);
+    // When no value is configured, the concept name itself may serve as the enum
+    // value (e.g. selected: { prop: selected } should match Selected=Selected).
+    // Register a lowercase key so Css.ts can find it via case-insensitive fallback.
+    if (!entry.value) {
+      lookup.set(`${entry.prop}::${concept}`, concept);
+    }
     classifiedProps.add(entry.prop);
   }
   return { lookup, classifiedProps };

--- a/packages/cli/tests/unit/transforms/Css.test.ts
+++ b/packages/cli/tests/unit/transforms/Css.test.ts
@@ -262,6 +262,43 @@ describe('CssTransformer', () => {
       expect(out).toContain('.ds-button[data-appearance="outline"]:hover:not(:disabled):not([aria-disabled="true"]) {');
     });
 
+    it('emits [aria-selected="true"] for enum-valued selected prop (Selected=Selected case)', async () => {
+      // Checkbox: selected: { prop: 'selected' } — no value → concept name is the enum value
+      const enumStates: ProcessingStates = {
+        selected: { prop: 'selected' },
+        indeterminate: { prop: 'selected', value: 'Indeterminate' },
+      };
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          // Enum value matching concept name (title-cased, as Figma produces)
+          { configuration: { selected: 'Selected' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+          // Explicit value mapping
+          { configuration: { selected: 'Indeterminate' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+          // Rest value — should be skipped
+          { configuration: { selected: 'Unselected' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        ],
+      }, 'dsCheckbox', 'TOKEN', enumStates);
+      expect(out).toContain('[aria-selected="true"]');
+      expect(out).toContain(':indeterminate,');
+      expect(out).not.toContain('Unselected');
+      expect(out).not.toContain('data-selected=');
+    });
+
+    it('does not regress boolean state props (disabled::true still matches)', async () => {
+      const boolStates: ProcessingStates = {
+        disabled: { prop: 'disabled' },
+      };
+      const out = await run(tmpDir, {
+        default: { elements: {} },
+        variants: [
+          { configuration: { disabled: 'true' }, elements: { root: { styles: { layoutMode: 'HORIZONTAL' } } } },
+        ],
+      }, 'dsButton', 'TOKEN', boolStates);
+      expect(out).toContain('.ds-button:disabled,');
+      expect(out).not.toContain('data-disabled=');
+    });
+
     it('produces no state-related selectors when processingStates is absent', async () => {
       const out = await run(tmpDir, {
         default: { elements: {} },

--- a/packages/cli/tests/unit/transforms/states.test.ts
+++ b/packages/cli/tests/unit/transforms/states.test.ts
@@ -95,6 +95,24 @@ describe('buildStateLookup', () => {
     expect(classifiedProps.has('isDisabled')).toBe(true);
     expect(classifiedProps.has('validation')).toBe(true);
   });
+
+  it('also registers concept name as key when no value is specified (enum support)', () => {
+    const { lookup } = buildStateLookup({
+      selected: { prop: 'selected' },
+    });
+    // boolean default still present
+    expect(lookup.get('selected::true')).toBe('selected');
+    // concept name key added for case-insensitive enum matching
+    expect(lookup.get('selected::selected')).toBe('selected');
+  });
+
+  it('does NOT add concept name key when value is explicitly specified', () => {
+    const { lookup } = buildStateLookup({
+      active: { prop: 'state', value: 'pressed' },
+    });
+    expect(lookup.get('state::pressed')).toBe('active');
+    expect(lookup.has('state::active')).toBe(false);
+  });
 });
 
 describe('buildOmittedProps', () => {


### PR DESCRIPTION
## Summary

When `config.processing.states` maps a prop to a concept without specifying a `value` (e.g. `selected: { prop: selected }`), enum-valued variants like `Selected=Selected` were silently skipped — only `selected::true` was registered in the lookup, so the enum value never matched and its styling never reached `styles.css`.

The fix registers the concept name itself as a secondary lookup key when no `value` is specified, and uses a case-insensitive fallback in the CSS transformer so `Selected=Selected` resolves to the `selected` concept and emits `[aria-selected="true"]`.

## Test coverage

- `buildStateLookup` now registers `prop::conceptName` in addition to `prop::true` when no `value` is configured; confirmed it does NOT add the extra key for explicit-value entries.
- New CSS transformer test: enum prop `selected: { prop: 'selected' }` emits `[aria-selected="true"]` for `Selected=Selected`, `:indeterminate` for explicit `Indeterminate` value, and skips the rest value `Unselected`.
- Regression test: boolean props (`disabled::true`) continue to work unchanged.

Closes DirectedEdges/specs#157
