### PR TITLE
feat(schema): textOverflow and maxLines TEXT style keys (ADR-062)

### DIFF
--- a/adr/062-text-truncation.md
+++ b/adr/062-text-truncation.md
@@ -12,12 +12,12 @@
 
 A text node in Figma can be configured to truncate its content with an ellipsis when the content exceeds the node's bounds. Two `TextNode` properties govern this behaviour:
 
-- [`textTruncation`](https://developers.figma.com/docs/plugins/api/properties/TextNode-texttruncation/) — `'DISABLED' | 'ENDING'`. Whether truncation with a trailing ellipsis is applied.
-- [`maxLines`](https://developers.figma.com/docs/plugins/api/properties/TextNode-maxlines/) — `number | null`. The maximum number of lines a text node may reach before it truncates. Only meaningful when `textTruncation` is `'ENDING'`; `null` means no line limit.
+- [`textTruncation`](https://developers.figma.com/docs/plugins/api/properties/TextNode-texttruncation/) — `'DISABLED' | 'ENDING'`. Whether truncation with a trailing ellipsis is applied. A closed enum.
+- [`maxLines`](https://developers.figma.com/docs/plugins/api/properties/TextNode-maxlines/) — `number | null`. The maximum number of lines a text node may reach before it truncates. Only meaningful when `textTruncation` is `'ENDING'`; `null` means no line limit. An ordinary number.
 
-Neither property is currently represented in the schema. `Styles` in `types/Styles.ts` and the `Styles` definition in `schema/styles.schema.json` have no key for either, and `StyleKey` does not enumerate them. As a result, truncation configuration is silently dropped from spec output — a fidelity gap for line-clamped labels, single-line truncating text, and any component whose text overflow behaviour is part of its design contract. Reverse-direction tooling likewise has no key to write these values back to a Figma node.
+Neither property is currently represented in the schema. `Styles` in `types/Styles.ts` and the `Styles` definition in `schema/styles.schema.json` have no key for either, and `StyleKey` does not enumerate them. As a result, truncation configuration is silently dropped from spec output — a fidelity gap for line-clamped labels, single-line truncating text, and any component whose text overflow behaviour is part of its design contract.
 
-Both properties belong to the `TEXT` element type only. Both are structural: they describe a fixed configuration on the node and are **not** token-bindable, prop-bindable, or conditional in Figma.
+Both properties belong to the `TEXT` element type only. `textTruncation` is a structural enum that is not token-bindable. `maxLines` is a plain number — the same shape as `width`, `height`, `opacity`, and `cornerSmoothing`, all of which are already typed as `Style`.
 
 ---
 
@@ -25,57 +25,58 @@ Both properties belong to the `TEXT` element type only. Both are structural: the
 
 - **Additive-only** — introduce new optional keys without altering any existing type or schema, so downstream consumers incur no breaking change (MINOR bump).
 - **Type ↔ schema parity** — every new `types/` field has a matching `schema/` definition; no drift (Constitution I).
-- **Structural-enum typing rule** — a closed, non-token-bindable value set MUST be a named type, not `Style` (Constitution "Typing — structural enums vs. `Style`"). This is why `textTruncation` mirrors `LayoutMode`/`Position` rather than reusing `Style`, and `maxLines` mirrors `PositionOffset`.
+- **Structural-enum typing rule** — a closed, non-token-bindable value set MUST be a named type, not `Style` (Constitution "Typing — structural enums vs. `Style`"). This governs `textTruncation`.
+- **Consistency for plain numbers** — a numeric property with no closed value set is typed as `Style`, exactly like every other numeric key on `Styles` (`width`, `opacity`, `cornerSmoothing`). This governs `maxLines`. The named-narrow-type rule targets shapes like `PositionOffset` (`number | string | null`), not a plain number.
 - **Naming governance** — field names and enum values chosen per Constitution VI (code-platforms-first), documented below.
 - **No runtime logic** — this package gains only type declarations and schema definitions (Constitution II).
-- **Round-trip fidelity** — the enum member names must survive a Figma → spec → Figma round trip without a translation table the writer would have to invert.
 
 ---
 
 ## Options Considered
 
-### Option A: Two named structural types — `TextTruncation` and `MaxLines` *(Selected)*
+### Option A: `textTruncation` as a named enum; `maxLines` as `Style` *(Selected)*
 
-Add `textTruncation` typed as `TextTruncation | null` (`type TextTruncation = 'DISABLED' | 'ENDING'`) and `maxLines` typed as `MaxLines` (`type MaxLines = number | null`), each with a matching `*StyleValue` schema definition. Mirrors the established structural-enum siblings (`LayoutMode`, `Position`, `PositionOffset`).
+- `textTruncation`: `TextTruncation | null` where `type TextTruncation = 'DISABLED' | 'ENDING'`, with a `TextTruncationStyleValue` schema definition — mirrors `LayoutMode`/`Position`.
+- `maxLines`: `Style`, with the shared `NumberStyleValue` schema definition — mirrors `width`, `opacity`, `cornerSmoothing`.
 
 **Pros**:
-- Satisfies the structural-enum typing rule directly — closed value sets get named types.
-- Symmetric, self-documenting type and schema definitions consistent with existing structural keys.
-- `TextTruncation` is reusable if a future reverse-writer or validator needs the enum by name.
+- Each property is typed by its actual nature: a closed enum gets a named type; a plain number gets `Style`.
+- `maxLines` stays consistent with every other numeric key and needs no bespoke type or schema definition.
+- `Style` correctly permits a `TokenReference` for `maxLines`, matching Figma's variable-binding capability for numeric properties and the transformer's existing treatment (a token-bindable pure number).
 
 **Cons / Trade-offs**:
-- Adds two named types to the public surface rather than reusing generic value types.
+- Two properties in the same feature are typed differently. This reflects a real difference in their value domains, not an inconsistency.
 
 ---
 
-### Option B: Type both as generic `Style` *(Rejected)*
+### Option B: Both as named structural types (`TextTruncation`, `MaxLines`) *(Rejected)*
 
-Type `textTruncation` and `maxLines` as `Style` (like the grandfathered `textAlignHorizontal`).
+Give `maxLines` a dedicated `MaxLines = number | null` type and a `MaxLinesStyleValue` schema definition.
 
-**Rejected because**: Violates the "structural enums vs. `Style`" rule — both values are closed and non-token-bindable, so they must be named types. `Style` would also imply they can carry `TokenReference`/`PropBinding`/`Conditional`, which is false for these properties. The existing `textAlignHorizontal: Style` typing is a grandfathered inconsistency, not a precedent to extend.
+**Rejected because**: `maxLines` is a plain number with no closed value set and is token-bindable like other numeric properties. A named narrow type is reserved for non-`Style` shapes such as `PositionOffset`. Introducing `MaxLines` would make `maxLines` gratuitously inconsistent with `width`, `height`, and `opacity`, and would wrongly exclude `TokenReference` from its value set.
 
 ---
 
-### Option C: Single composite `TextTruncation` object `{ mode, maxLines }` *(Rejected)*
+### Option C: Both as generic `Style` *(Rejected)*
 
-Model both properties as one nested object.
+Type `textTruncation` as `Style` too (like the grandfathered `textAlignHorizontal`).
 
-**Rejected because**: Figma exposes two independent flat properties; `maxLines` is a valid standalone value on a node even when read alongside `textTruncation`. Composing them invents a shape no source or consumer uses, complicates the flat `Styles` map, and would force the transformer and any writer to pack/unpack a synthetic object. Flat keys mirror the source and keep per-key diffing (`DETAILS: LAYERED`) working unchanged.
+**Rejected because**: `textTruncation` has a closed, non-token-bindable value set, so the "structural enums vs. `Style`" rule requires a named type. `Style` would also wrongly imply it can carry `TokenReference`/`PropBinding`/`Conditional`. The `textAlignHorizontal: Style` typing is a grandfathered inconsistency, not a precedent to extend.
 
 ---
 
 ## Decision
 
-Add two flat, optional, `TEXT`-only structural keys to `Styles`, two named types, and matching schema definitions.
+Add two flat, optional, `TEXT`-only style keys to `Styles`, one named enum type, and matching schema definitions.
 
 ### Type changes (`types/`)
 
 | File | Change | Bump |
 |------|--------|------|
 | `types/Styles.ts` | Add field `textTruncation: TextTruncation \| null` to `Styles` | MINOR |
-| `types/Styles.ts` | Add field `maxLines: MaxLines` to `Styles` | MINOR |
+| `types/Styles.ts` | Add field `maxLines: Style` to `Styles` | MINOR |
 | `types/Styles.ts` | Add `export type TextTruncation = 'DISABLED' \| 'ENDING'` | MINOR |
-| `types/Styles.ts` | Add `export type MaxLines = number \| null` | MINOR |
+| `types/index.ts` | Re-export `TextTruncation` from the barrel | MINOR |
 | `types/Styles.ts` | Add `'textTruncation'` and `'maxLines'` to the `StyleKey` union | MINOR |
 
 **Example — new shape** (`types/Styles.ts`):
@@ -87,12 +88,11 @@ Styles:
   textAlignVertical: Style
   # Whether text truncates with a trailing ellipsis. Structural — not token-bindable. TEXT only.
   textTruncation: TextTruncation | null
-  # Max line count before ENDING truncation applies; null = no limit. Structural — not token-bindable. TEXT only.
-  maxLines: MaxLines
+  # Max line count before ENDING truncation applies; null = no limit. Plain number. TEXT only.
+  maxLines: Style
 
-# New named types
+# New named type (enum only — maxLines needs none)
 TextTruncation: "'DISABLED' | 'ENDING'"
-MaxLines: "number | null"
 ```
 
 ### Schema changes (`schema/`)
@@ -100,37 +100,33 @@ MaxLines: "number | null"
 | File | Change | Bump |
 |------|--------|------|
 | `schema/styles.schema.json` | Add property `textTruncation` → `#/definitions/TextTruncationStyleValue` under `Styles.properties` | MINOR |
-| `schema/styles.schema.json` | Add property `maxLines` → `#/definitions/MaxLinesStyleValue` under `Styles.properties` | MINOR |
-| `schema/styles.schema.json` | Add definitions `TextTruncationStyleValue` and `MaxLinesStyleValue` | MINOR |
+| `schema/styles.schema.json` | Add property `maxLines` → `#/definitions/NumberStyleValue` under `Styles.properties` | MINOR |
+| `schema/styles.schema.json` | Add definition `TextTruncationStyleValue` | MINOR |
 
 **Example — new shape** (`schema/styles.schema.json`):
 ```yaml
 # Under #/definitions/Styles/properties (additionalProperties stays false)
 textTruncation:
   $ref: "#/definitions/TextTruncationStyleValue"
-  description: "Whether text truncates with a trailing ellipsis. Structural property — not token-bindable."
+  description: "Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable."
 maxLines:
-  $ref: "#/definitions/MaxLinesStyleValue"
+  $ref: "#/definitions/NumberStyleValue"   # reuses the shared number value (number | TokenReference | null)
   description: "Maximum number of lines before ENDING truncation applies; null or absent means no limit."
 
-# New definitions (mirror LayoutModeStyleValue / PositionOffset shape)
+# New definition (mirror LayoutModeStyleValue)
 TextTruncationStyleValue:
   description: "Text truncation value. Structural property — not token-bindable."
   oneOf:
     - { type: string, enum: ["DISABLED", "ENDING"] }
     - { type: "null" }
-MaxLinesStyleValue:
-  description: "Maximum line count before truncation, or null for no limit. Not token-bindable."
-  oneOf:
-    - { type: number }
-    - { type: "null" }
 ```
 
 ### Notes
 
+- **`maxLines` reuses `NumberStyleValue`** — the same definition backing `width`, `height`, `opacity`, and `cornerSmoothing` (`number | TokenReference | null`). No new type or schema definition is introduced for it.
 - **Both keys optional** — `Styles` is a `Partial`; the keys are present only for `TEXT` elements. `additionalProperties: false` on the `Styles` schema definition means the new properties MUST be declared there for valid text output to pass validation.
-- **`| null` on `textTruncation`** — mirrors the sibling structural enums (`LayoutMode`, `Position`, `MainAxisAlignment`), all of which are `TypeName | null`, and tolerates a defensive null read for non-text or unset nodes.
-- **Naming — `maxLines`** (Constitution VI, rule 2): a single code platform, Android/Jetpack Compose, names this property exactly `maxLines`, and it coincides with Figma's name — so the code-platform choice imposes zero transformer translation. (SwiftUI `lineLimit`, React Native `numberOfLines` diverge; no 2+ code-platform consensus, so rule 1 does not apply.)
+- **`| null` on `textTruncation`** — mirrors the sibling structural enums (`LayoutMode`, `Position`, `MainAxisAlignment`), all typed `TypeName | null`.
+- **Naming — `maxLines`** (Constitution VI, rule 2): a single code platform, Android/Jetpack Compose, names this property exactly `maxLines`, coinciding with Figma's name — zero transformer translation. (SwiftUI `lineLimit`, React Native `numberOfLines` diverge; no 2+ code-platform consensus, so rule 1 does not apply.)
 - **Naming — `textTruncation` and values `DISABLED`/`ENDING`** (Constitution VI, rule 3): no code-platform consensus exists for the truncation-mode concept (SwiftUI `truncationMode`, CSS `text-overflow`, Android `TextOverflow`, React Native `ellipsizeMode` all differ). Deferring to Figma's `textTruncation` name and its `'DISABLED' | 'ENDING'` values avoids a lossy mode-mapping table and preserves reverse-direction round-trip fidelity. Values are already `SCREAMING_CASE`, satisfying the enum-casing rule.
 
 ---
@@ -140,7 +136,7 @@ MaxLinesStyleValue:
 - **Symmetric**: Yes.
 - **Parity check**:
   - `Styles.textTruncation` (`TextTruncation | null`) ↔ `Styles.properties.textTruncation` → `TextTruncationStyleValue` (`enum ["DISABLED","ENDING"]` ∪ `null`).
-  - `Styles.maxLines` (`MaxLines` = `number | null`) ↔ `Styles.properties.maxLines` → `MaxLinesStyleValue` (`number` ∪ `null`).
+  - `Styles.maxLines` (`Style`) ↔ `Styles.properties.maxLines` → `NumberStyleValue` (`number` ∪ `TokenReference` ∪ `null`).
   - `StyleKey` gains `'textTruncation'` and `'maxLines'`, matching the two new `Styles` properties.
 
 ---
@@ -159,7 +155,7 @@ MaxLinesStyleValue:
 
 **Version bump**: `0.28.0 → 0.28.0` (`MINOR`; lands within the in-progress, unreleased `0.28.0`)
 
-**Justification**: All changes are additive — two new optional fields on `Styles`, two new exported types, two additive `StyleKey` members, and additive schema definitions. No existing type, field, or schema property is removed, renamed, or restructured. Additive changes are `MINOR` per Constitution III and the Versioning policy. Because `0.28.0` is unreleased, the additions ride within that MINOR release rather than requiring a new version line.
+**Justification**: All changes are additive — two new optional fields on `Styles`, one new exported type, two additive `StyleKey` members, and one additive schema definition (plus a reuse of the existing `NumberStyleValue`). No existing type, field, or schema property is removed, renamed, or restructured. Additive changes are `MINOR` per Constitution III and the Versioning policy. Because `0.28.0` is unreleased, the additions ride within that MINOR release.
 
 ---
 
@@ -167,6 +163,7 @@ MaxLinesStyleValue:
 
 - Spec output faithfully represents text truncation configuration; line-clamped and single-line-truncating text no longer lose that information.
 - Reverse-direction tooling (`figma-from-specs`) gains named keys to write `textTruncation` and `maxLines` back to a Figma `TextNode`.
+- `maxLines` behaves like every other numeric style key — it can carry a plain number, a `TokenReference`, or `null`, and needs no special handling in consumers.
 - Consumers validating against `schema/styles.schema.json` must adopt schema `0.28.0`; text nodes carrying the new keys would fail validation against `0.27.0` (`additionalProperties: false`).
-- `TextTruncation` and `MaxLines` become part of the public type surface and are subject to the stability rules of Constitution III going forward.
+- `TextTruncation` becomes part of the public type surface and is subject to the stability rules of Constitution III going forward.
 - The grandfathered `textAlignHorizontal: Style` / `textAlignVertical: Style` typing remains untouched; this ADR does not retrofit those to named types.

--- a/adr/062-text-truncation.md
+++ b/adr/062-text-truncation.md
@@ -1,4 +1,4 @@
-# ADR: Text truncation style keys (`textTruncation`, `maxLines`)
+# ADR: Text overflow style keys (`textOverflow`, `maxLines`)
 
 **Branch**: `062-text-truncation`
 **Created**: 2026-07-09
@@ -10,58 +10,81 @@
 
 ## Context
 
-A text node in Figma can be configured to truncate its content with an ellipsis when the content exceeds the node's bounds. Two `TextNode` properties govern this behaviour:
+A text node in Figma can be configured to truncate its content with an ellipsis when the content exceeds the node's bounds. Two Figma properties govern this — `textTruncation` (`'DISABLED' | 'ENDING'`) and `maxLines` (`number | null`, only meaningful when truncation is on). Neither is currently represented in the schema: `Styles` in `types/Styles.ts` and the `Styles` definition in `schema/styles.schema.json` have no key for either, and `StyleKey` does not enumerate them. Truncation configuration is therefore silently dropped from spec output — a fidelity gap for line-clamped labels, single-line truncating text, and any component whose text-overflow behaviour is part of its design contract.
 
-- [`textTruncation`](https://developers.figma.com/docs/plugins/api/properties/TextNode-texttruncation/) — `'DISABLED' | 'ENDING'`. Whether truncation with a trailing ellipsis is applied. A closed enum.
-- [`maxLines`](https://developers.figma.com/docs/plugins/api/properties/TextNode-maxlines/) — `number | null`. The maximum number of lines a text node may reach before it truncates. Only meaningful when `textTruncation` is `'ENDING'`; `null` means no line limit. An ordinary number.
+Both properties belong to the `TEXT` element type only. They are available in **both** runtimes: the Plugin API exposes them as top-level `TextNode` properties, and the REST API nests them under the node's `style` object (`TypeStyle.textTruncation`, `TypeStyle.maxLines`).
 
-Neither property is currently represented in the schema. `Styles` in `types/Styles.ts` and the `Styles` definition in `schema/styles.schema.json` have no key for either, and `StyleKey` does not enumerate them. As a result, truncation configuration is silently dropped from spec output — a fidelity gap for line-clamped labels, single-line truncating text, and any component whose text overflow behaviour is part of its design contract.
+### Naming — how each platform models this
 
-Both properties belong to the `TEXT` element type only. `textTruncation` is a structural enum that is not token-bindable. `maxLines` is a plain number — the same shape as `width`, `height`, `opacity`, and `cornerSmoothing`, all of which are already typed as `Style`.
+The schema names identifiers by code-platform vocabulary, not Figma's (Constitution VI). Comparing the three target platforms:
+
+**Truncation / overflow handling**
+
+| Platform | Property | Values |
+|----------|----------|--------|
+| Web (CSS) | `text-overflow` | `clip` \| `ellipsis` (+ `<string>`) |
+| Android (Compose) | `overflow: TextOverflow` | `Clip` \| `Ellipsis` \| `Visible` \| `StartEllipsis` \| `MiddleEllipsis` |
+| iOS (SwiftUI) | `truncationMode` | `.head` \| `.middle` \| `.tail` |
+| Figma | `textTruncation` | `DISABLED` \| `ENDING` |
+
+**Maximum line count**
+
+| Platform | Property |
+|----------|----------|
+| Android (Compose) | `maxLines: Int` |
+| iOS (SwiftUI) | `lineLimit(Int?)` |
+| Web (CSS) | `line-clamp: <n>` |
+| Figma | `maxLines` |
+
+Reading these against the constitution's naming rules:
+
+- **Property name → `textOverflow`.** The term "overflow" is shared by **two** code platforms (CSS `text-overflow`, Compose `TextOverflow`); "truncation" by only one (SwiftUI `truncationMode`) plus Figma. Constitution VI rule 1 (favor a term 2+ code platforms share) selects **overflow**. The `text` prefix disambiguates from container overflow (already modelled by `clipContent`).
+- **Values → `'CLIP' | 'ELLIPSIS'`.** CSS (`clip`/`ellipsis`) and Compose (`Clip`/`Ellipsis`) agree on these value names too — again 2 code platforms (rule 1). SCREAMING_CASE per the Styles enum-casing rule. The set extends cleanly to Compose's `VISIBLE` / `START_ELLIPSIS` / `MIDDLE_ELLIPSIS` if ever needed. No platform models this as a boolean — all use an enum — so a boolean is rejected as a dead-end that cannot express clip-vs-visible or truncation position.
+- **`maxLines` kept.** Android/Compose uses exactly `maxLines`; it is unabbreviated and unambiguous under a `TEXT` element. No platform uses `maxTextLines`; SwiftUI's `lineLimit` is the only alternative and is less transparent. `maxLines` is a plain number, so it is typed as `Style` like every other numeric key (`width`, `opacity`, `cornerSmoothing`) — not a named type.
+
+Figma's `textTruncation` values (`DISABLED`/`ENDING`) are remapped to the platform vocabulary by the transformer (`DISABLED → CLIP`, `ENDING → ELLIPSIS`), the same way `mainAxisAlignment` remaps Figma's `MIN`/`MAX`.
 
 ---
 
 ## Decision Drivers
 
-- **Additive-only** — introduce new optional keys without altering any existing type or schema, so downstream consumers incur no breaking change (MINOR bump).
+- **Additive-only** — new optional keys, no change to any existing type or schema (MINOR bump).
 - **Type ↔ schema parity** — every new `types/` field has a matching `schema/` definition; no drift (Constitution I).
-- **Structural-enum typing rule** — a closed, non-token-bindable value set MUST be a named type, not `Style` (Constitution "Typing — structural enums vs. `Style`"). This governs `textTruncation`.
-- **Consistency for plain numbers** — a numeric property with no closed value set is typed as `Style`, exactly like every other numeric key on `Styles` (`width`, `opacity`, `cornerSmoothing`). This governs `maxLines`. The named-narrow-type rule targets shapes like `PositionOffset` (`number | string | null`), not a plain number.
-- **Naming governance** — field names and enum values chosen per Constitution VI (code-platforms-first), documented below.
+- **Structural-enum typing rule** — a closed, non-token-bindable value set MUST be a named type, not `Style` (Constitution "Typing — structural enums vs. `Style`"). Governs `textOverflow`.
+- **Consistency for plain numbers** — a numeric property with no closed value set is typed as `Style`, like every other numeric key. Governs `maxLines`.
+- **Code-platforms-first naming** — names and values chosen per Constitution VI, as derived above.
 - **No runtime logic** — this package gains only type declarations and schema definitions (Constitution II).
 
 ---
 
 ## Options Considered
 
-### Option A: `textTruncation` as a named enum; `maxLines` as `Style` *(Selected)*
+### Option A: `textOverflow: 'CLIP' | 'ELLIPSIS'` (named enum); `maxLines: Style` *(Selected)*
 
-- `textTruncation`: `TextTruncation | null` where `type TextTruncation = 'DISABLED' | 'ENDING'`, with a `TextTruncationStyleValue` schema definition — mirrors `LayoutMode`/`Position`.
-- `maxLines`: `Style`, with the shared `NumberStyleValue` schema definition — mirrors `width`, `opacity`, `cornerSmoothing`.
+- `textOverflow`: `TextOverflow | null` where `type TextOverflow = 'CLIP' | 'ELLIPSIS'`, with a `TextOverflowStyleValue` schema definition — mirrors `LayoutMode`/`Position`, and mirrors CSS/Compose for both the name and the values.
+- `maxLines`: `Style`, reusing the shared `NumberStyleValue` schema definition — mirrors `width`, `opacity`, `cornerSmoothing`.
 
 **Pros**:
-- Each property is typed by its actual nature: a closed enum gets a named type; a plain number gets `Style`.
-- `maxLines` stays consistent with every other numeric key and needs no bespoke type or schema definition.
-- `Style` correctly permits a `TokenReference` for `maxLines`, matching Figma's variable-binding capability for numeric properties and the transformer's existing treatment (a token-bindable pure number).
+- Name and values both satisfy the 2-code-platform rule (CSS + Compose), fully unbiasing from Figma.
+- Each property is typed by its actual nature: closed enum → named type; plain number → `Style`.
+- `Style` correctly permits a `TokenReference` for `maxLines`, matching Figma's variable-binding capability for numeric properties.
 
 **Cons / Trade-offs**:
-- Two properties in the same feature are typed differently. This reflects a real difference in their value domains, not an inconsistency.
+- The transformer must remap Figma's `DISABLED`/`ENDING` to `CLIP`/`ELLIPSIS` — a small, well-precedented value map (like `mainAxisAlignment`).
 
 ---
 
-### Option B: Both as named structural types (`TextTruncation`, `MaxLines`) *(Rejected)*
+### Option B: Keep Figma's `textTruncation` with `'DISABLED' | 'ENDING'` *(Rejected)*
 
-Give `maxLines` a dedicated `MaxLines = number | null` type and a `MaxLinesStyleValue` schema definition.
-
-**Rejected because**: `maxLines` is a plain number with no closed value set and is token-bindable like other numeric properties. A named narrow type is reserved for non-`Style` shapes such as `PositionOffset`. Introducing `MaxLines` would make `maxLines` gratuitously inconsistent with `width`, `height`, and `opacity`, and would wrongly exclude `TokenReference` from its value set.
+**Rejected because**: both the name ("truncation") and the values (`DISABLED`/`ENDING`) are Figma-only; no code platform uses them. Violates Constitution VI, which prefers code-platform vocabulary and treats Figma as the data source, not the naming authority.
 
 ---
 
-### Option C: Both as generic `Style` *(Rejected)*
+### Option C: Model overflow as a boolean *(Rejected)*
 
-Type `textTruncation` as `Style` too (like the grandfathered `textAlignHorizontal`).
+A boolean such as `truncate: true | false`.
 
-**Rejected because**: `textTruncation` has a closed, non-token-bindable value set, so the "structural enums vs. `Style`" rule requires a named type. `Style` would also wrongly imply it can carry `TokenReference`/`PropBinding`/`Conditional`. The `textAlignHorizontal: Style` typing is a grandfathered inconsistency, not a precedent to extend.
+**Rejected because**: no target platform models this as a boolean — all use an enum. A boolean cannot express clip-vs-visible or truncation position (start/middle/end), is not extensible, and reads worse (`textOverflow: ELLIPSIS` is clearer than `truncate: true`).
 
 ---
 
@@ -73,61 +96,56 @@ Add two flat, optional, `TEXT`-only style keys to `Styles`, one named enum type,
 
 | File | Change | Bump |
 |------|--------|------|
-| `types/Styles.ts` | Add field `textTruncation: TextTruncation \| null` to `Styles` | MINOR |
+| `types/Styles.ts` | Add field `textOverflow: TextOverflow \| null` to `Styles` | MINOR |
 | `types/Styles.ts` | Add field `maxLines: Style` to `Styles` | MINOR |
-| `types/Styles.ts` | Add `export type TextTruncation = 'DISABLED' \| 'ENDING'` | MINOR |
-| `types/index.ts` | Re-export `TextTruncation` from the barrel | MINOR |
-| `types/Styles.ts` | Add `'textTruncation'` and `'maxLines'` to the `StyleKey` union | MINOR |
+| `types/Styles.ts` | Add `export type TextOverflow = 'CLIP' \| 'ELLIPSIS'` | MINOR |
+| `types/index.ts` | Re-export `TextOverflow` from the barrel | MINOR |
+| `types/Styles.ts` | Add `'textOverflow'` and `'maxLines'` to the `StyleKey` union | MINOR |
 
 **Example — new shape** (`types/Styles.ts`):
 ```yaml
 # After — within the Styles Partial
 Styles:
-  # …existing text keys…
   textAlignHorizontal: Style
   textAlignVertical: Style
-  # Whether text truncates with a trailing ellipsis. Structural — not token-bindable. TEXT only.
-  textTruncation: TextTruncation | null
-  # Max line count before ENDING truncation applies; null = no limit. Plain number. TEXT only.
+  # How overflowing text is handled. Structural — not token-bindable. TEXT only.
+  textOverflow: TextOverflow | null
+  # Max line count before ELLIPSIS overflow applies; null = no limit. Plain number. TEXT only.
   maxLines: Style
 
 # New named type (enum only — maxLines needs none)
-TextTruncation: "'DISABLED' | 'ENDING'"
+TextOverflow: "'CLIP' | 'ELLIPSIS'"
 ```
 
 ### Schema changes (`schema/`)
 
 | File | Change | Bump |
 |------|--------|------|
-| `schema/styles.schema.json` | Add property `textTruncation` → `#/definitions/TextTruncationStyleValue` under `Styles.properties` | MINOR |
+| `schema/styles.schema.json` | Add property `textOverflow` → `#/definitions/TextOverflowStyleValue` under `Styles.properties` | MINOR |
 | `schema/styles.schema.json` | Add property `maxLines` → `#/definitions/NumberStyleValue` under `Styles.properties` | MINOR |
-| `schema/styles.schema.json` | Add definition `TextTruncationStyleValue` | MINOR |
+| `schema/styles.schema.json` | Add definition `TextOverflowStyleValue` | MINOR |
 
 **Example — new shape** (`schema/styles.schema.json`):
 ```yaml
-# Under #/definitions/Styles/properties (additionalProperties stays false)
-textTruncation:
-  $ref: "#/definitions/TextTruncationStyleValue"
-  description: "Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable."
+textOverflow:
+  $ref: "#/definitions/TextOverflowStyleValue"
+  description: "How overflowing text is handled — CLIP (cut off) or ELLIPSIS (trailing ellipsis). Structural property — not token-bindable."
 maxLines:
-  $ref: "#/definitions/NumberStyleValue"   # reuses the shared number value (number | TokenReference | null)
-  description: "Maximum number of lines before ENDING truncation applies; null or absent means no limit."
+  $ref: "#/definitions/NumberStyleValue"   # reuses number | TokenReference | null
+  description: "Maximum number of lines before ELLIPSIS overflow applies; null or absent means no limit."
 
-# New definition (mirror LayoutModeStyleValue)
-TextTruncationStyleValue:
-  description: "Text truncation value. Structural property — not token-bindable."
+TextOverflowStyleValue:
+  description: "Text overflow handling value. Structural property — not token-bindable."
   oneOf:
-    - { type: string, enum: ["DISABLED", "ENDING"] }
+    - { type: string, enum: ["CLIP", "ELLIPSIS"] }
     - { type: "null" }
 ```
 
 ### Notes
 
-- **`maxLines` reuses `NumberStyleValue`** — the same definition backing `width`, `height`, `opacity`, and `cornerSmoothing` (`number | TokenReference | null`). No new type or schema definition is introduced for it.
-- **Both keys optional** — `Styles` is a `Partial`; the keys are present only for `TEXT` elements. `additionalProperties: false` on the `Styles` schema definition means the new properties MUST be declared there for valid text output to pass validation.
-- **`| null` on `textTruncation`** — mirrors the sibling structural enums (`LayoutMode`, `Position`, `MainAxisAlignment`), all typed `TypeName | null`.
-- **Naming — `maxLines`** (Constitution VI, rule 2): a single code platform, Android/Jetpack Compose, names this property exactly `maxLines`, coinciding with Figma's name — zero transformer translation. (SwiftUI `lineLimit`, React Native `numberOfLines` diverge; no 2+ code-platform consensus, so rule 1 does not apply.)
-- **Naming — `textTruncation` and values `DISABLED`/`ENDING`** (Constitution VI, rule 3): no code-platform consensus exists for the truncation-mode concept (SwiftUI `truncationMode`, CSS `text-overflow`, Android `TextOverflow`, React Native `ellipsizeMode` all differ). Deferring to Figma's `textTruncation` name and its `'DISABLED' | 'ENDING'` values avoids a lossy mode-mapping table and preserves reverse-direction round-trip fidelity. Values are already `SCREAMING_CASE`, satisfying the enum-casing rule.
+- **`maxLines` reuses `NumberStyleValue`** — the shared definition (`number | TokenReference | null`) backing `width`, `opacity`, `cornerSmoothing`. No new type or schema definition for it.
+- **Both keys optional** — `Styles` is a `Partial`; present only for `TEXT` elements. `additionalProperties: false` on the `Styles` definition means the new properties MUST be declared there for valid text output.
+- **`| null` on `textOverflow`** — mirrors the sibling structural enums (`LayoutMode`, `Position`, `MainAxisAlignment`), all typed `TypeName | null`.
 
 ---
 
@@ -135,9 +153,9 @@ TextTruncationStyleValue:
 
 - **Symmetric**: Yes.
 - **Parity check**:
-  - `Styles.textTruncation` (`TextTruncation | null`) ↔ `Styles.properties.textTruncation` → `TextTruncationStyleValue` (`enum ["DISABLED","ENDING"]` ∪ `null`).
+  - `Styles.textOverflow` (`TextOverflow | null`) ↔ `Styles.properties.textOverflow` → `TextOverflowStyleValue` (`enum ["CLIP","ELLIPSIS"]` ∪ `null`).
   - `Styles.maxLines` (`Style`) ↔ `Styles.properties.maxLines` → `NumberStyleValue` (`number` ∪ `TokenReference` ∪ `null`).
-  - `StyleKey` gains `'textTruncation'` and `'maxLines'`, matching the two new `Styles` properties.
+  - `StyleKey` gains `'textOverflow'` and `'maxLines'`, matching the two new `Styles` properties.
 
 ---
 
@@ -145,7 +163,7 @@ TextTruncationStyleValue:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | Emits the two new keys for `TEXT` elements | None — generator already reads `textTruncation` (pureString) and `maxLines` (pureNumber) and emits them; recompiles against the new types |
+| `specs-from-figma` | Emits the two new keys for `TEXT` elements in both runtimes | None — generator already implemented: a `textOverflow` handler remaps Figma `textTruncation` → `CLIP`/`ELLIPSIS`; `maxLines` reads as a pure number. REST adapter surfaces both from `TypeStyle` via node getters. Recompiles against the new types |
 | `specs-cli` | New keys may appear in validated/serialized output | Recompile against the new schema version; no code change |
 | `specs-plugin-2` | New keys may appear in plugin-side spec output | Recompile against the new types; no code change |
 
@@ -155,15 +173,16 @@ TextTruncationStyleValue:
 
 **Version bump**: `0.28.0 → 0.28.0` (`MINOR`; lands within the in-progress, unreleased `0.28.0`)
 
-**Justification**: All changes are additive — two new optional fields on `Styles`, one new exported type, two additive `StyleKey` members, and one additive schema definition (plus a reuse of the existing `NumberStyleValue`). No existing type, field, or schema property is removed, renamed, or restructured. Additive changes are `MINOR` per Constitution III and the Versioning policy. Because `0.28.0` is unreleased, the additions ride within that MINOR release.
+**Justification**: All changes are additive — two new optional fields on `Styles`, one new exported type, two additive `StyleKey` members, and one additive schema definition (plus reuse of `NumberStyleValue`). No existing type, field, or schema property is removed, renamed, or restructured. Additive changes are `MINOR` per Constitution III and the Versioning policy. Because `0.28.0` is unreleased, the additions ride within that MINOR release.
 
 ---
 
 ## Consequences
 
-- Spec output faithfully represents text truncation configuration; line-clamped and single-line-truncating text no longer lose that information.
-- Reverse-direction tooling (`figma-from-specs`) gains named keys to write `textTruncation` and `maxLines` back to a Figma `TextNode`.
-- `maxLines` behaves like every other numeric style key — it can carry a plain number, a `TokenReference`, or `null`, and needs no special handling in consumers.
+- Spec output faithfully represents text-overflow configuration in both Plugin and REST runtimes; line-clamped and truncating text no longer lose that information.
+- The schema uses code-platform vocabulary (`textOverflow`, `CLIP`/`ELLIPSIS`) rather than Figma's (`textTruncation`, `DISABLED`/`ENDING`); the transformer owns the one-way value remap.
+- `maxLines` behaves like every other numeric style key — a plain number, a `TokenReference`, or `null` — and needs no special handling in consumers.
+- Reverse-direction tooling (`figma-from-specs`) gains named keys to write both back to a Figma `TextNode`, inverting the remap.
 - Consumers validating against `schema/styles.schema.json` must adopt schema `0.28.0`; text nodes carrying the new keys would fail validation against `0.27.0` (`additionalProperties: false`).
-- `TextTruncation` becomes part of the public type surface and is subject to the stability rules of Constitution III going forward.
-- The grandfathered `textAlignHorizontal: Style` / `textAlignVertical: Style` typing remains untouched; this ADR does not retrofit those to named types.
+- `TextOverflow` becomes part of the public type surface, subject to the stability rules of Constitution III.
+- The grandfathered `textAlignHorizontal: Style` / `textAlignVertical: Style` typing remains untouched.

--- a/adr/062-text-truncation.md
+++ b/adr/062-text-truncation.md
@@ -1,0 +1,172 @@
+# ADR: Text truncation style keys (`textTruncation`, `maxLines`)
+
+**Branch**: `062-text-truncation`
+**Created**: 2026-07-09
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+A text node in Figma can be configured to truncate its content with an ellipsis when the content exceeds the node's bounds. Two `TextNode` properties govern this behaviour:
+
+- [`textTruncation`](https://developers.figma.com/docs/plugins/api/properties/TextNode-texttruncation/) — `'DISABLED' | 'ENDING'`. Whether truncation with a trailing ellipsis is applied.
+- [`maxLines`](https://developers.figma.com/docs/plugins/api/properties/TextNode-maxlines/) — `number | null`. The maximum number of lines a text node may reach before it truncates. Only meaningful when `textTruncation` is `'ENDING'`; `null` means no line limit.
+
+Neither property is currently represented in the schema. `Styles` in `types/Styles.ts` and the `Styles` definition in `schema/styles.schema.json` have no key for either, and `StyleKey` does not enumerate them. As a result, truncation configuration is silently dropped from spec output — a fidelity gap for line-clamped labels, single-line truncating text, and any component whose text overflow behaviour is part of its design contract. Reverse-direction tooling likewise has no key to write these values back to a Figma node.
+
+Both properties belong to the `TEXT` element type only. Both are structural: they describe a fixed configuration on the node and are **not** token-bindable, prop-bindable, or conditional in Figma.
+
+---
+
+## Decision Drivers
+
+- **Additive-only** — introduce new optional keys without altering any existing type or schema, so downstream consumers incur no breaking change (MINOR bump).
+- **Type ↔ schema parity** — every new `types/` field has a matching `schema/` definition; no drift (Constitution I).
+- **Structural-enum typing rule** — a closed, non-token-bindable value set MUST be a named type, not `Style` (Constitution "Typing — structural enums vs. `Style`"). This is why `textTruncation` mirrors `LayoutMode`/`Position` rather than reusing `Style`, and `maxLines` mirrors `PositionOffset`.
+- **Naming governance** — field names and enum values chosen per Constitution VI (code-platforms-first), documented below.
+- **No runtime logic** — this package gains only type declarations and schema definitions (Constitution II).
+- **Round-trip fidelity** — the enum member names must survive a Figma → spec → Figma round trip without a translation table the writer would have to invert.
+
+---
+
+## Options Considered
+
+### Option A: Two named structural types — `TextTruncation` and `MaxLines` *(Selected)*
+
+Add `textTruncation` typed as `TextTruncation | null` (`type TextTruncation = 'DISABLED' | 'ENDING'`) and `maxLines` typed as `MaxLines` (`type MaxLines = number | null`), each with a matching `*StyleValue` schema definition. Mirrors the established structural-enum siblings (`LayoutMode`, `Position`, `PositionOffset`).
+
+**Pros**:
+- Satisfies the structural-enum typing rule directly — closed value sets get named types.
+- Symmetric, self-documenting type and schema definitions consistent with existing structural keys.
+- `TextTruncation` is reusable if a future reverse-writer or validator needs the enum by name.
+
+**Cons / Trade-offs**:
+- Adds two named types to the public surface rather than reusing generic value types.
+
+---
+
+### Option B: Type both as generic `Style` *(Rejected)*
+
+Type `textTruncation` and `maxLines` as `Style` (like the grandfathered `textAlignHorizontal`).
+
+**Rejected because**: Violates the "structural enums vs. `Style`" rule — both values are closed and non-token-bindable, so they must be named types. `Style` would also imply they can carry `TokenReference`/`PropBinding`/`Conditional`, which is false for these properties. The existing `textAlignHorizontal: Style` typing is a grandfathered inconsistency, not a precedent to extend.
+
+---
+
+### Option C: Single composite `TextTruncation` object `{ mode, maxLines }` *(Rejected)*
+
+Model both properties as one nested object.
+
+**Rejected because**: Figma exposes two independent flat properties; `maxLines` is a valid standalone value on a node even when read alongside `textTruncation`. Composing them invents a shape no source or consumer uses, complicates the flat `Styles` map, and would force the transformer and any writer to pack/unpack a synthetic object. Flat keys mirror the source and keep per-key diffing (`DETAILS: LAYERED`) working unchanged.
+
+---
+
+## Decision
+
+Add two flat, optional, `TEXT`-only structural keys to `Styles`, two named types, and matching schema definitions.
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `types/Styles.ts` | Add field `textTruncation: TextTruncation \| null` to `Styles` | MINOR |
+| `types/Styles.ts` | Add field `maxLines: MaxLines` to `Styles` | MINOR |
+| `types/Styles.ts` | Add `export type TextTruncation = 'DISABLED' \| 'ENDING'` | MINOR |
+| `types/Styles.ts` | Add `export type MaxLines = number \| null` | MINOR |
+| `types/Styles.ts` | Add `'textTruncation'` and `'maxLines'` to the `StyleKey` union | MINOR |
+
+**Example — new shape** (`types/Styles.ts`):
+```yaml
+# After — within the Styles Partial
+Styles:
+  # …existing text keys…
+  textAlignHorizontal: Style
+  textAlignVertical: Style
+  # Whether text truncates with a trailing ellipsis. Structural — not token-bindable. TEXT only.
+  textTruncation: TextTruncation | null
+  # Max line count before ENDING truncation applies; null = no limit. Structural — not token-bindable. TEXT only.
+  maxLines: MaxLines
+
+# New named types
+TextTruncation: "'DISABLED' | 'ENDING'"
+MaxLines: "number | null"
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `schema/styles.schema.json` | Add property `textTruncation` → `#/definitions/TextTruncationStyleValue` under `Styles.properties` | MINOR |
+| `schema/styles.schema.json` | Add property `maxLines` → `#/definitions/MaxLinesStyleValue` under `Styles.properties` | MINOR |
+| `schema/styles.schema.json` | Add definitions `TextTruncationStyleValue` and `MaxLinesStyleValue` | MINOR |
+
+**Example — new shape** (`schema/styles.schema.json`):
+```yaml
+# Under #/definitions/Styles/properties (additionalProperties stays false)
+textTruncation:
+  $ref: "#/definitions/TextTruncationStyleValue"
+  description: "Whether text truncates with a trailing ellipsis. Structural property — not token-bindable."
+maxLines:
+  $ref: "#/definitions/MaxLinesStyleValue"
+  description: "Maximum number of lines before ENDING truncation applies; null or absent means no limit."
+
+# New definitions (mirror LayoutModeStyleValue / PositionOffset shape)
+TextTruncationStyleValue:
+  description: "Text truncation value. Structural property — not token-bindable."
+  oneOf:
+    - { type: string, enum: ["DISABLED", "ENDING"] }
+    - { type: "null" }
+MaxLinesStyleValue:
+  description: "Maximum line count before truncation, or null for no limit. Not token-bindable."
+  oneOf:
+    - { type: number }
+    - { type: "null" }
+```
+
+### Notes
+
+- **Both keys optional** — `Styles` is a `Partial`; the keys are present only for `TEXT` elements. `additionalProperties: false` on the `Styles` schema definition means the new properties MUST be declared there for valid text output to pass validation.
+- **`| null` on `textTruncation`** — mirrors the sibling structural enums (`LayoutMode`, `Position`, `MainAxisAlignment`), all of which are `TypeName | null`, and tolerates a defensive null read for non-text or unset nodes.
+- **Naming — `maxLines`** (Constitution VI, rule 2): a single code platform, Android/Jetpack Compose, names this property exactly `maxLines`, and it coincides with Figma's name — so the code-platform choice imposes zero transformer translation. (SwiftUI `lineLimit`, React Native `numberOfLines` diverge; no 2+ code-platform consensus, so rule 1 does not apply.)
+- **Naming — `textTruncation` and values `DISABLED`/`ENDING`** (Constitution VI, rule 3): no code-platform consensus exists for the truncation-mode concept (SwiftUI `truncationMode`, CSS `text-overflow`, Android `TextOverflow`, React Native `ellipsizeMode` all differ). Deferring to Figma's `textTruncation` name and its `'DISABLED' | 'ENDING'` values avoids a lossy mode-mapping table and preserves reverse-direction round-trip fidelity. Values are already `SCREAMING_CASE`, satisfying the enum-casing rule.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes.
+- **Parity check**:
+  - `Styles.textTruncation` (`TextTruncation | null`) ↔ `Styles.properties.textTruncation` → `TextTruncationStyleValue` (`enum ["DISABLED","ENDING"]` ∪ `null`).
+  - `Styles.maxLines` (`MaxLines` = `number | null`) ↔ `Styles.properties.maxLines` → `MaxLinesStyleValue` (`number` ∪ `null`).
+  - `StyleKey` gains `'textTruncation'` and `'maxLines'`, matching the two new `Styles` properties.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Emits the two new keys for `TEXT` elements | None — generator already reads `textTruncation` (pureString) and `maxLines` (pureNumber) and emits them; recompiles against the new types |
+| `specs-cli` | New keys may appear in validated/serialized output | Recompile against the new schema version; no code change |
+| `specs-plugin-2` | New keys may appear in plugin-side spec output | Recompile against the new types; no code change |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.28.0 → 0.28.0` (`MINOR`; lands within the in-progress, unreleased `0.28.0`)
+
+**Justification**: All changes are additive — two new optional fields on `Styles`, two new exported types, two additive `StyleKey` members, and additive schema definitions. No existing type, field, or schema property is removed, renamed, or restructured. Additive changes are `MINOR` per Constitution III and the Versioning policy. Because `0.28.0` is unreleased, the additions ride within that MINOR release rather than requiring a new version line.
+
+---
+
+## Consequences
+
+- Spec output faithfully represents text truncation configuration; line-clamped and single-line-truncating text no longer lose that information.
+- Reverse-direction tooling (`figma-from-specs`) gains named keys to write `textTruncation` and `maxLines` back to a Figma `TextNode`.
+- Consumers validating against `schema/styles.schema.json` must adopt schema `0.28.0`; text nodes carrying the new keys would fail validation against `0.27.0` (`additionalProperties: false`).
+- `TextTruncation` and `MaxLines` become part of the public type surface and are subject to the stability rules of Constitution III going forward.
+- The grandfathered `textAlignHorizontal: Style` / `textAlignVertical: Style` typing remains untouched; this ADR does not retrofit those to named types.

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 062 | Text Truncation Style Keys — `textTruncation` and `maxLines` on `Styles` | |
+| 062 | Text Overflow & Max Lines — `textOverflow` and `maxLines` on `Styles` | |
 | 061 | Schema Entry Points for Concern-Split Output | |
 | 059 | Border Style and Dash Pattern — `borderStyle` and `borderDashPattern` on `Styles` | |
 | 058 | Wrapper Collapse Config Flag — `processing.wrapperCollapse` | |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 062 | Text Truncation Style Keys — `textTruncation` and `maxLines` on `Styles` | |
 | 061 | Schema Entry Points for Concern-Split Output | |
 | 059 | Border Style and Dash Pattern — `borderStyle` and `borderDashPattern` on `Styles` | |
 | 058 | Wrapper Collapse Config Flag — `processing.wrapperCollapse` | |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Styles.textTruncation` — typed as `TextTruncation` (`'DISABLED' | 'ENDING'`) or `null`; whether text truncates with a trailing ellipsis (TEXT only, not token-bindable)
+- `Styles.maxLines` — typed as `MaxLines` (`number | null`); maximum line count before `'ENDING'` truncation applies (TEXT only, not token-bindable)
+
 ### Changed
 
 ### Removed

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Styles.textTruncation` — typed as `TextTruncation` (`'DISABLED' | 'ENDING'`) or `null`; whether text truncates with a trailing ellipsis (TEXT only, not token-bindable)
-- `Styles.maxLines` — maximum line count before `'ENDING'` truncation applies; null for no limit (TEXT only)
+- `Styles.textOverflow` — typed as `TextOverflow` (`'CLIP' | 'ELLIPSIS'`) or `null`; how overflowing text is handled (TEXT only, not token-bindable). Named after CSS `text-overflow` / Compose `TextOverflow`
+- `Styles.maxLines` — maximum line count before `'ELLIPSIS'` text overflow applies; null for no limit (TEXT only)
 
 ### Changed
 

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Styles.textTruncation` — typed as `TextTruncation` (`'DISABLED' | 'ENDING'`) or `null`; whether text truncates with a trailing ellipsis (TEXT only, not token-bindable)
-- `Styles.maxLines` — typed as `MaxLines` (`number | null`); maximum line count before `'ENDING'` truncation applies (TEXT only, not token-bindable)
+- `Styles.maxLines` — maximum line count before `'ENDING'` truncation applies; null for no limit (TEXT only)
 
 ### Changed
 

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -41,8 +41,8 @@
         "typography": { "$ref": "#/definitions/TypographyStyleValue", "description": "Typography properties. TokenReference when the node references a named text style; Typography when defined inline." },
         "textAlignHorizontal": { "$ref": "#/definitions/StringStyleValue", "description": "Horizontal text alignment" },
         "textAlignVertical": { "$ref": "#/definitions/StringStyleValue", "description": "Vertical text alignment" },
-        "textTruncation": { "$ref": "#/definitions/TextTruncationStyleValue", "description": "Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable." },
-        "maxLines": { "$ref": "#/definitions/NumberStyleValue", "description": "Maximum number of lines before ENDING truncation applies; null or absent means no limit." },
+        "textOverflow": { "$ref": "#/definitions/TextOverflowStyleValue", "description": "How overflowing text is handled — CLIP (cut off) or ELLIPSIS (trailing ellipsis). Structural property — not token-bindable." },
+        "maxLines": { "$ref": "#/definitions/NumberStyleValue", "description": "Maximum number of lines before ELLIPSIS text overflow applies; null or absent means no limit." },
         "mainAxisAlignment": { "$ref": "#/definitions/MainAxisAlignmentStyleValue", "description": "Alignment along the main axis (depends on layoutMode). Structural property — not token-bindable." },
         "primaryAxisSizingMode": { "$ref": "#/definitions/StringStyleValue", "description": "Primary axis sizing mode" },
         "crossAxisAlignment": { "$ref": "#/definitions/CrossAxisAlignmentStyleValue", "description": "Alignment along the cross axis (perpendicular to layoutMode). Structural property — not token-bindable." },
@@ -383,10 +383,10 @@
         { "type": "null" }
       ]
     },
-    "TextTruncationStyleValue": {
-      "description": "Text truncation value. Structural property — not token-bindable.",
+    "TextOverflowStyleValue": {
+      "description": "Text overflow handling value. Structural property — not token-bindable.",
       "oneOf": [
-        { "type": "string", "enum": ["DISABLED", "ENDING"] },
+        { "type": "string", "enum": ["CLIP", "ELLIPSIS"] },
         { "type": "null" }
       ]
     },

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -42,7 +42,7 @@
         "textAlignHorizontal": { "$ref": "#/definitions/StringStyleValue", "description": "Horizontal text alignment" },
         "textAlignVertical": { "$ref": "#/definitions/StringStyleValue", "description": "Vertical text alignment" },
         "textTruncation": { "$ref": "#/definitions/TextTruncationStyleValue", "description": "Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable." },
-        "maxLines": { "$ref": "#/definitions/MaxLinesStyleValue", "description": "Maximum number of lines before ENDING truncation applies; null or absent means no limit. Structural property — not token-bindable." },
+        "maxLines": { "$ref": "#/definitions/NumberStyleValue", "description": "Maximum number of lines before ENDING truncation applies; null or absent means no limit." },
         "mainAxisAlignment": { "$ref": "#/definitions/MainAxisAlignmentStyleValue", "description": "Alignment along the main axis (depends on layoutMode). Structural property — not token-bindable." },
         "primaryAxisSizingMode": { "$ref": "#/definitions/StringStyleValue", "description": "Primary axis sizing mode" },
         "crossAxisAlignment": { "$ref": "#/definitions/CrossAxisAlignmentStyleValue", "description": "Alignment along the cross axis (perpendicular to layoutMode). Structural property — not token-bindable." },
@@ -387,13 +387,6 @@
       "description": "Text truncation value. Structural property — not token-bindable.",
       "oneOf": [
         { "type": "string", "enum": ["DISABLED", "ENDING"] },
-        { "type": "null" }
-      ]
-    },
-    "MaxLinesStyleValue": {
-      "description": "Maximum line count before truncation, or null for no limit. Not token-bindable.",
-      "oneOf": [
-        { "type": "number" },
         { "type": "null" }
       ]
     },

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -41,6 +41,8 @@
         "typography": { "$ref": "#/definitions/TypographyStyleValue", "description": "Typography properties. TokenReference when the node references a named text style; Typography when defined inline." },
         "textAlignHorizontal": { "$ref": "#/definitions/StringStyleValue", "description": "Horizontal text alignment" },
         "textAlignVertical": { "$ref": "#/definitions/StringStyleValue", "description": "Vertical text alignment" },
+        "textTruncation": { "$ref": "#/definitions/TextTruncationStyleValue", "description": "Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable." },
+        "maxLines": { "$ref": "#/definitions/MaxLinesStyleValue", "description": "Maximum number of lines before ENDING truncation applies; null or absent means no limit. Structural property — not token-bindable." },
         "mainAxisAlignment": { "$ref": "#/definitions/MainAxisAlignmentStyleValue", "description": "Alignment along the main axis (depends on layoutMode). Structural property — not token-bindable." },
         "primaryAxisSizingMode": { "$ref": "#/definitions/StringStyleValue", "description": "Primary axis sizing mode" },
         "crossAxisAlignment": { "$ref": "#/definitions/CrossAxisAlignmentStyleValue", "description": "Alignment along the cross axis (perpendicular to layoutMode). Structural property — not token-bindable." },
@@ -378,6 +380,20 @@
       "description": "Cross axis alignment value. Structural property — not token-bindable.",
       "oneOf": [
         { "type": "string", "enum": ["START", "END", "CENTER", "STRETCH", "BASELINE"] },
+        { "type": "null" }
+      ]
+    },
+    "TextTruncationStyleValue": {
+      "description": "Text truncation value. Structural property — not token-bindable.",
+      "oneOf": [
+        { "type": "string", "enum": ["DISABLED", "ENDING"] },
+        { "type": "null" }
+      ]
+    },
+    "MaxLinesStyleValue": {
+      "description": "Maximum line count before truncation, or null for no limit. Not token-bindable.",
+      "oneOf": [
+        { "type": "number" },
         { "type": "null" }
       ]
     },

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -9,7 +9,7 @@ import type {
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
   MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset,
-  StrokeDashPattern, TextTruncation, MaxLines,
+  StrokeDashPattern, TextTruncation,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -876,21 +876,7 @@ const _ttStyleNumber: Styles = { textTruncation: 1 };
 // @ts-expect-error: arbitrary string is not valid for textTruncation
 const _ttArbitrary: Styles = { textTruncation: 'CLIP' };
 
-// ─── MaxLines ───────────────────────────────────────────────────────────────
-
-// number is valid
-const _mlNumber: MaxLines = 3;
-
-// null is valid (no limit)
-const _mlNull: MaxLines = null;
-
-// @ts-expect-error: string is not valid MaxLines
-const _mlString: MaxLines = '3';
-
-// @ts-expect-error: boolean is not valid MaxLines
-const _mlBool: MaxLines = true;
-
-// ─── Styles.maxLines (MaxLines) ──────────────────────────────────────────────
+// ─── Styles.maxLines (Style — a plain number like width/opacity) ─────────────
 
 // number line count
 const withMaxLines: Styles = { maxLines: 2 };
@@ -901,8 +887,10 @@ const withMaxLinesNull: Styles = { maxLines: null };
 // absent is valid
 const withNoMaxLines: Styles = {};
 
-// @ts-expect-error: TokenReference is not valid for maxLines (not token-bindable)
-const _mlToken: Styles = { maxLines: { $token: 'Text.MaxLines', $type: 'number' } satisfies TokenReference };
+// TokenReference is valid — maxLines is an ordinary Style number, token-bindable
+const withMaxLinesToken: Styles = {
+  maxLines: { $token: 'Text.MaxLines', $type: 'number' } satisfies TokenReference,
+};
 
-// @ts-expect-error: string is not valid for maxLines
-const _mlStyleString: Styles = { maxLines: '2' };
+// @ts-expect-error: boolean-only object is not a valid Style for maxLines
+const _mlBadObject: Styles = { maxLines: { value: 2 } };

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -9,7 +9,7 @@ import type {
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
   MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset,
-  StrokeDashPattern, TextTruncation,
+  StrokeDashPattern, TextOverflow,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -840,41 +840,44 @@ const _dashNumber: Styles = { strokeDashPattern: 8 };
 // @ts-expect-error: string is not valid for strokeDashPattern
 const _dashString: Styles = { strokeDashPattern: 'dashed' };
 
-// ─── TextTruncation ───────────────────────────────────────────────────────────
+// ─── TextOverflow ─────────────────────────────────────────────────────────────
 
 // Valid enum values
-const _ttDisabled: TextTruncation = 'DISABLED';
-const _ttEnding: TextTruncation = 'ENDING';
+const _toClip: TextOverflow = 'CLIP';
+const _toEllipsis: TextOverflow = 'ELLIPSIS';
 
-// @ts-expect-error: arbitrary string is not valid TextTruncation
-const _ttBad: TextTruncation = 'MIDDLE';
+// @ts-expect-error: arbitrary string is not valid TextOverflow
+const _toBad: TextOverflow = 'FADE';
 
-// @ts-expect-error: number is not valid TextTruncation
-const _ttNumber: TextTruncation = 0;
+// @ts-expect-error: Figma's raw value is not valid TextOverflow (remapped in the generator)
+const _toFigmaRaw: TextOverflow = 'ENDING';
+
+// @ts-expect-error: number is not valid TextOverflow
+const _toNumber: TextOverflow = 0;
 
 // @ts-expect-error: lowercase is not valid (SCREAMING_CASE required)
-const _ttLowercase: TextTruncation = 'ending';
+const _toLowercase: TextOverflow = 'clip';
 
-// ─── Styles.textTruncation (TextTruncation | null) ───────────────────────────
+// ─── Styles.textOverflow (TextOverflow | null) ───────────────────────────────
 
 // Valid enum values on Styles
-const withTruncationDisabled: Styles = { textTruncation: 'DISABLED' };
-const withTruncationEnding: Styles = { textTruncation: 'ENDING' };
+const withOverflowClip: Styles = { textOverflow: 'CLIP' };
+const withOverflowEllipsis: Styles = { textOverflow: 'ELLIPSIS' };
 
 // null is valid
-const withTruncationNull: Styles = { textTruncation: null };
+const withOverflowNull: Styles = { textOverflow: null };
 
 // absent is valid (all Styles fields optional)
-const withNoTruncation: Styles = {};
+const withNoOverflow: Styles = {};
 
-// @ts-expect-error: TokenReference is not valid for textTruncation (not token-bindable)
-const _ttToken: Styles = { textTruncation: { $token: 'Text.Truncation', $type: 'string' } satisfies TokenReference };
+// @ts-expect-error: TokenReference is not valid for textOverflow (not token-bindable)
+const _toToken: Styles = { textOverflow: { $token: 'Text.Overflow', $type: 'string' } satisfies TokenReference };
 
-// @ts-expect-error: number is not valid for textTruncation
-const _ttStyleNumber: Styles = { textTruncation: 1 };
+// @ts-expect-error: number is not valid for textOverflow
+const _toStyleNumber: Styles = { textOverflow: 1 };
 
-// @ts-expect-error: arbitrary string is not valid for textTruncation
-const _ttArbitrary: Styles = { textTruncation: 'CLIP' };
+// @ts-expect-error: arbitrary string is not valid for textOverflow
+const _toArbitrary: Styles = { textOverflow: 'FADE' };
 
 // ─── Styles.maxLines (Style — a plain number like width/opacity) ─────────────
 

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -9,7 +9,7 @@ import type {
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
   MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset,
-  StrokeDashPattern,
+  StrokeDashPattern, TextTruncation, MaxLines,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -839,3 +839,70 @@ const _dashNumber: Styles = { strokeDashPattern: 8 };
 
 // @ts-expect-error: string is not valid for strokeDashPattern
 const _dashString: Styles = { strokeDashPattern: 'dashed' };
+
+// ─── TextTruncation ───────────────────────────────────────────────────────────
+
+// Valid enum values
+const _ttDisabled: TextTruncation = 'DISABLED';
+const _ttEnding: TextTruncation = 'ENDING';
+
+// @ts-expect-error: arbitrary string is not valid TextTruncation
+const _ttBad: TextTruncation = 'MIDDLE';
+
+// @ts-expect-error: number is not valid TextTruncation
+const _ttNumber: TextTruncation = 0;
+
+// @ts-expect-error: lowercase is not valid (SCREAMING_CASE required)
+const _ttLowercase: TextTruncation = 'ending';
+
+// ─── Styles.textTruncation (TextTruncation | null) ───────────────────────────
+
+// Valid enum values on Styles
+const withTruncationDisabled: Styles = { textTruncation: 'DISABLED' };
+const withTruncationEnding: Styles = { textTruncation: 'ENDING' };
+
+// null is valid
+const withTruncationNull: Styles = { textTruncation: null };
+
+// absent is valid (all Styles fields optional)
+const withNoTruncation: Styles = {};
+
+// @ts-expect-error: TokenReference is not valid for textTruncation (not token-bindable)
+const _ttToken: Styles = { textTruncation: { $token: 'Text.Truncation', $type: 'string' } satisfies TokenReference };
+
+// @ts-expect-error: number is not valid for textTruncation
+const _ttStyleNumber: Styles = { textTruncation: 1 };
+
+// @ts-expect-error: arbitrary string is not valid for textTruncation
+const _ttArbitrary: Styles = { textTruncation: 'CLIP' };
+
+// ─── MaxLines ───────────────────────────────────────────────────────────────
+
+// number is valid
+const _mlNumber: MaxLines = 3;
+
+// null is valid (no limit)
+const _mlNull: MaxLines = null;
+
+// @ts-expect-error: string is not valid MaxLines
+const _mlString: MaxLines = '3';
+
+// @ts-expect-error: boolean is not valid MaxLines
+const _mlBool: MaxLines = true;
+
+// ─── Styles.maxLines (MaxLines) ──────────────────────────────────────────────
+
+// number line count
+const withMaxLines: Styles = { maxLines: 2 };
+
+// null (no limit)
+const withMaxLinesNull: Styles = { maxLines: null };
+
+// absent is valid
+const withNoMaxLines: Styles = {};
+
+// @ts-expect-error: TokenReference is not valid for maxLines (not token-bindable)
+const _mlToken: Styles = { maxLines: { $token: 'Text.MaxLines', $type: 'number' } satisfies TokenReference };
+
+// @ts-expect-error: string is not valid for maxLines
+const _mlStyleString: Styles = { maxLines: '2' };

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -46,6 +46,10 @@ export type Styles = Partial<{
   typography: TokenReference | Typography;
   textAlignHorizontal: Style;
   textAlignVertical: Style;
+  /** Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
+  textTruncation: TextTruncation | null;
+  /** Maximum number of lines before `ENDING` truncation applies; `null` or absent means no limit. Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
+  maxLines: MaxLines;
   textColor: ColorStyle;
   /** Alignment along the main axis (depends on `layoutMode`). Structural property — not token-bindable. @since 0.18.0 */
   mainAxisAlignment: MainAxisAlignment | null;
@@ -260,6 +264,20 @@ export type MainAxisAlignment = 'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN';
 export type CrossAxisAlignment = 'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASELINE';
 
 /**
+ * Text truncation mode. Structural property that cannot be token-bound.
+ * `'ENDING'` truncates overflowing text with a trailing ellipsis; `'DISABLED'` does not truncate.
+ * @since 0.28.0
+ */
+export type TextTruncation = 'DISABLED' | 'ENDING';
+
+/**
+ * Maximum number of lines before truncation, or `null` for no limit.
+ * Only meaningful when `textTruncation` is `'ENDING'`. Structural property that cannot be token-bound.
+ * @since 0.28.0
+ */
+export type MaxLines = number | null;
+
+/**
  * Dash geometry for a dashed stroke.
  * Presence on `Styles.strokeDashPattern` indicates a dashed stroke; null or absent indicates solid.
  * `dash` and `gap` are in pixels and correspond to index 0 and 1 of Figma's `strokeDashes` array.
@@ -337,6 +355,8 @@ export type StyleKey =
   | 'typography'
   | 'textAlignHorizontal'
   | 'textAlignVertical'
+  | 'textTruncation'
+  | 'maxLines'
   | 'textColor'
   | 'mainAxisAlignment'
   | 'primaryAxisSizingMode'

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -48,8 +48,8 @@ export type Styles = Partial<{
   textAlignVertical: Style;
   /** Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
   textTruncation: TextTruncation | null;
-  /** Maximum number of lines before `ENDING` truncation applies; `null` or absent means no limit. Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
-  maxLines: MaxLines;
+  /** Maximum number of lines before `ENDING` truncation applies; `null` or absent means no limit. Present on TEXT element type only. @since 0.28.0 */
+  maxLines: Style;
   textColor: ColorStyle;
   /** Alignment along the main axis (depends on `layoutMode`). Structural property — not token-bindable. @since 0.18.0 */
   mainAxisAlignment: MainAxisAlignment | null;
@@ -269,13 +269,6 @@ export type CrossAxisAlignment = 'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASEL
  * @since 0.28.0
  */
 export type TextTruncation = 'DISABLED' | 'ENDING';
-
-/**
- * Maximum number of lines before truncation, or `null` for no limit.
- * Only meaningful when `textTruncation` is `'ENDING'`. Structural property that cannot be token-bound.
- * @since 0.28.0
- */
-export type MaxLines = number | null;
 
 /**
  * Dash geometry for a dashed stroke.

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -46,9 +46,9 @@ export type Styles = Partial<{
   typography: TokenReference | Typography;
   textAlignHorizontal: Style;
   textAlignVertical: Style;
-  /** Whether text truncates with a trailing ellipsis when content exceeds bounds. Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
-  textTruncation: TextTruncation | null;
-  /** Maximum number of lines before `ENDING` truncation applies; `null` or absent means no limit. Present on TEXT element type only. @since 0.28.0 */
+  /** How overflowing text is handled — `CLIP` (cut off) or `ELLIPSIS` (trailing ellipsis). Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
+  textOverflow: TextOverflow | null;
+  /** Maximum number of lines before `ELLIPSIS` text overflow applies; `null` or absent means no limit. Present on TEXT element type only. @since 0.28.0 */
   maxLines: Style;
   textColor: ColorStyle;
   /** Alignment along the main axis (depends on `layoutMode`). Structural property — not token-bindable. @since 0.18.0 */
@@ -264,11 +264,12 @@ export type MainAxisAlignment = 'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN';
 export type CrossAxisAlignment = 'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASELINE';
 
 /**
- * Text truncation mode. Structural property that cannot be token-bound.
- * `'ENDING'` truncates overflowing text with a trailing ellipsis; `'DISABLED'` does not truncate.
+ * How text is handled when it overflows its bounds. Structural property that cannot be token-bound.
+ * `'CLIP'` cuts the text off; `'ELLIPSIS'` truncates with a trailing ellipsis.
+ * Named after CSS `text-overflow` and Jetpack Compose `TextOverflow` (values `clip`/`ellipsis`).
  * @since 0.28.0
  */
-export type TextTruncation = 'DISABLED' | 'ENDING';
+export type TextOverflow = 'CLIP' | 'ELLIPSIS';
 
 /**
  * Dash geometry for a dashed stroke.
@@ -348,7 +349,7 @@ export type StyleKey =
   | 'typography'
   | 'textAlignHorizontal'
   | 'textAlignVertical'
-  | 'textTruncation'
+  | 'textOverflow'
   | 'maxLines'
   | 'textColor'
   | 'mainAxisAlignment'

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -28,7 +28,7 @@ export type { Config, ResolvedConfig, ColorFormat, VariantStateEntry, TransformE
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextTruncation, MaxLines } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -28,7 +28,7 @@ export type { Config, ResolvedConfig, ColorFormat, VariantStateEntry, TransformE
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextTruncation, MaxLines } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextTruncation } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -28,7 +28,7 @@ export type { Config, ResolvedConfig, ColorFormat, VariantStateEntry, TransformE
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextTruncation } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextOverflow } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -116,7 +116,6 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 | `AspectRatio` | Width-to-height ratio | `{ x: 16, y: 9 }` |
 | `StrokeDashPattern` | Dash geometry for a dashed stroke — presence signals dashed; null or absent signals solid | `{ dash: 8, gap: 4 }` |
 | `TextTruncation` | Text truncation mode enum | `"DISABLED"`, `"ENDING"` |
-| `MaxLines` | Maximum line count before truncation, or null for no limit | `2`, `null` |
 
 ### Relating properties to values
 
@@ -136,4 +135,4 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 - `aspectRatio` accepts `AspectRatio | null`.
 - `strokeDashPattern` accepts `StrokeDashPattern | null` — not token-bindable; presence signals a dashed stroke, null or absent signals solid.
 - `textTruncation` accepts `TextTruncation | null` (`"DISABLED" | "ENDING"`) — not token-bindable; `"ENDING"` truncates overflowing text with a trailing ellipsis.
-- `maxLines` accepts `MaxLines` (`number | null`) — not token-bindable; the line limit before `textTruncation: "ENDING"` applies, or `null` for no limit.
+- `maxLines` accepts any `Style` (a plain number like other sizes); the line limit before `textTruncation: "ENDING"` applies, or `null` for no limit.

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -50,8 +50,10 @@ Combined view: every style property, grouped by category and then by name, with 
 | Size | `width` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Spacing | `itemSpacing` | ✓ |  |  |  |  |
 | Spacing | `padding` | ✓ |  |  |  |  |
+| Text | `maxLines` |  | ✓ |  |  |  |
 | Text | `textAlignHorizontal` |  | ✓ |  |  |  |
 | Text | `textAlignVertical` |  | ✓ |  |  |  |
+| Text | `textTruncation` |  | ✓ |  |  |  |
 | Text | `typography` |  | ✓ |  |  |  |
 | Transform | `rotation` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Visibility | `clipContent` | ✓ |  |  |  |  |
@@ -113,6 +115,8 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 | `PositionOffset` | Positional offset value | `24` (px), `"25%"` (SCALE), `null` |
 | `AspectRatio` | Width-to-height ratio | `{ x: 16, y: 9 }` |
 | `StrokeDashPattern` | Dash geometry for a dashed stroke — presence signals dashed; null or absent signals solid | `{ dash: 8, gap: 4 }` |
+| `TextTruncation` | Text truncation mode enum | `"DISABLED"`, `"ENDING"` |
+| `MaxLines` | Maximum line count before truncation, or null for no limit | `2`, `null` |
 
 ### Relating properties to values
 
@@ -131,3 +135,5 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 - `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset` accept `PositionOffset` (`number | string | null`) — not token-bindable.
 - `aspectRatio` accepts `AspectRatio | null`.
 - `strokeDashPattern` accepts `StrokeDashPattern | null` — not token-bindable; presence signals a dashed stroke, null or absent signals solid.
+- `textTruncation` accepts `TextTruncation | null` (`"DISABLED" | "ENDING"`) — not token-bindable; `"ENDING"` truncates overflowing text with a trailing ellipsis.
+- `maxLines` accepts `MaxLines` (`number | null`) — not token-bindable; the line limit before `textTruncation: "ENDING"` applies, or `null` for no limit.

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -53,7 +53,7 @@ Combined view: every style property, grouped by category and then by name, with 
 | Text | `maxLines` |  | ✓ |  |  |  |
 | Text | `textAlignHorizontal` |  | ✓ |  |  |  |
 | Text | `textAlignVertical` |  | ✓ |  |  |  |
-| Text | `textTruncation` |  | ✓ |  |  |  |
+| Text | `textOverflow` |  | ✓ |  |  |  |
 | Text | `typography` |  | ✓ |  |  |  |
 | Transform | `rotation` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Visibility | `clipContent` | ✓ |  |  |  |  |
@@ -85,6 +85,7 @@ Several spec style keys differ from the Figma node property they read from. Spec
 | `centerVerticalOffset` | `y` (constraint CENTER) | [ADR 041](https://github.com/DirectedEdges/specs/blob/main/adr/041-layout-positioning.md) |
 
 | `strokeDashPattern` | `strokeDashes` | [ADR 059](https://github.com/DirectedEdges/specs/blob/main/adr/059-border-style.md) |
+| `textOverflow` | `textTruncation` (values remapped: `DISABLED`→`CLIP`, `ENDING`→`ELLIPSIS`) | [ADR 062](https://github.com/DirectedEdges/specs/blob/main/adr/062-text-truncation.md) |
 
 All other style keys — `width`, `height`, `opacity`, `padding`, `itemSpacing`, `cornerRadius`, `strokeWeight`, `rotation`, etc. — use the same name as the Figma node property.
 
@@ -115,7 +116,7 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 | `PositionOffset` | Positional offset value | `24` (px), `"25%"` (SCALE), `null` |
 | `AspectRatio` | Width-to-height ratio | `{ x: 16, y: 9 }` |
 | `StrokeDashPattern` | Dash geometry for a dashed stroke — presence signals dashed; null or absent signals solid | `{ dash: 8, gap: 4 }` |
-| `TextTruncation` | Text truncation mode enum | `"DISABLED"`, `"ENDING"` |
+| `TextOverflow` | Text overflow handling enum | `"CLIP"`, `"ELLIPSIS"` |
 
 ### Relating properties to values
 
@@ -134,5 +135,5 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 - `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset` accept `PositionOffset` (`number | string | null`) — not token-bindable.
 - `aspectRatio` accepts `AspectRatio | null`.
 - `strokeDashPattern` accepts `StrokeDashPattern | null` — not token-bindable; presence signals a dashed stroke, null or absent signals solid.
-- `textTruncation` accepts `TextTruncation | null` (`"DISABLED" | "ENDING"`) — not token-bindable; `"ENDING"` truncates overflowing text with a trailing ellipsis.
-- `maxLines` accepts any `Style` (a plain number like other sizes); the line limit before `textTruncation: "ENDING"` applies, or `null` for no limit.
+- `textOverflow` accepts `TextOverflow | null` (`"CLIP" | "ELLIPSIS"`) — not token-bindable; `"ELLIPSIS"` truncates overflowing text with a trailing ellipsis, `"CLIP"` cuts it off. Named after CSS `text-overflow` / Compose `TextOverflow`.
+- `maxLines` accepts any `Style` (a plain number like other sizes); the line limit before `textOverflow: "ELLIPSIS"` applies, or `null` for no limit.


### PR DESCRIPTION
Adds the schema contract for text-overflow on TEXT elements. Implements ADR-062.

## What
- **`textOverflow`**: `TextOverflow | null` where `TextOverflow = 'CLIP' | 'ELLIPSIS'`; schema `TextOverflowStyleValue`. Structural, not token-bindable.
- **`maxLines`**: `Style` (a plain number like `width`/`opacity`); reuses the shared `NumberStyleValue`.
- `StyleKey` extended; both keys TEXT-only.

## Naming (Constitution VI)
`textOverflow` + `CLIP`/`ELLIPSIS` match CSS `text-overflow` and Compose `TextOverflow` — two code platforms agree on both the name and the values (rule 1), unbiasing from Figma's `textTruncation`/`DISABLED`/`ENDING`. The ADR carries the full per-platform comparison tables and rationale.

## Included
- `types/Styles.ts`, `types/index.ts`, `schema/styles.schema.json`
- Type tests (`tests/Styles.test-d.ts`), CHANGELOG (unreleased 0.28.0), docs (`site/.../schema/styles.md`), ADR-062, INDEX
- Gates: tsc build, type tests, schema validation (5/5) all green

## Semver
Additive → MINOR; lands within the in-progress unreleased `0.28.0`.

## Related
- Generator implementation: `DirectedEdges/specs-from-figma#138`.

Refs DirectedEdges/specs#187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
