### PR TITLE
fix(cli): stream fetch response to disk to handle large Figma files

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0] - Unreleased
 
+### Fixed
+
+- **`fetch` streams large Figma files to disk instead of buffering in memory** — Previously, `specs fetch` read the entire Figma API response into a JavaScript string before writing it. Files large enough to exceed Node's ~512 MB string limit crashed with `Cannot create a string longer than 0x1fffffe8 characters`. The response body is now streamed directly to a temporary file and renamed into place only on success, so arbitrarily large files are handled without memory pressure and a failed mid-download leaves no partial file behind.
+
 ### Added
 
 `Config.processing.collapsePrimitiveWrapper` is now wired into the CLI.

--- a/packages/cli/src/commands/FetchCommand.ts
+++ b/packages/cli/src/commands/FetchCommand.ts
@@ -83,15 +83,19 @@ function normalizeSources(sources?: MinimalConfig['sources']): Array<{ alias: st
   }));
 }
 
-async function figmaFetch(url: string, token: string): Promise<{ status: number; body: string; headers: Headers }> {
+async function figmaFetch(url: string, token: string): Promise<{ status: number; body: string; headers: Headers; stream: ReadableStream<Uint8Array> | null }> {
   const response = await fetch(url, {
     headers: {
       'X-Figma-Token': token
     }
   });
 
-  const body = await response.text();
-  return { status: response.status, body, headers: response.headers };
+  if (response.status !== 200) {
+    const body = await response.text();
+    return { status: response.status, body, headers: response.headers, stream: null };
+  }
+
+  return { status: response.status, body: '', headers: response.headers, stream: response.body };
 }
 
 const RATE_LIMIT_TYPE_LABELS: Record<string, string> = {
@@ -315,7 +319,8 @@ export const Fetch = new Command('fetch')
 
           const stopSpinner = startSpinner(`Downloading: ${entry.alias} ${kind}`);
 
-          const { status, body, headers } = await figmaFetch(url, token);
+          const result = await figmaFetch(url, token);
+          const { status, body, headers, stream } = result;
           const elapsed = stopSpinner();
 
           const classification = classifyHttpStatus(status);
@@ -340,7 +345,29 @@ export const Fetch = new Command('fetch')
           }
 
           const outputPath = path.join(outDir, `${entry.alias}.${kind}.json`);
-          await fs.writeFile(outputPath, body, 'utf-8');
+          if (stream) {
+            const tmpPath = `${outputPath}.tmp`;
+            try {
+              const writeStream = fs.createWriteStream(tmpPath);
+              await new Promise<void>((resolve, reject) => {
+                const reader = stream.getReader();
+                const pump = () =>
+                  reader.read().then(({ done, value }) => {
+                    if (done) { writeStream.end(); return; }
+                    writeStream.write(value, (err) => { if (err) reject(err); else pump(); });
+                  }).catch(reject);
+                writeStream.on('finish', resolve);
+                writeStream.on('error', reject);
+                pump();
+              });
+              await fs.rename(tmpPath, outputPath);
+            } catch (err) {
+              await fs.remove(tmpPath).catch(() => {});
+              throw err;
+            }
+          } else {
+            await fs.writeFile(outputPath, body, 'utf-8');
+          }
 
           console.log(`✓ Downloaded: ${entry.alias} ${kind} (${elapsed})`);
 


### PR DESCRIPTION
## Summary

- specs fetch crashed with `Cannot create a string longer than 0x1fffffe8 characters` when the Figma library file exceeded Node's ~512 MB string limit
- Response body is now streamed directly to a .tmp file and atomically renamed on success
- A failed mid-download leaves no partial file behind; behavior for normal-sized files is unchanged

## Test plan

- [ ] Run specs fetch against a normal-sized file and confirm output is identical to before
- [ ] Confirm no .tmp file remains in the data directory after a successful fetch
- [ ] Confirm that interrupting a fetch mid-download leaves no partial .json file

Generated with Claude Code