### PR TITLE
feat(schema): Subcomponent.source — Figma node identity (ADR-060)

### DIFF
--- a/adr/060-subcomponent-source-metadata.md
+++ b/adr/060-subcomponent-source-metadata.md
@@ -196,9 +196,9 @@ Subcomponent:
 
 ## Semver Decision
 
-**Version bump**: `0.27.x → 0.28.0` (`MINOR`)
+**Version bump**: within `0.27.x` — no version change required
 
-**Justification**: All changes are additive — a new optional field on `Subcomponent` and a new exported type `SubcomponentSource`. No existing field is removed, renamed, or narrowed. Per the constitution: "MINOR for additive types or new optional fields."
+**Justification**: This change ships as part of the active `release/schema-0.27.0-cli-0.23.0` release. All changes are additive (optional field, new exported type); no bump beyond the release version is warranted.
 
 ---
 

--- a/adr/060-subcomponent-source-metadata.md
+++ b/adr/060-subcomponent-source-metadata.md
@@ -2,7 +2,7 @@
 
 **Branch**: `060-subcomponent-source-metadata`
 **Created**: 2026-06-27
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 060 | Subcomponent Figma Source Identity — `Subcomponent.source` | |
 | 059 | Border Style and Dash Pattern — `borderStyle` and `borderDashPattern` on `Styles` | |
 | 058 | Wrapper Collapse Config Flag — `processing.wrapperCollapse` | |
 | 057 | Fix `Metadata.generator.version` type: `number` → `string` | |
@@ -36,6 +35,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 060 | Subcomponent Figma Source Identity — `Subcomponent.source` | Add optional `SubcomponentSource` (`pageId`, `nodeId`, `nodeType`) to `Subcomponent`; enables reverse-direction tools to resolve `SubcomponentRef` to Figma nodes |
 | 059 | Stroke Dash Pattern — `strokeDashPattern` on `Styles` | Add `StrokeDashPattern { dash, gap }` structural type; presence = dashed stroke, null/absent = solid; not token-bindable |
 | 058 | Collapsing Wrapped Primitives — `processing.collapsePrimitiveWrapper` | Add optional boolean to `Config.processing` (default false); strips plain container wrappers around a single text/glyph child and promotes the leaf to spec root |
 | 057 | Fix `Metadata.generator.version` type: `number` → `string` | Corrects type mismatch — field holds semver strings (e.g. `"1.10.0"`) in all producers; was incorrectly typed as `number` |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Styles.strokeDashPattern` — typed as `StrokeDashPattern` (`{ dash: number; gap: number }`) or `null`; presence signals a dashed stroke, null or absent signals solid; maps from Figma `strokeDashes[0]` (dash) and `strokeDashes[1]` (gap)
+- `Subcomponent.source` — optional `SubcomponentSource` (`{ pageId, nodeId, nodeType }`) carrying the Figma node identity for each inline subcomponent; enables reverse-direction tools to resolve `SubcomponentRef` entries to Figma nodes without side-channels
 
 ### Changed
 

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -941,9 +941,30 @@
       ],
       "additionalProperties": false
     },
+    "SubcomponentSource": {
+      "type": "object",
+      "description": "Figma source identity for a subcomponent node. Carries pageId, nodeId, and nodeType to enable reverse-direction tools to resolve a subcomponent back to its originating Figma node.",
+      "properties": {
+        "pageId": {
+          "type": "string",
+          "description": "The Figma page ID containing this subcomponent's node."
+        },
+        "nodeId": {
+          "type": "string",
+          "description": "The Figma node ID for this subcomponent's component node."
+        },
+        "nodeType": {
+          "type": "string",
+          "description": "The Figma node type.",
+          "enum": ["COMPONENT", "COMPONENT_SET", "FRAME"]
+        }
+      },
+      "required": ["pageId", "nodeId", "nodeType"],
+      "additionalProperties": false
+    },
     "Subcomponent": {
       "type": "object",
-      "description": "A subcomponent's data, derived from ComponentData but excluding metadata and subcomponents.",
+      "description": "A subcomponent's data, derived from ComponentData but excluding metadata and subcomponents. The optional source field carries Figma node identity for reverse-direction tooling.",
       "allOf": [
         {
           "$ref": "#/definitions/Component"
@@ -960,7 +981,13 @@
             ]
           }
         }
-      ]
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/SubcomponentSource",
+          "description": "Figma source identity for this subcomponent's node. Populated by the generator; absent in specs produced before ADR-060."
+        }
+      }
     },
     "NumberProp": {
       "type": "object",

--- a/packages/schema/tests/Subcomponent.test-d.ts
+++ b/packages/schema/tests/Subcomponent.test-d.ts
@@ -1,0 +1,37 @@
+import type { Subcomponent, SubcomponentSource, Subcomponents } from '../types/Subcomponent.js';
+
+// SubcomponentSource — required fields
+const source: SubcomponentSource = {
+  pageId: '790:6766',
+  nodeId: '1477:200',
+  nodeType: 'COMPONENT',
+};
+
+// SubcomponentSource — nodeType accepts all three values
+const _frame: SubcomponentSource = { pageId: 'p', nodeId: 'n', nodeType: 'FRAME' };
+const _set: SubcomponentSource = { pageId: 'p', nodeId: 'n', nodeType: 'COMPONENT_SET' };
+
+// Subcomponent — source is optional; a minimal subcomponent remains valid without it
+const minimal: Subcomponent = {
+  title: 'My Sub',
+  anatomy: { root: { type: 'container' } },
+  default: { layout: ['root'], elements: { root: {} } },
+};
+
+// Subcomponent — source can be present
+const withSource: Subcomponent = {
+  title: 'My Sub',
+  anatomy: { root: { type: 'container' } },
+  default: { layout: ['root'], elements: { root: {} } },
+  source,
+};
+
+// Subcomponents record
+const subs: Subcomponents = {
+  '1B': withSource,
+  '2A': minimal,
+};
+
+// SubcomponentSource is exported from index
+import type { SubcomponentSource as IndexSource } from '../types/index.js';
+const _indexed: IndexSource = source;

--- a/packages/schema/types/Subcomponent.ts
+++ b/packages/schema/types/Subcomponent.ts
@@ -1,11 +1,36 @@
 import { Component } from "./Component.js";
 
 /**
- * Represents a subcomponent in the data model.
- * 
- * A subcomponent is like a component but excludes metadata and nested subcomponents.
+ * Figma source identity for a subcomponent node.
+ * Carries the Figma-specific provenance needed to resolve a subcomponent
+ * back to its originating node — pageId, nodeId, and nodeType.
+ * Intentionally a subset of Metadata.source; kept independent so the two
+ * can evolve separately.
+ * @since 0.27.0
  */
-export type Subcomponent = Omit<Component, 'metadata' | 'subcomponents'>;
+export type SubcomponentSource = {
+  /** The Figma page ID containing this subcomponent's node. */
+  pageId: string;
+  /** The Figma node ID for this subcomponent's component node. */
+  nodeId: string;
+  /** The Figma node type. */
+  nodeType: 'COMPONENT' | 'COMPONENT_SET' | 'FRAME';
+};
+
+/**
+ * Represents a subcomponent in the data model.
+ *
+ * A subcomponent is like a component but excludes full metadata and nested subcomponents.
+ * The optional `source` field carries the Figma node identity needed for reverse-direction
+ * tools (e.g. spec → Figma writers) to instantiate subcomponent-referenced elements.
+ */
+export type Subcomponent = Omit<Component, 'metadata' | 'subcomponents'> & {
+  /**
+   * Figma source identity for this subcomponent's node.
+   * Populated by the generator; absent in specs produced before ADR-060.
+   */
+  source?: SubcomponentSource;
+};
 
 /**
  * Record of subcomponents keyed by name

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -12,7 +12,7 @@ export type { Anatomy, AnatomyElement, ElementTypeRef, SubcomponentRef } from '.
 export type { Props, AnyProp, BooleanProp, StringProp, EnumProp, SlotProp, NumberProp, FigmaCodeOnlySource, FigmaPropExtension, PropExtensions } from './Props.js';
 export type { Variant, Variants } from './Variant.js';
 export type { Metadata } from './Metadata.js';
-export type { Subcomponent, Subcomponents } from './Subcomponent.js';
+export type { Subcomponent, Subcomponents, SubcomponentSource } from './Subcomponent.js';
 export type { InstanceExample, InstanceExamples } from './InstanceExample.js';
 
 // Element and structure types

--- a/site/src/content/docs/schema/subcomponents.md
+++ b/site/src/content/docs/schema/subcomponents.md
@@ -5,10 +5,12 @@ description: "Embedded child component definitions and $ref linking"
 
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge pro-badge">Pro</span>')</script>
 
-Subcomponents are smaller components embedded within a parent component's spec. They follow the same structure as a top-level `Component` but without `metadata` or nested subcomponents.
+Subcomponents are smaller components embedded within a parent component's spec. They follow the same structure as a top-level `Component` but without `metadata` or nested subcomponents. An optional `source` field carries the Figma node identity needed for reverse-direction tooling.
 
 ```ts
-type Subcomponent = Omit<Component, 'metadata' | 'subcomponents'>;
+type Subcomponent = Omit<Component, 'metadata' | 'subcomponents'> & {
+  source?: SubcomponentSource;
+};
 type Subcomponents = Record<string, Subcomponent>;
 ```
 
@@ -24,6 +26,33 @@ A `Subcomponent` contains:
 | `default` | [`Variant`](/specs/schema/variants.md/#variant) | Yes | Default variant |
 | `variants` | [`Variant[]`](variants.md) | No | Variant overrides |
 | `invalidVariantCombinations` | [`PropConfigurations[]`](prop-configurations.md) | No | Invalid prop combinations |
+| `source` | `SubcomponentSource` | No | Figma source identity for this subcomponent's node |
+
+### SubcomponentSource
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `pageId` | `string` | Figma page ID containing this subcomponent's node |
+| `nodeId` | `string` | Figma node ID for this subcomponent's component node |
+| `nodeType` | `'COMPONENT' \| 'COMPONENT_SET' \| 'FRAME'` | Figma node type |
+
+```yaml
+subcomponents:
+  formLabel:
+    title: Form / Label
+    source:
+      pageId: "790:6766"
+      nodeId: "1477:200"
+      nodeType: COMPONENT
+    anatomy:
+      root:
+        type: container
+    default:
+      layout:
+        - root
+      elements:
+        root: {}
+```
 
 ## Linking
 


### PR DESCRIPTION
## Summary

- Adds optional `source?: SubcomponentSource` to `Subcomponent`, carrying `pageId`, `nodeId`, and `nodeType` from the originating Figma node
- Adds and exports `SubcomponentSource` type
- Enables reverse-direction tools (spec → Figma writers) to resolve `SubcomponentRef` entries to Figma nodes without side-channels
- No version bump — ships within `0.27.0`

## Gates

- ✅ `tsc -p tsconfig.build.json --noEmit` — clean
- ✅ `validate-schema.sh` — 5/5 passed
- ✅ `tests/Subcomponent.test-d.ts` — clean

## Test plan

- [ ] Review `packages/schema/types/Subcomponent.ts` — `SubcomponentSource` type and updated `Subcomponent` intersection
- [ ] Review `packages/schema/schema/component.schema.json` — new `SubcomponentSource` definition, updated `Subcomponent`
- [ ] Review `packages/schema/tests/Subcomponent.test-d.ts`
- [ ] Review `packages/schema/CHANGELOG.md` entry under `[0.27.0]`
- [ ] Review `site/src/content/docs/schema/subcomponents.md` doc update

Closes ADR-060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)