### PR TITLE
fix(schema): correct Metadata.generator.version type number → string (#150)

### DIFF
--- a/adr/057-generator-version-string.md
+++ b/adr/057-generator-version-string.md
@@ -2,7 +2,7 @@
 
 **Branch**: `057-generator-version-string`
 **Created**: 2026-06-15
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/057-generator-version-string.md
+++ b/adr/057-generator-version-string.md
@@ -1,0 +1,118 @@
+# ADR: Fix `Metadata.generator.version` Type: `number` → `string`
+
+**Branch**: `057-generator-version-string`
+**Created**: 2026-06-15
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+`Metadata.generator.version` is currently typed as `number` in `types/Metadata.ts` and declared as `"type": "number"` in `schema/component.schema.json`. In practice, both the plugin and the CLI have passed semver strings (e.g. `"1.10.0"`) since the `__PLUGIN_VERSION__` build-time define was changed from a hardcoded integer to a semver string. This has been the effective runtime behavior since schema v0.22.0 / specs-from-figma v0.19.0.
+
+The result is a type mismatch: the TypeScript type says `number`, the JSON schema says `number`, but every consumer writes a string. This causes type errors in `specs-from-figma`'s `build:types` step and means schema validation would reject all real output as invalid.
+
+```yaml
+# Current (incorrect)
+generator:
+  version: 1        # typed/validated as number
+
+# Actual runtime output (semver string)
+generator:
+  version: "1.10.0"
+```
+
+---
+
+## Decision Drivers
+
+- **Type ↔ schema symmetry (Constitution I)**: Both artifacts must describe the same structure. Changing only one is not acceptable.
+- **Strict TypeScript compliance (Constitution V)**: The type must match actual usage with zero type errors under strict mode.
+- **Schema validity (Constitution IV)**: The JSON schema must pass mechanical validation and accurately reflect serialized output.
+- **Semver classification (Constitution, Versioning)**: Changing the type of a required field from `number` to `string` is a breaking change in the type contract.
+
+---
+
+## Options Considered
+
+*(Pre-decided — no alternatives evaluated)*
+
+The field has never validly held a numeric value in production; the `number` type was a mistake introduced when the integer placeholder was replaced by a semver build-time define. The correct fix is to align the type and schema with the actual contract. No alternative (e.g., keeping `number`, widening to `number | string`) accurately represents the field's meaning or usage.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Metadata.ts` | Change `generator.version` from `number` to `string` | MAJOR |
+
+**Before / After** (`types/Metadata.ts`):
+```yaml
+# Before
+generator:
+  version: number   # incorrect — never held a numeric value in production
+
+# After
+generator:
+  version: string   # semver string (e.g. "1.10.0")
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Change `#/definitions/Metadata/properties/generator/properties/version` from `"type": "number"` to `"type": "string"` | MAJOR |
+
+**Before / After** (`schema/component.schema.json`):
+```yaml
+# Before
+version:
+  type: number
+
+# After
+version:
+  type: string
+```
+
+### Notes
+
+The field is in `required` within the `generator` object — this does not change. Only the value type changes. No field is added, removed, or renamed.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — both `types/Metadata.ts` and `component.schema.json` change `version` from `number`/`"number"` to `string`/`"string"` in lockstep.
+- **Parity check**: `Metadata.generator.version: string` maps to `#/definitions/Metadata/properties/generator/properties/version: { "type": "string" }`.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Eliminates existing type error in `build:types` | Recompile — no source changes needed; the semver string was already being passed |
+| `specs-cli` | Type error on `generator.version` field resolved | Recompile — no source changes needed; semver string was already being passed |
+| `specs-plugin-2` | Type error resolved | Recompile — no source changes needed; `__PLUGIN_VERSION__` semver string was already correct |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.24.x → 0.25.0` (`MAJOR`)
+
+**Justification**: Changing the declared type of a required field (`generator.version: number → string`) is a breaking change to the published type and schema contract per Constitution III ("Removing or renaming an exported type or a named field within a type is a breaking change"). Any consumer that validated against the schema or compiled against the type for the old `number` shape must update. The bump has already been reserved in the current release branch (`release/schema-0.25.0-cli-0.21.0`).
+
+---
+
+## Consequences
+
+- `Metadata.generator.version` is correctly typed as `string` in both the TypeScript types and JSON schema.
+- All three downstream consumers compile cleanly against the updated type without source changes.
+- Schema validation now accepts real-world output (semver strings) and rejects numeric values, which were never valid in practice.
+- Consumers pinned to schema v0.24.x or earlier that validate `generator.version` as a number will need to upgrade; in practice this is a no-op since no real output ever held a numeric value.

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 057 | Fix `Metadata.generator.version` type: `number` → `string` | |
 | 056 | Rename `SlotProp.minItems`/`maxItems` → `minChildren`/`maxChildren` | Align with Figma-native `slotSettings` field names; `anyOf` populated from `preferredValues` when `allowPreferredValuesOnly` is true |
 | 055 | Variant State Classification via `processing.states` | |
 | 054 | Workspace Schema File | |
@@ -33,6 +32,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 057 | Fix `Metadata.generator.version` type: `number` → `string` | Corrects type mismatch — field holds semver strings (e.g. `"1.10.0"`) in all producers; was incorrectly typed as `number` |
 | 055 | Variant State Classification via `processing.states` | Add `VariantStateEntry` type; add `Config.processing.states` — classifies Figma variant props as browser-driven or consumer-controlled for CSS selector and contract output |
 | 051 | Platform Code-Syntax Token Profiles | Add `FIGMA_SYNTAX_WEB`/`_IOS`/`_ANDROID` to `Config.format.tokens`, emitting per-platform Figma code syntax with fallback to `TOKEN` |
 | 043 | Custom Color Format Configuration | Add `Config.format.color` with 9-format enum (HEX default); rename `ColorValue` → `ColorObject`; widen color types with `string` arm |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 057 | Fix `Metadata.generator.version` type: `number` → `string` | |
 | 056 | Rename `SlotProp.minItems`/`maxItems` → `minChildren`/`maxChildren` | Align with Figma-native `slotSettings` field names; `anyOf` populated from `preferredValues` when `allowPreferredValuesOnly` is true |
 | 055 | Variant State Classification via `processing.states` | |
 | 054 | Workspace Schema File | |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Specs schema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - Unreleased
+
+### Changed
+
+- `Metadata.generator.version` — type corrected from `number` to `string`; field holds a semver string (e.g. `"1.10.0"`)
+
+### Migration
+
+- `Metadata.generator.version` → `Metadata.generator.version`: update any code that treated this field as a number; read it as a string instead
+
 ## [0.24.0] - 2026-06-05
 
 Introduces the transformer pipeline's schema foundation. `Config.transformers` (a flat `TransformEntry[]`) replaces the old two-level `config.transform.transformers` wrapper, and a new `workspace.schema.json` provides IDE validation for `specs.config.yaml`. `Config.processing.states` adds a concept-keyed map that classifies Figma variant props as browser-driven or consumer-controlled states, enabling the `css` transformer to emit semantic CSS selectors and the `contract` transformer to omit browser-driven props from Props interfaces.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directededges/specs-schema",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Specs UI Component Schema - TypeScript types and JSON schema definitions for component specifications",
   "license": "CC-BY-4.0",
   "author": "Nathan Curtis <nathan@directededges.com>",

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -849,7 +849,7 @@
               "type": "string"
             },
             "version": {
-              "type": "number"
+              "type": "string"
             },
             "name": {
               "type": "string"

--- a/packages/schema/tests/Metadata.test-d.ts
+++ b/packages/schema/tests/Metadata.test-d.ts
@@ -15,7 +15,7 @@ const baseConfig: Metadata['config'] = {
 const withoutLicense: Metadata = {
   author: 'test',
   lastUpdated: '2026-02-24T00:00:00Z',
-  generator: { url: 'https://example.com', version: 1, name: 'test' },
+  generator: { url: 'https://example.com', version: '1.10.0', name: 'test' },
   schema: { url: 'https://example.com/schema', version: '1.0.0' },
   source: { pageId: 'p1', nodeId: 'n1', nodeType: 'COMPONENT' },
   config: baseConfig,
@@ -26,7 +26,7 @@ const withLicense: Metadata = {
   ...withoutLicense,
   generator: {
     url: 'https://example.com',
-    version: 1,
+    version: '1.10.0',
     name: 'test',
     license: {
       status: 'VALID',
@@ -41,6 +41,11 @@ const _level: string = withLicense.generator.license!.level;
 
 // generator.license is optional — can be undefined
 const _optional: { status: string; level: string } | undefined = withoutLicense.generator.license;
+
+// generator.version is a string (semver), not a number
+const _version: string = withoutLicense.generator.version;
+// @ts-expect-error — number is not assignable to string
+const _versionBad: Metadata['generator'] = { url: '', version: 1, name: '' };
 
 // ─── schema.latest — optional discovery URL (ADR 023) ───────────────────────
 

--- a/packages/schema/types/Metadata.ts
+++ b/packages/schema/types/Metadata.ts
@@ -25,7 +25,7 @@ export type Metadata = {
   lastUpdated: string;
   generator: {
     url: string;
-    version: number;
+    version: string;
     name: string;
     /**
      * Resolved license state at the time this component spec was generated.

--- a/site/src/content/docs/schema/metadata.md
+++ b/site/src/content/docs/schema/metadata.md
@@ -12,6 +12,7 @@ Generation metadata attached to the spec. Present when the spec was produced by 
 | `author` | `string` | Yes | Who or what generated the spec |
 | `lastUpdated` | `string` | Yes | ISO 8601 timestamp |
 | `generator` | `object` | Yes | Tool info — `name`, `version`, `url`, and optional `license` |
+| `generator.version` | `string` | Yes | Semver string of the tool that produced the spec (e.g. `"1.10.0"`) |
 | `generator.license` | `object` | No | License status (`status`: VALID/EXPIRED/NONE) and `level` (FREE/PRO/EXTENDED) |
 | `schema` | `object` | Yes | Schema version info — `url`, `version`, and optional `latest` URL |
 | `source` | `object` | Yes | Figma source — `pageId`, `nodeId`, `nodeType` (COMPONENT, COMPONENT_SET, or FRAME) |


### PR DESCRIPTION
## Summary

`Metadata.generator.version` was typed as `number` in both `types/Metadata.ts` and `component.schema.json`, but all producers (plugin, CLI) have passed semver strings (e.g. `"1.10.0"`) since v0.22.0. This PR corrects the type and schema to match actual usage.

## Test coverage

- Updated `tests/Metadata.test-d.ts` fixtures to use semver strings
- Added `@ts-expect-error` assertion confirming `number` is rejected
- All three gates pass: `tsc -p tsconfig.build.json`, `validate-schema.sh`, `tsc --noEmit tests/Metadata.test-d.ts`

Closes DirectedEdges/specs#150