### PR TITLE
chore(site): serve docs at specsplugin.com root (project 015)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -7,7 +7,7 @@
 > ```
 >
 > Everything below is a prompt *for Claude*, not a tutorial for you.
-> For a manual walkthrough, see the [Getting Started](https://directededges.github.io/specs/cli/getting-started/) guide.
+> For a manual walkthrough, see the [Getting Started](https://www.specsplugin.com/cli/getting-started/) guide.
 
 ---
 
@@ -207,7 +207,7 @@ output:                                # ASKED-5c (Essentials) — file layout o
   # defaultFormat: yaml                # OMITTED — stdout-only knob; the `--format` CLI flag overrides per command
 ```
 
-If the user later wants to enable anything marked **OMITTED**, point them at the [Configuration Reference](https://directededges.github.io/specs/config/) — those features are opt-in because either (a) absence means the feature is off (`subcomponents`, `glyphNamePattern`, `codeOnlyPropsPattern`), or (b) they're advanced tuning knobs rarely needed in a first setup (`slotConstraints`, `inferNumberProps`, `emptyVariants`, `defaultFormat`).
+If the user later wants to enable anything marked **OMITTED**, point them at the [Configuration Reference](https://www.specsplugin.com/config/) — those features are opt-in because either (a) absence means the feature is off (`subcomponents`, `glyphNamePattern`, `codeOnlyPropsPattern`), or (b) they're advanced tuning knobs rarely needed in a first setup (`slotConstraints`, `inferNumberProps`, `emptyVariants`, `defaultFormat`).
 
 **Note on `output:`**: `specs init` today does not write this section. If it's missing after Step 2, Claude will create it in sub-step 5c with the defaults shown. If a future `specs init` adds it, the checkpoint still matches.
 
@@ -466,7 +466,7 @@ Summarize what exists now:
 Suggest immediate next steps:
 
 - Re-run `specs fetch && specs generate` anytime the Figma file updates.
-- See the [Workflows](https://directededges.github.io/specs/cli/workflows/) guide for CI/CD automation.
+- See the [Workflows](https://www.specsplugin.com/cli/workflows/) guide for CI/CD automation.
 - Enable Pro features later by adding `SPECS_LICENSE_KEY` to `.env`.
 
 Do **not** offer to `git init`, `git add`, or `git commit` unless the user asks.
@@ -500,6 +500,6 @@ Regardless of UI, for the `.env` step, prefer the "create stub file, user pastes
 
 ## See also
 
-- [Getting Started](https://directededges.github.io/specs/cli/getting-started/) — the manual walkthrough
-- [Configuration Reference](https://directededges.github.io/specs/config/) — full option docs
-- [CLI Overview](https://directededges.github.io/specs/cli/) — per-command flags and behavior
+- [Getting Started](https://www.specsplugin.com/cli/getting-started/) — the manual walkthrough
+- [Configuration Reference](https://www.specsplugin.com/config/) — full option docs
+- [CLI Overview](https://www.specsplugin.com/cli/) — per-command flags and behavior

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Specs is a fast, deterministic ecosystem for defining and generating production-
 - Set up for continuous integration
 - Configure the files, formats, and data you need
 
-[Set up the CLI →](https://directededges.github.io/specs/cli/getting-started/)
+[Set up the CLI →](https://www.specsplugin.com/cli/getting-started/)
 
-Both the plugin and CLI generate specs consistent with the [Specs schema](https://directededges.github.io/specs/schema/), a specifications model architected to unify component definitions for implementation across web, iOS, Android, and Figma.
+Both the plugin and CLI generate specs consistent with the [Specs schema](https://www.specsplugin.com/schema/), a specifications model architected to unify component definitions for implementation across web, iOS, Android, and Figma.
 
 ## Repeatable, production-grade specs in seconds
 
@@ -63,10 +63,10 @@ specs generate
 ```
 
 Helpful documentation includes:
-- [Overview](https://directededges.github.io/specs/cli/)
-- [Getting started](https://directededges.github.io/specs/cli/getting-started/)
-- [Configuration file](https://directededges.github.io/specs/cli/configuration/) details
-- Per [command](https://directededges.github.io/specs/cli/commands/) instructions and flags
+- [Overview](https://www.specsplugin.com/cli/)
+- [Getting started](https://www.specsplugin.com/cli/getting-started/)
+- [Configuration file](https://www.specsplugin.com/cli/configuration/) details
+- Per [command](https://www.specsplugin.com/cli/commands/) instructions and flags
 
 
 ### `@directededges/specs-schema`
@@ -83,7 +83,7 @@ Exports include:
 - [TypeScript types](packages/schema/types/) — complete type definitions for all schema entities (`Component`, `Config`, `Styles`, `Element`, `AnyProp`, etc.)
 - `DEFAULT_CONFIG` — a runtime configuration object controlling output shape (format, token resolution, variant depth, etc.)
 
-Learn more in the [Schema docs](https://directededges.github.io/specs/schema/), including details on each property including component, variants, styles, props and more.
+Learn more in the [Schema docs](https://www.specsplugin.com/schema/), including details on each property including component, variants, styles, props and more.
 
 ### `@directededges/specs-from-figma`
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-> Also available at: https://directededges.github.io/specs/overview/terms-of-service/
+> Also available at: https://www.specsplugin.com/overview/terms-of-service/
 
 **Directed Edges**
 **Effective Date:** April 6, 2026

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -123,7 +123,7 @@ Adds configurable color output format (`Config.format.color`) supporting nine fo
 
 ## [0.19.0] - 2026-04-28
 
-Replaces Figma-raw `x`, `y`, and `layoutPositioning` with constraint-based positioning properties. `position` replaces `layoutPositioning` as a strict `Position` enum. Directional offsets (`top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset`) replace `x`/`y` with anchor semantics derived from Figma constraints. See the [Layout Positioning guide](/specs/guides/layout-positioning/) for constraint mapping rules and platform usage examples.
+Replaces Figma-raw `x`, `y`, and `layoutPositioning` with constraint-based positioning properties. `position` replaces `layoutPositioning` as a strict `Position` enum. Directional offsets (`top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset`) replace `x`/`y` with anchor semantics derived from Figma constraints. See the [Layout Positioning guide](/guides/layout-positioning/) for constraint mapping rules and platform usage examples.
 
 ### Added
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,8 +5,7 @@ const pro = { text: 'Pro', variant: 'tip' };
 const experimental = { text: 'Experimental', variant: 'default' };
 
 export default defineConfig({
-  site: 'https://directededges.github.io',
-  base: '/specs',
+  site: 'https://www.specsplugin.com',
   server: { port: 4323 },
   integrations: [
     starlight({

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+www.specsplugin.com

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -9,11 +9,11 @@ import config from 'virtual:starlight/user-config';
 import { Icon } from '@astrojs/starlight/components';
 
 const FOOTER_LINKS = [
-  { label: 'About', href: '/specs/overview/aboutspecs/' },
+  { label: 'About', href: '/overview/aboutspecs/' },
   { label: 'Support', href: 'https://github.com/DirectedEdges/specs/issues' },
-  { label: 'License', href: '/specs/overview/license/' },
-  { label: 'Licensing', href: '/specs/overview/licensing/' },
-  { label: 'Terms of Service', href: '/specs/overview/terms-of-service/' },
+  { label: 'License', href: '/overview/license/' },
+  { label: 'Licensing', href: '/overview/licensing/' },
+  { label: 'Terms of Service', href: '/overview/terms-of-service/' },
   { label: 'GitHub', href: 'https://github.com/DirectedEdges/specs' },
 ];
 
@@ -40,7 +40,7 @@ const COPYRIGHT_YEAR = 2026;
       Schema licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a> ·
       CLI under <a href="https://github.com/DirectedEdges/specs/blob/main/packages/cli/LICENSE">MIT</a> —
       when reusing the schema, credit Nathan Curtis and link the repository; see the
-      <a href="/specs/overview/license/">full license</a> for attribution details.
+      <a href="/overview/license/">full license</a> for attribution details.
     </p>
     <p class="copyright">
       © Directed Edges, LLC {COPYRIGHT_YEAR} · Independent project, not affiliated with Figma Inc.

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -17,12 +17,12 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
 const SECTION_LINKS = [
-  { label: 'Plugin', href: '/specs/plugin/', prefix: '/specs/plugin/' },
-  { label: 'Commands', href: '/specs/cli/', prefix: '/specs/cli/' },
-  { label: 'Schema', href: '/specs/schema/', prefix: '/specs/schema/' },
+  { label: 'Plugin', href: '/plugin/', prefix: '/plugin/' },
+  { label: 'Commands', href: '/cli/', prefix: '/cli/' },
+  { label: 'Schema', href: '/schema/', prefix: '/schema/' },
   // Points at the Settings section home for now, per explicit instruction.
   // TODO: point to the future consolidated Docs section landing page once Settings+Guides are merged.
-  { label: 'Docs', href: '/specs/settings/', prefix: '/specs/settings/' },
+  { label: 'Docs', href: '/settings/', prefix: '/settings/' },
 ];
 
 const pathname = Astro.url.pathname;

--- a/site/src/content/docs/cli/analyze/index.md
+++ b/site/src/content/docs/cli/analyze/index.md
@@ -37,8 +37,8 @@ specs analyze props --analysis ./reports
 
 | Analyzer | Output | What it produces |
 |----------|--------|-----------------|
-| [`props`](/specs/cli/analyze/props/) | `_analysis/props.yaml` | Cross-library prop inventory — frequency, enum discordance, API surface, slots |
-| [`styling`](/specs/cli/analyze/styling/) | `_analysis/styling.byComponent.json`, `_analysis/styling.byToken.json` | Token usage indexed by component and by token name |
+| [`props`](/cli/analyze/props/) | `_analysis/props.yaml` | Cross-library prop inventory — frequency, enum discordance, API surface, slots |
+| [`styling`](/cli/analyze/styling/) | `_analysis/styling.byComponent.json`, `_analysis/styling.byToken.json` | Token usage indexed by component and by token name |
 
 ## Output Directory
 
@@ -56,5 +56,5 @@ specs/
 
 ## See Also
 
-- [`analyze` command](/specs/cli/commands/analyze/) — full CLI reference
-- [Transforms overview](/specs/cli/transforms/) — build artifacts (contract, css)
+- [`analyze` command](/cli/commands/analyze/) — full CLI reference
+- [Transforms overview](/cli/transforms/) — build artifacts (contract, css)

--- a/site/src/content/docs/cli/analyze/props.md
+++ b/site/src/content/docs/cli/analyze/props.md
@@ -347,6 +347,6 @@ The date in the filename keeps multiple runs distinct as the library evolves. Th
 
 ## See Also
 
-- [Analyze overview](/specs/cli/analyze/)
-- [`styling` analyzer](/specs/cli/analyze/styling/)
-- [Transforms overview](/specs/cli/transforms/)
+- [Analyze overview](/cli/analyze/)
+- [`styling` analyzer](/cli/analyze/styling/)
+- [Transforms overview](/cli/transforms/)

--- a/site/src/content/docs/cli/analyze/styling.md
+++ b/site/src/content/docs/cli/analyze/styling.md
@@ -149,6 +149,6 @@ Each token entry has:
 
 ## See Also
 
-- [Analyze overview](/specs/cli/analyze/)
-- [`props` analyzer](/specs/cli/analyze/props/)
-- [Transforms overview](/specs/cli/transforms/)
+- [Analyze overview](/cli/analyze/)
+- [`props` analyzer](/cli/analyze/props/)
+- [Transforms overview](/cli/transforms/)

--- a/site/src/content/docs/cli/commands/apply-custom-tokens.md
+++ b/site/src/content/docs/cli/commands/apply-custom-tokens.md
@@ -5,7 +5,7 @@ description: "Inject your team's token shapes into fetched Figma data so generat
 
 ## The Problem
 
-Specs generates token references in a fixed shape — `{ $token, $type }` or one of the other [built-in profiles](/specs/settings/tokens/). But many teams already have a token system with its own naming conventions and output shapes: Style Dictionary aliases, JSON schema references, platform-specific formats, or custom structures built for their toolchain.
+Specs generates token references in a fixed shape — `{ $token, $type }` or one of the other [built-in profiles](/settings/tokens/). But many teams already have a token system with its own naming conventions and output shapes: Style Dictionary aliases, JSON schema references, platform-specific formats, or custom structures built for their toolchain.
 
 You can't make Specs guess your format. You need a way to say: _"For this Figma variable, output **this exact object** instead."_
 
@@ -214,12 +214,12 @@ If your data files were fetched from a Figma branch (using a branch file key in 
 
 Inspect the fetched files directly to verify which IDs are present. If you maintain separate mapping files per branch, keep them alongside the branch data.
 
-See [Fetching Figma Branches](/specs/cli/commands/fetch/#fetching-figma-branches) for details.
+See [Fetching Figma Branches](/cli/commands/fetch/#fetching-figma-branches) for details.
 
 ---
 
 **See Also:**
-- [Tokens configuration](/specs/settings/tokens/) — all token profiles compared
-- [Configuration Reference](/specs/settings/) — `dataDirectory` and `sources` setup
-- [Generate Command](/specs/cli/commands/generate/) — processing augmented data
-- [Fetch Command](/specs/cli/commands/fetch/) — fetching raw data before augmentation
+- [Tokens configuration](/settings/tokens/) — all token profiles compared
+- [Configuration Reference](/settings/) — `dataDirectory` and `sources` setup
+- [Generate Command](/cli/commands/generate/) — processing augmented data
+- [Fetch Command](/cli/commands/fetch/) — fetching raw data before augmentation

--- a/site/src/content/docs/cli/commands/fetch.md
+++ b/site/src/content/docs/cli/commands/fetch.md
@@ -13,7 +13,7 @@ specs fetch [options]
 
 - `FIGMA_TOKEN` must be set in your environment.
 - `specs.config.yaml` must include `dataDirectory` (or deprecated `sourceDirectory`) and `sources`.
-- Fetching `variables` or `styles` requires your Figma organization to be on an **Enterprise** plan — Figma restricts those REST endpoints regardless of your Specs license. `file` data works on any plan. See [CLI Requirements](/specs/cli/#requirements).
+- Fetching `variables` or `styles` requires your Figma organization to be on an **Enterprise** plan — Figma restricts those REST endpoints regardless of your Specs license. `file` data works on any plan. See [CLI Requirements](/cli/#requirements).
 
 ## Options
 
@@ -84,5 +84,5 @@ If you use `applyCustomTokens` with branch-fetched data, be aware that Figma var
 ---
 
 **See Also:**
-- [Configuration Reference](/specs/settings/) - dataDirectory and sources setup
-- [Generate Command](/specs/cli/commands/generate/) - Processing fetched data
+- [Configuration Reference](/settings/) - dataDirectory and sources setup
+- [Generate Command](/cli/commands/generate/) - Processing fetched data

--- a/site/src/content/docs/cli/commands/generate.md
+++ b/site/src/content/docs/cli/commands/generate.md
@@ -30,7 +30,7 @@ specs generate
 specs generate components.md -o specs/library.yaml
 ```
 
-The manifest references the source file and tracks which components to include. See [Scan Command](/specs/cli/commands/scan/) for creating manifests.
+The manifest references the source file and tracks which components to include. See [Scan Command](/cli/commands/scan/) for creating manifests.
 
 ### File Mode
 
@@ -89,7 +89,7 @@ export SPECS_LICENSE_KEY="your-license-key"
 specs generate components.md -o specs/all.yaml
 ```
 
-See [Getting Started — License](/specs/cli/getting-started.md/#step-3-set-your-license-key-optional) for setup details.
+See [Getting Started — License](/cli/getting-started.md/#step-3-set-your-license-key-optional) for setup details.
 
 ### `-o, --output <path>`
 Output file or directory path. Accepts both file paths and directory paths.
@@ -175,7 +175,7 @@ Separate API specification, variant configuration, and examples.
 - **Default**: `false` (complete component data in each file)
 - **Output**: Up to three files: `api.yaml` (anatomy, props), `variants.yaml` (default, variants), and `examples.yaml` (slotContentExamples, instanceExamples)
 - `examples.yaml` is written only when at least one component has example data; components without examples are omitted from it.
-- Example output (`slotContentExamples`, `instanceExamples`) is a [Pro feature](/specs/settings/default-slot-content/) — on the free tier it is omitted, so `examples.yaml` is not produced.
+- Example output (`slotContentExamples`, `instanceExamples`) is a [Pro feature](/settings/default-slot-content/) — on the free tier it is omitted, so `examples.yaml` is not produced.
 
 ```bash
 specs generate components.md -o specs/ --split-concerns
@@ -293,6 +293,6 @@ specs generate
 ---
 
 **See Also:**
-- [Scan Command](/specs/cli/commands/scan/) - Create component manifest
-- [Configuration Reference](/specs/settings/) - Format and config options
-- [Getting Started](/specs/cli/getting-started/) - Installation and license setup
+- [Scan Command](/cli/commands/scan/) - Create component manifest
+- [Configuration Reference](/settings/) - Format and config options
+- [Getting Started](/cli/getting-started/) - Installation and license setup

--- a/site/src/content/docs/cli/commands/init.md
+++ b/site/src/content/docs/cli/commands/init.md
@@ -141,5 +141,5 @@ specs init --force
 ---
 
 **See Also:**
-- [Configuration Reference](/specs/settings/) - Config file options
-- [Getting Started](/specs/cli/getting-started/) - Quick start guide
+- [Configuration Reference](/settings/) - Config file options
+- [Getting Started](/cli/getting-started/) - Quick start guide

--- a/site/src/content/docs/cli/commands/scan.md
+++ b/site/src/content/docs/cli/commands/scan.md
@@ -239,6 +239,6 @@ Manifests produced by older versions of `scan` (checkbox-list format like `- [x]
 ---
 
 **See Also:**
-- [Generate Command](/specs/cli/commands/generate/) - Generate specs from manifest or single component
-- [glyphNamePattern](/specs/settings/glyph-name-pattern/) - Pattern syntax that drives Glyphs-section partitioning
-- [Configuration Reference](/specs/settings/) - Format and config options
+- [Generate Command](/cli/commands/generate/) - Generate specs from manifest or single component
+- [glyphNamePattern](/settings/glyph-name-pattern/) - Pattern syntax that drives Glyphs-section partitioning
+- [Configuration Reference](/settings/) - Format and config options

--- a/site/src/content/docs/cli/commands/transform.md
+++ b/site/src/content/docs/cli/commands/transform.md
@@ -51,5 +51,5 @@ Show detailed output during transformation.
 
 ## See Also
 
-- [transform config](/specs/settings/transform/) — configure which transformers run by default
-- [tokens config](/specs/settings/tokens/) — control how token references are serialized in spec output
+- [transform config](/settings/transform/) — configure which transformers run by default
+- [tokens config](/settings/tokens/) — control how token references are serialized in spec output

--- a/site/src/content/docs/cli/getting-started.md
+++ b/site/src/content/docs/cli/getting-started.md
@@ -72,14 +72,14 @@ FIGMA_TOKEN=your_figma_token_here
 
 To create a token, go to [Figma Settings → Tokens](https://www.figma.com/settings/tokens), click **Create a new token**, and select these scopes: `file_metadata:read`, `file_content:read`, `library_assets:read`, `library_content:read`, and `file_variables:read`.
 
-A **license key** is optional — Specs CLI works at a free tier without one. To unlock Pro features, add `SPECS_LICENSE_KEY` to your `.env` file. See [Licensing](/specs/overview/licensing/) for details.
+A **license key** is optional — Specs CLI works at a free tier without one. To unlock Pro features, add `SPECS_LICENSE_KEY` to your `.env` file. See [Licensing](/overview/licensing/) for details.
 
 ### Other configuration (optional)
 
 The defaults from `specs init` work well for most setups. When you're ready to customize, these options are available in `specs.config.yaml`:
 
 - **`dataDirectory` / `outputDirectory`** — where fetched data is stored and specs are written. Defaults: `./data` and `./specs`.
-- **`config`** — controls output format (JSON/YAML, key casing, token format), processing behavior (variant depth, detail level), and what to include. See [Configuration Reference](/specs/schema/config/).
+- **`config`** — controls output format (JSON/YAML, key casing, token format), processing behavior (variant depth, detail level), and what to include. See [Configuration Reference](/schema/config/).
 - **`output`** — controls file organization: split per component, split by concern, use subfolders. All default to `false`.
 
 ## Step 3: Fetch the Figma file
@@ -110,7 +110,7 @@ Then open the generated manifest (e.g., `data/library.manifest.md`) and adjust t
 | [ ] | Slot utility | 12:5 | COMPONENT | NONE |
 ```
 
-By default, `scan` checks only components marked **Ready for Dev** in Figma. If your file has no Dev Mode status set anywhere, it falls back to including every `COMPONENT_SET` and standalone `COMPONENT`. Re-running `scan` preserves your manual edits and only flips checkboxes when a component's `Dev Status` actually changes — pass `--keep-checks` to preserve them even then. See the [`scan`](/specs/cli/commands/scan/) reference for full merge behavior.
+By default, `scan` checks only components marked **Ready for Dev** in Figma. If your file has no Dev Mode status set anywhere, it falls back to including every `COMPONENT_SET` and standalone `COMPONENT`. Re-running `scan` preserves your manual edits and only flips checkboxes when a component's `Dev Status` actually changes — pass `--keep-checks` to preserve them even then. See the [`scan`](/cli/commands/scan/) reference for full merge behavior.
 
 ## Step 5: Generate specs
 

--- a/site/src/content/docs/cli/index.md
+++ b/site/src/content/docs/cli/index.md
@@ -8,11 +8,11 @@ The Specs command-line interface (CLI) generates design system specifications fr
 
 | Command | Purpose | Output |
 |---------|---------|--------|
-| [`init`](/specs/cli/commands/init/) | Initialize config file with defaults | `specs.config.yaml` |
-| [`fetch`](/specs/cli/commands/fetch/) | Download raw REST payloads from Figma | JSON files in `dataDirectory` |
-| [`scan`](/specs/cli/commands/scan/) | List all components in file | Markdown manifest |
-| [`generate`](/specs/cli/commands/generate/) | Generate specs from a manifest or single component | YAML/JSON spec file(s) |
-| [`applyCustomTokens`](/specs/cli/commands/apply-custom-tokens/) | Inject `$custom` objects into fetched data | Modified variables/styles JSON |
+| [`init`](/cli/commands/init/) | Initialize config file with defaults | `specs.config.yaml` |
+| [`fetch`](/cli/commands/fetch/) | Download raw REST payloads from Figma | JSON files in `dataDirectory` |
+| [`scan`](/cli/commands/scan/) | List all components in file | Markdown manifest |
+| [`generate`](/cli/commands/generate/) | Generate specs from a manifest or single component | YAML/JSON spec file(s) |
+| [`applyCustomTokens`](/cli/commands/apply-custom-tokens/) | Inject `$custom` objects into fetched data | Modified variables/styles JSON |
 
 ### Global Options
 
@@ -35,7 +35,7 @@ With a **Pro license**, specs also include design token references, variable bin
 | Design token references | — | Yes |
 | Variable and visibility bindings | — | Yes |
 
-Set up your license key in your environment to unlock Pro features. See [Getting Started — License](/specs/cli/getting-started/#step-3-set-your-license-key-optional).
+Set up your license key in your environment to unlock Pro features. See [Getting Started — License](/cli/getting-started/#step-3-set-your-license-key-optional).
 
 ## Output Format
 
@@ -95,10 +95,10 @@ data/
   - `variables` / `styles` — Figma restricts these REST endpoints to organizations on an **Enterprise** plan, regardless of your Specs license
 - **License key** (optional) via `SPECS_LICENSE_KEY` for Pro features
 
-See [Getting Started](/specs/cli/getting-started/) for installation instructions.
+See [Getting Started](/cli/getting-started/) for installation instructions.
 
 ## See Also
 
-- [Getting Started](/specs/cli/getting-started/) - Installation, license, and quick start
-- [Workflows](/specs/cli/workflows/) - Real-world usage patterns and CI/CD
-- [Configuration](/specs/settings/) - Config file reference
+- [Getting Started](/cli/getting-started/) - Installation, license, and quick start
+- [Workflows](/cli/workflows/) - Real-world usage patterns and CI/CD
+- [Configuration](/settings/) - Config file reference

--- a/site/src/content/docs/cli/transforms/contract.md
+++ b/site/src/content/docs/cli/transforms/contract.md
@@ -84,11 +84,11 @@ A slot is required (non-optional in `Slots`) only when its rule is `always`. The
 | `whenNotNull` | Present when the named prop is not `null`/`undefined`. |
 | `whenValue` | Present when the named prop equals a specific value. |
 
-`SlotRules` is consumed by the [`react` transformer](/specs/cli/transforms/react/) to gate rendering of the corresponding element. Rules inferred with a caveat (e.g. a controlling prop identified heuristically rather than from an explicit spec binding) carry an inline comment on their `SlotRules` entry.
+`SlotRules` is consumed by the [`react` transformer](/cli/transforms/react/) to gate rendering of the corresponding element. Rules inferred with a caveat (e.g. a controlling prop identified heuristically rather than from an explicit spec binding) carry an inline comment on their `SlotRules` entry.
 
 ## Config
 
-No transformer-specific options. Prop omission for browser-driven states comes from [`config.processing.states`](/specs/settings/states/).
+No transformer-specific options. Prop omission for browser-driven states comes from [`config.processing.states`](/settings/states/).
 
 ```yaml
 config:
@@ -121,12 +121,12 @@ dsActionList/
       Item.contract.ts          ← subcomponent (DsActionListItemProps, DsActionListItemDefaults)
 ```
 
-The parent contract file only includes the parent component's own types — subcomponent types do not appear in it. Configure subcomponent discovery in [`config.processing.subcomponents`](/specs/settings/subcomponents/).
+The parent contract file only includes the parent component's own types — subcomponent types do not appear in it. Configure subcomponent discovery in [`config.processing.subcomponents`](/settings/subcomponents/).
 
 ## See Also
 
-- [Transforms overview](/specs/cli/transforms/)
-- [`processing.states` config](/specs/settings/states/) — classify which props are browser-driven vs consumer-controlled
-- [`css` transformer](/specs/cli/transforms/css/)
-- [`react` transformer](/specs/cli/transforms/react/) — consumes `Slots`/`SlotRules` to gate element rendering
-- [`stories` transformer](/specs/cli/transforms/stories/)
+- [Transforms overview](/cli/transforms/)
+- [`processing.states` config](/settings/states/) — classify which props are browser-driven vs consumer-controlled
+- [`css` transformer](/cli/transforms/css/)
+- [`react` transformer](/cli/transforms/react/) — consumes `Slots`/`SlotRules` to gate element rendering
+- [`stories` transformer](/cli/transforms/stories/)

--- a/site/src/content/docs/cli/transforms/css.md
+++ b/site/src/content/docs/cli/transforms/css.md
@@ -99,7 +99,7 @@ Token references are resolved to CSS `var(--)` based on `config.format.tokens`:
 
 ## Config
 
-No transformer-specific options. Token format comes from `config.format.tokens`. Selector strategy for variant props comes from [`config.processing.states`](/specs/settings/states/).
+No transformer-specific options. Token format comes from `config.format.tokens`. Selector strategy for variant props comes from [`config.processing.states`](/settings/states/).
 
 ```yaml
 config:
@@ -202,12 +202,12 @@ The subcomponent stylesheet follows the same structure as the parent — default
 }
 ```
 
-Subcomponent stylesheets are fully self-contained — elements and variants from the parent component never appear in them. Configure subcomponent discovery in [`config.processing.subcomponents`](/specs/settings/subcomponents/).
+Subcomponent stylesheets are fully self-contained — elements and variants from the parent component never appear in them. Configure subcomponent discovery in [`config.processing.subcomponents`](/settings/subcomponents/).
 
 ## See Also
 
-- [Transforms overview](/specs/cli/transforms/)
-- [`processing.states` config](/specs/settings/states/) — classify variant props as semantic states
-- [`contract` transformer](/specs/cli/transforms/contract/)
-- [`react` transformer](/specs/cli/transforms/react/) — imports this stylesheet into the generated and authored components
-- [tokens config](/specs/settings/tokens/)
+- [Transforms overview](/cli/transforms/)
+- [`processing.states` config](/settings/states/) — classify variant props as semantic states
+- [`contract` transformer](/cli/transforms/contract/)
+- [`react` transformer](/cli/transforms/react/) — imports this stylesheet into the generated and authored components
+- [tokens config](/settings/tokens/)

--- a/site/src/content/docs/cli/transforms/index.md
+++ b/site/src/content/docs/cli/transforms/index.md
@@ -73,10 +73,10 @@ Transformer names can be passed as positional arguments, configured in `specs.co
 
 | Transformer | Output file | What it produces |
 |-------------|-------------|-----------------|
-| [`contract`](/specs/cli/transforms/contract/) | `generated/{Component}.contract.ts` | TypeScript Props interface and defaults constant, plus Slots/SlotRules when `variants.yaml` is present |
-| [`css`](/specs/cli/transforms/css/) | `generated/{Component}.styles.css` | CSS rules per anatomy element, with token vars, variant selectors, and structural presence/stacking fixes |
-| [`react`](/specs/cli/transforms/react/) | `generated/react/{Component}.scaffold.tsx` + seeded `src/react/{Component}.tsx` | A working React component wired to the contract and stylesheet, seeded once into an authored file you own |
-| [`stories`](/specs/cli/transforms/stories/) | `generated/react/{Component}.stories.tsx` | A Storybook CSF page with a story per prop-expressible variant, importing the authored component |
+| [`contract`](/cli/transforms/contract/) | `generated/{Component}.contract.ts` | TypeScript Props interface and defaults constant, plus Slots/SlotRules when `variants.yaml` is present |
+| [`css`](/cli/transforms/css/) | `generated/{Component}.styles.css` | CSS rules per anatomy element, with token vars, variant selectors, and structural presence/stacking fixes |
+| [`react`](/cli/transforms/react/) | `generated/react/{Component}.scaffold.tsx` + seeded `src/react/{Component}.tsx` | A working React component wired to the contract and stylesheet, seeded once into an authored file you own |
+| [`stories`](/cli/transforms/stories/) | `generated/react/{Component}.stories.tsx` | A Storybook CSF page with a story per prop-expressible variant, importing the authored component |
 
 `react` and `stories` both require `variants.yaml` — components without it are skipped with a warning.
 
@@ -109,5 +109,5 @@ config:
 
 ## See Also
 
-- [`transform` command](/specs/cli/commands/transform/) — full CLI reference
-- [transform config](/specs/settings/transform/) — configure default transformers
+- [`transform` command](/cli/commands/transform/) — full CLI reference
+- [transform config](/settings/transform/) — configure default transformers

--- a/site/src/content/docs/cli/transforms/react.md
+++ b/site/src/content/docs/cli/transforms/react.md
@@ -5,7 +5,7 @@ description: "Scaffold a working React component from the spec, then seed an aut
 
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
 
-Emits a functioning React component — BEM markup from the merged layout tree, `data-*` variant attributes, ARIA state attributes, and slot/element rendering gated on the visibility rules from the [`contract` transformer](/specs/cli/transforms/contract/). Also seeds a one-time authored copy of that component into your source tree, which the [`stories` transformer](/specs/cli/transforms/stories/) imports.
+Emits a functioning React component — BEM markup from the merged layout tree, `data-*` variant attributes, ARIA state attributes, and slot/element rendering gated on the visibility rules from the [`contract` transformer](/cli/transforms/contract/). Also seeds a one-time authored copy of that component into your source tree, which the [`stories` transformer](/cli/transforms/stories/) imports.
 
 ## Use When
 
@@ -89,7 +89,7 @@ export function DsAlert(props: DsAlertScaffoldProps) {
 
 ## Rendering Rules
 
-- **Root element** gets the component's kebab-cased class, every variant prop as a `data-*` attribute (boolean props use presence attributes, string/enum props use value attributes), and ARIA attributes for any prop classified in [`config.processing.states`](/specs/settings/states/) whose selector resolves to an `aria-*` attribute.
+- **Root element** gets the component's kebab-cased class, every variant prop as a `data-*` attribute (boolean props use presence attributes, string/enum props use value attributes), and ARIA attributes for any prop classified in [`config.processing.states`](/settings/states/) whose selector resolves to an `aria-*` attribute.
 - **Child elements** get the `__element` BEM suffix, matching the `css` transformer's selectors.
 - **Slot-typed elements** with a `slot` type surface as an additional `React.ReactNode` prop on `{Component}ScaffoldProps` (not in the spec-derived `Props` interface itself), rendered as `{p.slotName}`.
 - **Text elements** bound to a prop render `{p.propName}`; text elements with static spec content render that content verbatim (escaped for JSX).
@@ -114,7 +114,7 @@ Each subcomponent gets its own `generated/react/{Subcomponent}.scaffold.tsx` and
 
 ## See Also
 
-- [Transforms overview](/specs/cli/transforms/)
-- [`contract` transformer](/specs/cli/transforms/contract/) — Props, Slots, and SlotRules consumed here
-- [`css` transformer](/specs/cli/transforms/css/) — stylesheet imported by both the generated and authored component
-- [`stories` transformer](/specs/cli/transforms/stories/) — imports the authored component, not the generated scaffold
+- [Transforms overview](/cli/transforms/)
+- [`contract` transformer](/cli/transforms/contract/) — Props, Slots, and SlotRules consumed here
+- [`css` transformer](/cli/transforms/css/) — stylesheet imported by both the generated and authored component
+- [`stories` transformer](/cli/transforms/stories/) — imports the authored component, not the generated scaffold

--- a/site/src/content/docs/cli/transforms/stories.md
+++ b/site/src/content/docs/cli/transforms/stories.md
@@ -5,7 +5,7 @@ description: "Emit a Storybook CSF page with one story per prop-expressible vari
 
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
 
-Emits a Storybook Component Story Format (CSF) page for each component: a `Default` story plus one story per variant configuration that can be expressed through props. It imports the **authored** component seeded by the [`react` transformer](/specs/cli/transforms/react/), so Storybook always reflects your implementation, not the regenerated reference scaffold.
+Emits a Storybook Component Story Format (CSF) page for each component: a `Default` story plus one story per variant configuration that can be expressed through props. It imports the **authored** component seeded by the [`react` transformer](/cli/transforms/react/), so Storybook always reflects your implementation, not the regenerated reference scaffold.
 
 ## Use When
 
@@ -92,6 +92,6 @@ Each subcomponent gets its own `generated/react/{Subcomponent}.stories.tsx`, imp
 
 ## See Also
 
-- [Transforms overview](/specs/cli/transforms/)
-- [`react` transformer](/specs/cli/transforms/react/) — seeds the authored component these stories import
-- [`contract` transformer](/specs/cli/transforms/contract/) — source of `Defaults` used in story args
+- [Transforms overview](/cli/transforms/)
+- [`react` transformer](/cli/transforms/react/) — seeds the authored component these stories import
+- [`contract` transformer](/cli/transforms/contract/) — source of `Defaults` used in story args

--- a/site/src/content/docs/cli/workflows.md
+++ b/site/src/content/docs/cli/workflows.md
@@ -38,7 +38,7 @@ specs generate data/library.file.json \
   -o specs/button-icon.yaml
 ```
 
-Use `--format json` to output JSON instead of YAML. See [Output configuration](/specs/settings/output/) for all output modes and format options.
+Use `--format json` to output JSON instead of YAML. See [Output configuration](/settings/output/) for all output modes and format options.
 
 ---
 
@@ -95,7 +95,7 @@ specs generate components.md \
   --verbose
 ```
 
-Split output into per-component files, subfolders, or separate API and variant files using [output mode flags](/specs/settings/output/).
+Split output into per-component files, subfolders, or separate API and variant files using [output mode flags](/settings/output/).
 
 ---
 
@@ -245,5 +245,5 @@ git commit -m "manifest: keep DS Tooltip NEW unchecked — pending API redesign"
 
 ## See Also
 
-- [CLI Overview](/specs/cli/) - Commands, Free vs Pro, output format
-- [Settings](/specs/settings/) - Config file reference
+- [CLI Overview](/cli/) - Commands, Free vs Pro, output format
+- [Settings](/settings/) - Config file reference

--- a/site/src/content/docs/guides/absolute-positioning.md
+++ b/site/src/content/docs/guides/absolute-positioning.md
@@ -178,7 +178,7 @@ width: null
 
 ## Variant-by-variant differences
 
-Specs emits all positioning properties on every variant — active keys carry their computed value, inactive keys carry `null`. This ensures [variant layering](/specs/guides/variant-layering) can detect any constraint change between variants: a key that's absent can't be compared.
+Specs emits all positioning properties on every variant — active keys carry their computed value, inactive keys carry `null`. This ensures [variant layering](/guides/variant-layering) can detect any constraint change between variants: a key that's absent can't be compared.
 
 ### Constraint type change: MIN → STRETCH
 

--- a/site/src/content/docs/guides/code-only-props.md
+++ b/site/src/content/docs/guides/code-only-props.md
@@ -114,4 +114,4 @@ The processing engine traverses all descendants of the container recursively, ex
 
 - [Code-Only Props in Figma](https://nathanacurtis.substack.com/p/code-only-props-in-figma) — the Figma convention for encoding developer-facing properties on hidden layers
 - [ADR 027 — Code-Only Props](https://github.com/DirectedEdges/specs/blob/main/adr/027-code-only-props.md) — architecture decision record covering the extraction model and provenance metadata
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/consolidating-props.md
+++ b/site/src/content/docs/guides/consolidating-props.md
@@ -25,7 +25,7 @@ The same pattern appears with icons. An icon element needs:
 1. **Show Icon** (boolean) — toggles the instance layer's visibility
 2. **Icon** (instance swap) — selects which icon to display
 
-Developers think of this as one thing: an icon is either provided or it isn't. When the icon is an instance swap that matches a [glyph name pattern](/specs/guides/glyph-name-pattern/), Specs classifies it as a `glyph` content type — but the two-prop problem remains the same.
+Developers think of this as one thing: an icon is either provided or it isn't. When the icon is an instance swap that matches a [glyph name pattern](/guides/glyph-name-pattern/), Specs classifies it as a `glyph` content type — but the two-prop problem remains the same.
 
 When these prop pairs aren't consolidated, consumers of the spec must manually understand which booleans correspond to which content props and how they interact — duplicating logic that Specs can infer automatically.
 
@@ -105,7 +105,7 @@ The engine recognizes three types of content bindings:
 
 ## Conditional Visibility in Variants
 
-When a pair is active, the element's visibility is no longer a bare `true` or `false`. Instead, the spec expresses it as a [conditional](/specs/schema/conditional/) — a structured expression that says "this element is visible when the prop is not null." This connects the element-level rendering decision back to the prop API.
+When a pair is active, the element's visibility is no longer a bare `true` or `false`. Instead, the spec expresses it as a [conditional](/schema/conditional/) — a structured expression that says "this element is visible when the prop is not null." This connects the element-level rendering decision back to the prop API.
 
 For example, a Button's default variant with a consolidated label and icon:
 
@@ -142,7 +142,7 @@ Rather than requiring consumers to cross-reference `showLabel: true` with a sepa
 
 ## See Also
 
-- [Icon Glyphs guide](/specs/guides/glyph-name-pattern/) — How icon instances are classified as glyphs
-- [Schema: Conditional](/specs/schema/conditional/) — Conditional expression syntax
-- [Schema: Props](/specs/schema/props/) — Prop types and nullability
-- [Schema: Elements](/specs/schema/elements/) — Element visibility bindings
+- [Icon Glyphs guide](/guides/glyph-name-pattern/) — How icon instances are classified as glyphs
+- [Schema: Conditional](/schema/conditional/) — Conditional expression syntax
+- [Schema: Props](/schema/props/) — Prop types and nullability
+- [Schema: Elements](/schema/elements/) — Element visibility bindings

--- a/site/src/content/docs/guides/data-layout.md
+++ b/site/src/content/docs/guides/data-layout.md
@@ -119,4 +119,4 @@ model:
 
 ## See Also
 
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/default-slot-content.md
+++ b/site/src/content/docs/guides/default-slot-content.md
@@ -52,7 +52,7 @@ config:
 **Default**: `false`. Existing output is unchanged until you opt in.
 
 :::note[Pro feature]
-`defaultSlotContent` requires a [Pro license](/specs/overview/licensing/). On the free tier the flag is ignored — no slot content is emitted. In the Figma plugin the control is hidden until a Pro license is active.
+`defaultSlotContent` requires a [Pro license](/overview/licensing/). On the free tier the flag is ignored — no slot content is emitted. In the Figma plugin the control is hidden until a Pro license is active.
 :::
 
 ## Default Slot Content vs. Instance Examples
@@ -60,10 +60,10 @@ config:
 These are two different things, often confused:
 
 - **Default slot content** (this guide) — the content *inside a slot*, captured structurally. No detection config; `defaultSlotContent` is the only switch.
-- **[Instance (ready-made) examples](/specs/guides/instance-examples/)** — whole pre-configured *instances* of a component, detected from named frames via `processing.instanceExamples`.
+- **[Instance (ready-made) examples](/guides/instance-examples/)** — whole pre-configured *instances* of a component, detected from named frames via `processing.instanceExamples`.
 
 ## Further Reading
 
-- [`defaultSlotContent`](/specs/settings/default-slot-content/) — config reference
-- [Instance (Ready-Made) Examples](/specs/guides/instance-examples/) — the sibling feature
-- [Schema: Component](/specs/schema/component/) — the `slotContentExamples` registry shape
+- [`defaultSlotContent`](/settings/default-slot-content/) — config reference
+- [Instance (Ready-Made) Examples](/guides/instance-examples/) — the sibling feature
+- [Schema: Component](/schema/component/) — the `slotContentExamples` registry shape

--- a/site/src/content/docs/guides/glyph-name-pattern.md
+++ b/site/src/content/docs/guides/glyph-name-pattern.md
@@ -154,5 +154,5 @@ This binding is created automatically — no additional configuration needed. It
 
 ## Further Reading
 
-- [CLI Configuration](/specs/settings/) — full config reference
-- [Subcomponent Scoping](/specs/guides/subcomponent-scoping/) — related config for detecting subcomponents (separate from glyph detection)
+- [CLI Configuration](/settings/) — full config reference
+- [Subcomponent Scoping](/guides/subcomponent-scoping/) — related config for detecting subcomponents (separate from glyph detection)

--- a/site/src/content/docs/guides/instance-examples.md
+++ b/site/src/content/docs/guides/instance-examples.md
@@ -34,7 +34,7 @@ instanceExamples:
 
 ## Configuration
 
-Detection mirrors [`subcomponents`](/specs/settings/subcomponents/): the **presence** of `processing.instanceExamples` is the on-switch. There is no separate `include` flag — when the block is present (and the license is Pro), examples are detected *and* emitted.
+Detection mirrors [`subcomponents`](/settings/subcomponents/): the **presence** of `processing.instanceExamples` is the on-switch. There is no separate `include` flag — when the block is present (and the license is Pro), examples are detected *and* emitted.
 
 ```yaml
 # specs.config.yaml
@@ -54,7 +54,7 @@ config:
 - `scope` — `PAGE` (component's page) or `FILE` (all pages, e.g. a dedicated Examples page).
 
 :::note[Pro feature]
-Instance examples require a [Pro license](/specs/overview/licensing/). On the free tier `processing.instanceExamples` is ignored — no detection, no output. In the Figma plugin the control is hidden until a Pro license is active.
+Instance examples require a [Pro license](/overview/licensing/). On the free tier `processing.instanceExamples` is ignored — no detection, no output. In the Figma plugin the control is hidden until a Pro license is active.
 :::
 
 ## Naming Tips
@@ -64,11 +64,11 @@ Instance examples require a [Pro license](/specs/overview/licensing/). On the fr
 ## Instance Examples vs. Default Slot Content
 
 - **Instance examples** (this guide) — whole pre-configured *instances*, detected from named frames.
-- **[Default slot content](/specs/guides/default-slot-content/)** — the content *inside a slot*, captured structurally with no detection config.
+- **[Default slot content](/guides/default-slot-content/)** — the content *inside a slot*, captured structurally with no detection config.
 
 ## Further Reading
 
-- [`processing.instanceExamples`](/specs/settings/instance-examples/) — config reference
-- [Default Slot Content](/specs/guides/default-slot-content/) — the sibling feature
-- [`subcomponents`](/specs/settings/subcomponents/) — the presence-driven detection model this mirrors
-- [Schema: Component](/specs/schema/component/) — the `instanceExamples` registry shape
+- [`processing.instanceExamples`](/settings/instance-examples/) — config reference
+- [Default Slot Content](/guides/default-slot-content/) — the sibling feature
+- [`subcomponents`](/settings/subcomponents/) — the presence-driven detection model this mirrors
+- [Schema: Component](/schema/component/) — the `instanceExamples` registry shape

--- a/site/src/content/docs/guides/invalid-variant-combinations.md
+++ b/site/src/content/docs/guides/invalid-variant-combinations.md
@@ -132,8 +132,8 @@ When `true`, the component output includes the `invalidVariantCombinations` fiel
 
 ## See Also
 
-- [Variant Layering](/specs/guides/variant-layering/) — how variants accumulate properties
-- [Variant Depth](/specs/guides/variant-depth/) — controlling variant expansion depth
-- [Variants](/specs/schema/variants/) — variant schema reference
-- [Component](/specs/schema/component/) — top-level component schema
-- [Config](/specs/schema/config/) — full configuration options
+- [Variant Layering](/guides/variant-layering/) — how variants accumulate properties
+- [Variant Depth](/guides/variant-depth/) — controlling variant expansion depth
+- [Variants](/schema/variants/) — variant schema reference
+- [Component](/schema/component/) — top-level component schema
+- [Config](/schema/config/) — full configuration options

--- a/site/src/content/docs/guides/key-formatting.md
+++ b/site/src/content/docs/guides/key-formatting.md
@@ -97,4 +97,4 @@ model:
 
 ## See Also
 
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/number-inference.md
+++ b/site/src/content/docs/guides/number-inference.md
@@ -89,4 +89,4 @@ Number inference follows the same pattern as boolean inference, which already ex
 ## Further Reading
 
 - [ADR 029 — NumberProp](https://github.com/DirectedEdges/specs/blob/main/adr/029-number-prop.md) — architecture decision record covering the `NumberProp` type, inference guard rules, and known false positives
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/slot-constraints.md
+++ b/site/src/content/docs/guides/slot-constraints.md
@@ -86,4 +86,4 @@ The field names `minChildren`/`maxChildren` align with Figma's native `slotSetti
 
 - [Code-Only Props in Figma](https://nathanacurtis.substack.com/p/code-only-props-in-figma) — the convention for encoding developer-facing properties on Figma layers
 - [Figma Slots for Repeating Items](https://nathanacurtis.substack.com/p/figma-slots-for-repeating-items) — design patterns for slots with quantity and content-type constraints
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/subcomponent-scoping.md
+++ b/site/src/content/docs/guides/subcomponent-scoping.md
@@ -136,4 +136,4 @@ subcomponents:
 ## Further Reading
 
 - [ADR 031 — Subcomponent Search Scope](https://github.com/DirectedEdges/specs/blob/main/adr/031-subcomponent-search-scope.md) — architecture decision record covering the `scope`, `match`, and `exclude` design
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/variant-depth.md
+++ b/site/src/content/docs/guides/variant-depth.md
@@ -82,4 +82,4 @@ model:
 
 ## See Also
 
-- [CLI Configuration](/specs/settings/) — full config reference
+- [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/guides/variant-layering.md
+++ b/site/src/content/docs/guides/variant-layering.md
@@ -473,13 +473,13 @@ Controls whether variant output uses layering:
 
 ### `Config.processing.variantDepth`
 
-Controls how many prop dimensions are expanded. See the [Variant Depth](/specs/guides/variant-depth/) guide.
+Controls how many prop dimensions are expanded. See the [Variant Depth](/guides/variant-depth/) guide.
 
 ---
 
 ## See Also
 
-- [Variant Depth](/specs/guides/variant-depth/) — controlling variant expansion depth
-- [Variant type](/specs/../packages/schema/types/Variant.ts/) — schema definition
-- [Config type](/specs/../packages/schema/types/Config.ts/) — full configuration options
-- [component.schema.json](/specs/../packages/schema/schema/component.schema.json/) — JSON Schema validation rules
+- [Variant Depth](/guides/variant-depth/) — controlling variant expansion depth
+- [Variant type](/../packages/schema/types/Variant.ts/) — schema definition
+- [Config type](/../packages/schema/types/Config.ts/) — full configuration options
+- [component.schema.json](/../packages/schema/schema/component.schema.json/) — JSON Schema validation rules

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -11,15 +11,15 @@ hero:
       variant: primary
       icon: right-arrow
     - text: Set up the CLI
-      link: /specs/cli/getting-started/
+      link: /cli/getting-started/
       variant: primary
       icon: right-arrow
     - text: Explore the schema
-      link: /specs/schema/
+      link: /schema/
       variant: minimal
       icon: right-arrow
     - text: Licensing
-      link: /specs/overview/licensing/
+      link: /overview/licensing/
       variant: minimal
       icon: right-arrow
 head:
@@ -71,15 +71,15 @@ A single spec records everything in Figma about a component, deterministic and c
 
 <div class="feature-grid">
 <CardGrid>
-<LinkCard title="Anatomy" href="/specs/schema/anatomy/" description="Every element by type, structured consistently across variants" />
-<LinkCard title="Props" href="/specs/schema/props/" description="All properties with every explicit per-variant difference detected" />
-<LinkCard title="Styling" href="/specs/schema/styles/" description="Token references, named styles, typography, and effects" />
-<LinkCard title="Layout" href="/specs/schema/layout/" description="Element hierarchy and flex vs. absolute positioning per variant" />
-<LinkCard title="Bindings" href="/specs/schema/prop-binding/" description="Prop bindings driving content, instances, and conditionals" />
-<LinkCard title="Subcomponents" href="/specs/schema/subcomponents/" description="Subcomponents discovered from your naming conventions" />
-<LinkCard title="Slots" href="/specs/schema/slot-content/" description="Where nested content composes and its per-variant defaults" />
-<LinkCard title="Ready-made examples" href="/specs/schema/instance-examples/" description="Pre-configured usage examples detected straight from your file" />
-<LinkCard title="Assets" href="/specs/guides/glyph-name-pattern/" description="Icon glyphs precisely distinguished from nested instances" />
+<LinkCard title="Anatomy" href="/schema/anatomy/" description="Every element by type, structured consistently across variants" />
+<LinkCard title="Props" href="/schema/props/" description="All properties with every explicit per-variant difference detected" />
+<LinkCard title="Styling" href="/schema/styles/" description="Token references, named styles, typography, and effects" />
+<LinkCard title="Layout" href="/schema/layout/" description="Element hierarchy and flex vs. absolute positioning per variant" />
+<LinkCard title="Bindings" href="/schema/prop-binding/" description="Prop bindings driving content, instances, and conditionals" />
+<LinkCard title="Subcomponents" href="/schema/subcomponents/" description="Subcomponents discovered from your naming conventions" />
+<LinkCard title="Slots" href="/schema/slot-content/" description="Where nested content composes and its per-variant defaults" />
+<LinkCard title="Ready-made examples" href="/schema/instance-examples/" description="Pre-configured usage examples detected straight from your file" />
+<LinkCard title="Assets" href="/guides/glyph-name-pattern/" description="Icon glyphs precisely distinguished from nested instances" />
 </CardGrid>
 </div>
 
@@ -89,17 +89,17 @@ Blend determinism with adaptability to generate specs based on how your system w
 
 <div class="guide-gallery">
 <CardGrid>
-<LinkCard title="Variant Layering" href="/specs/guides/variant-layering/" description="Compute layered styling like CSS rules" />
-<LinkCard title="Variant Depth" href="/specs/guides/variant-depth/" description="Control how many variant dimensions expand" />
-<LinkCard title="Data Layout" href="/specs/guides/data-layout/" description="Shape how hierarchy appears in output" />
-<LinkCard title="Consolidating Props" href="/specs/guides/consolidating-props/" description="Merge a toggle and its content into one prop" />
-<LinkCard title="Code-Only Props" href="/specs/guides/code-only-props/" description="Pull non-visual props from hidden layers" />
-<LinkCard title="Instance Examples" href="/specs/guides/instance-examples/" description="Detect ready-made, pre-configured usages" />
-<LinkCard title="Default Slot Content" href="/specs/guides/default-slot-content/" description="Reuse default slot content as examples" />
-<LinkCard title="Slot Constraints" href="/specs/guides/slot-constraints/" description="Set quantity and content-type slot rules" />
-<LinkCard title="Subcomponent Scoping" href="/specs/guides/subcomponent-scoping/" description="Discover, match, and exclude subcomponents" />
-<LinkCard title="Invalid Variant Combinations" href="/specs/guides/invalid-variant-combinations/" description="Mark unsupported variant combinations" />
-<LinkCard title="Key Formatting" href="/specs/guides/key-formatting/" description="Normalize property and element names" />
-<LinkCard title="Layout Positioning" href="/specs/guides/layout-positioning/" description="Map Figma constraints to positioning" />
+<LinkCard title="Variant Layering" href="/guides/variant-layering/" description="Compute layered styling like CSS rules" />
+<LinkCard title="Variant Depth" href="/guides/variant-depth/" description="Control how many variant dimensions expand" />
+<LinkCard title="Data Layout" href="/guides/data-layout/" description="Shape how hierarchy appears in output" />
+<LinkCard title="Consolidating Props" href="/guides/consolidating-props/" description="Merge a toggle and its content into one prop" />
+<LinkCard title="Code-Only Props" href="/guides/code-only-props/" description="Pull non-visual props from hidden layers" />
+<LinkCard title="Instance Examples" href="/guides/instance-examples/" description="Detect ready-made, pre-configured usages" />
+<LinkCard title="Default Slot Content" href="/guides/default-slot-content/" description="Reuse default slot content as examples" />
+<LinkCard title="Slot Constraints" href="/guides/slot-constraints/" description="Set quantity and content-type slot rules" />
+<LinkCard title="Subcomponent Scoping" href="/guides/subcomponent-scoping/" description="Discover, match, and exclude subcomponents" />
+<LinkCard title="Invalid Variant Combinations" href="/guides/invalid-variant-combinations/" description="Mark unsupported variant combinations" />
+<LinkCard title="Key Formatting" href="/guides/key-formatting/" description="Normalize property and element names" />
+<LinkCard title="Layout Positioning" href="/guides/layout-positioning/" description="Map Figma constraints to positioning" />
 </CardGrid>
 </div>

--- a/site/src/content/docs/overview/aboutspecs.md
+++ b/site/src/content/docs/overview/aboutspecs.md
@@ -35,9 +35,9 @@ This matters practically because structured specs become the primary input for d
 
 ## How It Works
 
-Specs runs in two environments, both powered by the same processing engine ([`@directededges/specs-from-figma`](/specs/)):
+Specs runs in two environments, both powered by the same processing engine ([`@directededges/specs-from-figma`](/)):
 
-- **CLI** — The [`specs` command line tool](/specs/cli/) fetches component data via Figma's REST API, then generates specs locally. Best for batch processing entire libraries, CI integration, and version-controlled output.
+- **CLI** — The [`specs` command line tool](/cli/) fetches component data via Figma's REST API, then generates specs locally. Best for batch processing entire libraries, CI integration, and version-controlled output.
 - **Figma Plugin** — Runs inside Figma using the Plugin API for real-time, single-component generation during design work.
 
 Both produce identical output from the same input. The difference is context: the CLI operates on cached file data for efficiency at scale, while the plugin provides immediate feedback during design iteration.

--- a/site/src/content/docs/overview/licensing.md
+++ b/site/src/content/docs/overview/licensing.md
@@ -146,12 +146,12 @@ elements:
 
 Pro features are never stripped from output — they're simply not created at the free tier. If a style property has a bound Figma variable, free-tier output shows the raw resolved value; pro-tier output shows the token reference alongside the value.
 
-> **Note**: Token references require that your source config includes `variables` in the `data` array. Style references require `styles`. See [Configuration](/specs/settings/) for details.
+> **Note**: Token references require that your source config includes `variables` in the `data` array. Style references require `styles`. See [Configuration](/settings/) for details.
 
 :::caution[Fetching variables and styles requires a Figma Enterprise plan]
 A Specs Pro license controls whether **already-fetched** variable and style data gets turned into token references and style references — it does not control whether that data can be fetched from Figma in the first place.
 
-Figma's REST API restricts the `variables` and `styles` endpoints to organizations on an **Enterprise** plan, regardless of your Specs license. If your Figma organization isn't on Enterprise, `specs fetch` can still fetch `file` data, but `variables` and `styles` fetches will fail — so a Pro license alone won't produce design token references or named style references. This restriction is specific to the CLI's REST-based `fetch`; it doesn't apply to the Figma Plugin, which reads variables and styles directly from the open file via Figma's Plugin API. See [CLI Requirements](/specs/cli/#requirements) for details.
+Figma's REST API restricts the `variables` and `styles` endpoints to organizations on an **Enterprise** plan, regardless of your Specs license. If your Figma organization isn't on Enterprise, `specs fetch` can still fetch `file` data, but `variables` and `styles` fetches will fail — so a Pro license alone won't produce design token references or named style references. This restriction is specific to the CLI's REST-based `fetch`; it doesn't apply to the Figma Plugin, which reads variables and styles directly from the open file via Figma's Plugin API. See [CLI Requirements](/cli/#requirements) for details.
 :::
 
 ### Config Settings and Licensing
@@ -254,6 +254,6 @@ License terms depend on your plan, but generally, no. Each Pro license is intend
 
 ## See Also
 
-- [Getting Started](/specs/overview/cli/getting-started/) — Installation and first spec
-- [Configuration Reference](/specs/settings/) — All config options
-- [Config Schema](/specs/overview/schema/config/) — Config type reference and defaults
+- [Getting Started](/overview/cli/getting-started/) — Installation and first spec
+- [Configuration Reference](/settings/) — All config options
+- [Config Schema](/overview/schema/config/) — Config type reference and defaults

--- a/site/src/content/docs/plugin/anatomy.mdx
+++ b/site/src/content/docs/plugin/anatomy.mdx
@@ -29,10 +29,10 @@ Additional variant exhibits are included whenever a new, uniquely named layer is
 
 ## Related Settings
 
-- **[Variant Depth](/specs/settings/variant-depth/)** — More depth means more variant exhibits to check for revealed elements
-- **[Glyph Name Pattern](/specs/settings/glyph-name-pattern/)** — Matched icon layers get typed as glyphs with resolved names
-- **[Subcomponents](/specs/settings/subcomponents/)** — Discovered subcomponents get their own separate Anatomy exhibits
-- **[Collapse Primitive Wrapper](/specs/settings/collapse-primitive-wrapper/)** — Strips wrapper containers, changing the root element markers
+- **[Variant Depth](/settings/variant-depth/)** — More depth means more variant exhibits to check for revealed elements
+- **[Glyph Name Pattern](/settings/glyph-name-pattern/)** — Matched icon layers get typed as glyphs with resolved names
+- **[Subcomponents](/settings/subcomponents/)** — Discovered subcomponents get their own separate Anatomy exhibits
+- **[Collapse Primitive Wrapper](/settings/collapse-primitive-wrapper/)** — Strips wrapper containers, changing the root element markers
 
 ## Examples
 

--- a/site/src/content/docs/plugin/color.mdx
+++ b/site/src/content/docs/plugin/color.mdx
@@ -32,4 +32,4 @@ Each variable carries independently editable Light and Dark values, directly in 
 
 <Figure src={darkModeCollectionModes} alt="The Specs collection's Variables panel, listing color roles like Icon stroke, Style fill, Style text, Variable fill, Token fill, and Dependency text, each with separately editable Light and Dark hex values" caption="The Specs collection's Variables panel: every color role — icon stroke, style and variable fill/stroke/text, raw value text, token fill/text, dependency fill/stroke/text — carries independently editable Light and Dark values." maxWidth="none" />
 
-Once Color is enabled, the collection's Light/Dark modes can be toggled directly in Figma — see [Dark Mode](/specs/plugin/dark-mode/) for how.
+Once Color is enabled, the collection's Light/Dark modes can be toggled directly in Figma — see [Dark Mode](/plugin/dark-mode/) for how.

--- a/site/src/content/docs/plugin/dark-mode.mdx
+++ b/site/src/content/docs/plugin/dark-mode.mdx
@@ -10,7 +10,7 @@ import colorModeHero from '../../../assets/plugin/ColorMode.png';
 import darkModeCollectionModes from '../../../assets/plugin/DarkModeCollectionModes.png';
 import customStyling from '../../../assets/plugin/CustomStyling.png';
 
-Once [Color](/specs/plugin/color/) is enabled, the `Specs` variable collection carries both a Light and a Dark value for every color. Dark Mode is the act of switching which mode is active — at the whole-page level, a single Specification, or one artwork frame at a time — using Figma's own mode switcher, with no need to regenerate anything.
+Once [Color](/plugin/color/) is enabled, the `Specs` variable collection carries both a Light and a Dark value for every color. Dark Mode is the act of switching which mode is active — at the whole-page level, a single Specification, or one artwork frame at a time — using Figma's own mode switcher, with no need to regenerate anything.
 
 <Figure src={colorModeHero} alt="A Props section shown twice side by side — the same spec in Light mode on the left and Dark mode on the right" maxWidth="none" />
 

--- a/site/src/content/docs/plugin/data.mdx
+++ b/site/src/content/docs/plugin/data.mdx
@@ -19,7 +19,7 @@ The Data section provides the component's full spec as a single block of text, i
 
 ## Related Settings
 
-- **[Output Format](/specs/settings/output-format/)** — Chooses `YAML` or `JSON` for the block
-- **[Keys](/specs/settings/keys/)** — Renames keys, such as `camelCase` or `snake_case`
-- **[Variant Depth](/specs/settings/variant-depth/)** — More depth means more variant entries
-- **[Details](/specs/settings/details/)** — `LAYERED` vs `FULL` changes how much gets captured
+- **[Output Format](/settings/output-format/)** — Chooses `YAML` or `JSON` for the block
+- **[Keys](/settings/keys/)** — Renames keys, such as `camelCase` or `snake_case`
+- **[Variant Depth](/settings/variant-depth/)** — More depth means more variant entries
+- **[Details](/settings/details/)** — `LAYERED` vs `FULL` changes how much gets captured

--- a/site/src/content/docs/plugin/index.mdx
+++ b/site/src/content/docs/plugin/index.mdx
@@ -11,7 +11,7 @@ hero:
       variant: primary
       icon: external
     - text: Explore Settings
-      link: /specs/settings/
+      link: /settings/
       variant: minimal
       icon: right-arrow
     - text: Buy Pro license
@@ -41,12 +41,12 @@ import pluginSettings from '../../../assets/plugin/PluginSettings.png';
 Generate a complete picture of the component, in exhaustive visual detail
 
 <div class="preview-grid preview-grid--3col">
-<PreviewCard href="/specs/plugin/anatomy/" title="Anatomy" description="Numbered markers annotate every element, with key attributes listed alongside" image={cardAnatomy} imageAlt="Numbered markers over a component's artwork" />
-<PreviewCard href="/specs/plugin/props/" title="Props" description="Every property, its options, and exactly what changes on the canvas when it's set" image={cardProps} imageAlt="A Success appearance exhibit with its property attributes listed" />
-<PreviewCard href="/specs/plugin/layout/" title="Layout" description="Direction, alignment, resizing, padding, and spacing annotated directly on the artwork" image={cardLayout} imageAlt="Direction, padding, and item-spacing markers over a component's artwork" />
-<PreviewCard href="/specs/plugin/modes/" title="Modes" description="Side-by-side exhibits for every light/dark or other variable mode the component uses" image={cardModes} imageAlt="Three corner-radius mode exhibits shown side by side" />
-<PreviewCard href="/specs/plugin/styling/" title="Styling" description="Every detected variable and style, what role it plays, and where it's applied" image={cardStyling} imageAlt="A Variables table listing token names, applied roles, and raw values" />
-<PreviewCard href="/specs/plugin/data/" title="Data" description="The same spec as structured YAML or JSON — a ready-made contract for AI/LLM tools" image={cardData} imageAlt="A YAML text block of a component's serialized spec" />
+<PreviewCard href="/plugin/anatomy/" title="Anatomy" description="Numbered markers annotate every element, with key attributes listed alongside" image={cardAnatomy} imageAlt="Numbered markers over a component's artwork" />
+<PreviewCard href="/plugin/props/" title="Props" description="Every property, its options, and exactly what changes on the canvas when it's set" image={cardProps} imageAlt="A Success appearance exhibit with its property attributes listed" />
+<PreviewCard href="/plugin/layout/" title="Layout" description="Direction, alignment, resizing, padding, and spacing annotated directly on the artwork" image={cardLayout} imageAlt="Direction, padding, and item-spacing markers over a component's artwork" />
+<PreviewCard href="/plugin/modes/" title="Modes" description="Side-by-side exhibits for every light/dark or other variable mode the component uses" image={cardModes} imageAlt="Three corner-radius mode exhibits shown side by side" />
+<PreviewCard href="/plugin/styling/" title="Styling" description="Every detected variable and style, what role it plays, and where it's applied" image={cardStyling} imageAlt="A Variables table listing token names, applied roles, and raw values" />
+<PreviewCard href="/plugin/data/" title="Data" description="The same spec as structured YAML or JSON — a ready-made contract for AI/LLM tools" image={cardData} imageAlt="A YAML text block of a component's serialized spec" />
 </div>
 
 ## Format it to match your system
@@ -54,13 +54,13 @@ Generate a complete picture of the component, in exhaustive visual detail
 Reshape the spec styling — not just what it contains, but how it looks
 
 <div class="preview-grid preview-grid--4col">
-<LinkCard href="/specs/plugin/color/" title="Color" description="Bind specs to variables that alias to your library" />
-<LinkCard href="/specs/plugin/dark-mode/" title="Dark Mode" description="Show specs in Light and Dark mode at any level" />
-<LinkCard href="/specs/plugin/spacing/" title="Spacing" description="Customize spec spacing to use your variables" />
-<LinkCard href="/specs/plugin/text/" title="Text" description="Apply text styles so output matches your typography" />
+<LinkCard href="/plugin/color/" title="Color" description="Bind specs to variables that alias to your library" />
+<LinkCard href="/plugin/dark-mode/" title="Dark Mode" description="Show specs in Light and Dark mode at any level" />
+<LinkCard href="/plugin/spacing/" title="Spacing" description="Customize spec spacing to use your variables" />
+<LinkCard href="/plugin/text/" title="Text" description="Apply text styles so output matches your typography" />
 </div>
 
-<p style="margin-top: 4rem">Also, <a href="/specs/plugin/multi-column-layout/">Multi-Column Layout</a> reshapes how a spec's exhibits are arranged — tiling them into a 2, 3, or 4-column grid instead of one long column — so a spec reads well whether it's a quick one-off or a dense reference sheet.</p>
+<p style="margin-top: 4rem">Also, <a href="/plugin/multi-column-layout/">Multi-Column Layout</a> reshapes how a spec's exhibits are arranged — tiling them into a 2, 3, or 4-column grid instead of one long column — so a spec reads well whether it's a quick one-off or a dense reference sheet.</p>
 
 <Figure src={homeMultiColumn} alt="The same Alert component's Appearance section shown in 1, 2, and 3-column layouts side by side" maxWidth="none" />
 
@@ -72,11 +72,11 @@ Set specs to match how you name and model components and systems in Figma
 
 Settings go beyond how elements are detected — they cover every stage, from what counts as a match to how the resulting data itself is formatted.
 
-- **Format**: [Tokens](/specs/settings/tokens/), [color values](/specs/settings/color/), [data format](/specs/settings/output-format/), [key values](/specs/settings/keys/)
-- **Variants**: [variant depth](/specs/settings/variant-depth/), [empty variants](/specs/settings/empty-variants/), [invalid variants](/specs/settings/invalid-variants/), [invalid combinations](/specs/settings/invalid-combinations/)
-- **Elements**: [icon glyphs](/specs/settings/glyph-name-pattern/), [subcomponents](/specs/settings/subcomponents/), [collapsed wrappers](/specs/settings/collapse-primitive-wrapper/), [default slot content](/specs/settings/default-slot-content/), [instance examples](/specs/settings/instance-examples/)
-- **Props**: [code-only props](/specs/settings/code-only-props-pattern/), [slot constraints](/specs/settings/slot-constraints/), [inferred number props](/specs/settings/infer-number-props/)
-- **Layout**: [layout representation](/specs/settings/layout/)
+- **Format**: [Tokens](/settings/tokens/), [color values](/settings/color/), [data format](/settings/output-format/), [key values](/settings/keys/)
+- **Variants**: [variant depth](/settings/variant-depth/), [empty variants](/settings/empty-variants/), [invalid variants](/settings/invalid-variants/), [invalid combinations](/settings/invalid-combinations/)
+- **Elements**: [icon glyphs](/settings/glyph-name-pattern/), [subcomponents](/settings/subcomponents/), [collapsed wrappers](/settings/collapse-primitive-wrapper/), [default slot content](/settings/default-slot-content/), [instance examples](/settings/instance-examples/)
+- **Props**: [code-only props](/settings/code-only-props-pattern/), [slot constraints](/settings/slot-constraints/), [inferred number props](/settings/infer-number-props/)
+- **Layout**: [layout representation](/settings/layout/)
 
 ## Deliver data into agentic workflows
 

--- a/site/src/content/docs/plugin/layout.mdx
+++ b/site/src/content/docs/plugin/layout.mdx
@@ -29,9 +29,9 @@ Additional container exhibits are included for each nested, non-instance auto-la
 
 ## Related Settings
 
-- **[Variant Depth](/specs/settings/variant-depth/)** — Controls how many per-variant layout subsections appear
-- **[Details](/specs/settings/details/)** — `LAYERED` shows only changed values per variant; `FULL` repeats everything
-- **[Collapse Primitive Wrapper](/specs/settings/collapse-primitive-wrapper/)** — Removes the wrapper container's own layout exhibit
+- **[Variant Depth](/settings/variant-depth/)** — Controls how many per-variant layout subsections appear
+- **[Details](/settings/details/)** — `LAYERED` shows only changed values per variant; `FULL` repeats everything
+- **[Collapse Primitive Wrapper](/settings/collapse-primitive-wrapper/)** — Removes the wrapper container's own layout exhibit
 
 ## Examples
 

--- a/site/src/content/docs/plugin/props.mdx
+++ b/site/src/content/docs/plugin/props.mdx
@@ -34,12 +34,12 @@ Boolean and slot props tile into a shared "Additional properties" grid, one labe
 
 ## Related Settings
 
-- **[Details](/specs/settings/details/)** — FULL renders only the properties table; LAYERED adds variant exhibits
-- **[Variant Depth](/specs/settings/variant-depth/)** — Limits how many variant property dimensions get their own subsection
-- **[Invalid Variants](/specs/settings/invalid-variants/)** — Includes otherwise-invalid options as placeholder exhibits per property
-- **[Invalid Combinations](/specs/settings/invalid-combinations/)** — Determines which multi-prop states appear in Additional variants
-- **[Empty Variants](/specs/settings/empty-variants/)** — Includes variant exhibits that show no differing elements
-- **[Code-Only Props Pattern](/specs/settings/code-only-props-pattern/)** — Adds hidden behavioral props as rows in the properties table
+- **[Details](/settings/details/)** — FULL renders only the properties table; LAYERED adds variant exhibits
+- **[Variant Depth](/settings/variant-depth/)** — Limits how many variant property dimensions get their own subsection
+- **[Invalid Variants](/settings/invalid-variants/)** — Includes otherwise-invalid options as placeholder exhibits per property
+- **[Invalid Combinations](/settings/invalid-combinations/)** — Determines which multi-prop states appear in Additional variants
+- **[Empty Variants](/settings/empty-variants/)** — Includes variant exhibits that show no differing elements
+- **[Code-Only Props Pattern](/settings/code-only-props-pattern/)** — Adds hidden behavioral props as rows in the properties table
 
 ## Examples
 

--- a/site/src/content/docs/plugin/styling.mdx
+++ b/site/src/content/docs/plugin/styling.mdx
@@ -28,8 +28,8 @@ Per table, each row includes:
 
 ## Related Settings
 
-- **[Tokens](/specs/settings/tokens/)** — Switches variable pills to a platform's code syntax name
-- **[Color](/specs/settings/color/)** — Formats resolved raw color values, e.g. hex vs RGB
+- **[Tokens](/settings/tokens/)** — Switches variable pills to a platform's code syntax name
+- **[Color](/settings/color/)** — Formats resolved raw color values, e.g. hex vs RGB
 
 ## Examples
 

--- a/site/src/content/docs/schema/anatomy.md
+++ b/site/src/content/docs/schema/anatomy.md
@@ -53,7 +53,7 @@ type SubcomponentRef = { $ref: string };
 // e.g. { $ref: "#/subcomponents/formLabel" }
 ```
 
-Within variants, each element's runtime properties (children, styles, content) are described by the [`Element`](/specs/schema/elements/) type. The element tree can also be expressed as a recursive [`Layout`](/specs/schema/layout/).
+Within variants, each element's runtime properties (children, styles, content) are described by the [`Element`](/schema/elements/) type. The element tree can also be expressed as a recursive [`Layout`](/schema/layout/).
 
 ## Further Reading
 

--- a/site/src/content/docs/schema/children.md
+++ b/site/src/content/docs/schema/children.md
@@ -13,7 +13,7 @@ interface SlotBinding extends PropBinding {
 }
 ```
 
-Because `SlotBinding extends` [`PropBinding`](/specs/schema/prop-binding/), existing `{ $binding }` values still validate — the slot variant simply adds an optional `examples` array.
+Because `SlotBinding extends` [`PropBinding`](/schema/prop-binding/), existing `{ $binding }` values still validate — the slot variant simply adds an optional `examples` array.
 
 ## `string[]`
 
@@ -27,14 +27,14 @@ children:
 
 ## `SlotBinding`
 
-When an element's children are driven by a slot prop, `children` is a [`PropBinding`](/specs/schema/prop-binding/) (a `$binding` JSON Pointer to the slot prop) optionally carrying authored example fills.
+When an element's children are driven by a slot prop, `children` is a [`PropBinding`](/schema/prop-binding/) (a `$binding` JSON Pointer to the slot prop) optionally carrying authored example fills.
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `$binding` | `string` | Yes | JSON Pointer to the slot prop (e.g. `#/props/children`) |
-| `examples` | [`SlotContentRef[]`](/specs/schema/slot-content-ref/) | No | Authored example fills for the slot |
+| `examples` | [`SlotContentRef[]`](/schema/slot-content-ref/) | No | Authored example fills for the slot |
 
-Each `examples[i]` is a [`SlotContentRef`](/specs/schema/slot-content-ref/) pointing into a [`slotContentExamples`](/specs/schema/slot-content/) registry or a [`Composition`](/specs/schema/composition/). Emitters currently write at most one entry — `examples[0]` is Figma's authoring default for the slot layer — but the array shape leaves room for more.
+Each `examples[i]` is a [`SlotContentRef`](/schema/slot-content-ref/) pointing into a [`slotContentExamples`](/schema/slot-content/) registry or a [`Composition`](/schema/composition/). Emitters currently write at most one entry — `examples[0]` is Figma's authoring default for the slot layer — but the array shape leaves room for more.
 
 ```yaml
 children:
@@ -48,4 +48,4 @@ children:
 ## Further Reading
 
 - [ADR 046 — Slots and Slot References](https://github.com/DirectedEdges/specs/blob/main/adr/046-slots-and-slot-references.md)
-- [defaultSlotContent (config)](/specs/settings/default-slot-content/) — emit captured default fills into `examples`
+- [defaultSlotContent (config)](/settings/default-slot-content/) — emit captured default fills into `examples`

--- a/site/src/content/docs/schema/component.md
+++ b/site/src/content/docs/schema/component.md
@@ -10,22 +10,22 @@ The `Component` type is the root object of every spec. It contains the component
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `title` | `string` | Yes | Component name |
-| `anatomy` | [`Anatomy`](/specs/schema/anatomy/) | Yes | Map of named elements that make up the component |
-| `props` | [`Props`](/specs/schema/props/) | No | Configurable input properties |
-| `default` | [`Variant`](/specs/schema/variants.md/#variant) | Yes | Default variant — the baseline appearance |
+| `anatomy` | [`Anatomy`](/schema/anatomy/) | Yes | Map of named elements that make up the component |
+| `props` | [`Props`](/schema/props/) | No | Configurable input properties |
+| `default` | [`Variant`](/schema/variants.md/#variant) | Yes | Default variant — the baseline appearance |
 | `variants` | [`Variant[]`](variants.md) | No | Layered variant overrides |
 | `invalidVariantCombinations` | [`PropConfigurations[]`](prop-configurations.md) | No | Prop combinations that are not valid together |
-| `subcomponents` | [`Subcomponents`](/specs/schema/subcomponents/) | No | Embedded child component definitions |
-| `metadata` | [`Metadata`](/specs/schema/metadata/) | No | Generation metadata (author, schema version, config) |
-| `instanceExamples` | [`InstanceExamples`](/specs/schema/instance-examples/) | No | **Pro.** Documented whole-component usage examples (emitted only with a Pro license) |
-| `slotContentExamples` | `Record<string, `[`SlotContent`](/specs/schema/slot-content/)`>` | No | **Pro.** Named slot-content fills, referenced by [`SlotContentRef`](/specs/schema/slot-content-ref/) from slot bindings and from `Element.propConfigurations` slot-prop entries |
+| `subcomponents` | [`Subcomponents`](/schema/subcomponents/) | No | Embedded child component definitions |
+| `metadata` | [`Metadata`](/schema/metadata/) | No | Generation metadata (author, schema version, config) |
+| `instanceExamples` | [`InstanceExamples`](/schema/instance-examples/) | No | **Pro.** Documented whole-component usage examples (emitted only with a Pro license) |
+| `slotContentExamples` | `Record<string, `[`SlotContent`](/schema/slot-content/)`>` | No | **Pro.** Named slot-content fills, referenced by [`SlotContentRef`](/schema/slot-content-ref/) from slot bindings and from `Element.propConfigurations` slot-prop entries |
 
 ## Examples and composed content
 
 Several optional fields document configured and composed usages of a component. Each has its own page:
 
-- [`InstanceExamples`](/specs/schema/instance-examples/) — pre-configured whole-component usages.
-- [`SlotContent`](/specs/schema/slot-content/) — the `anatomy + elements + layout` triplet used as a named slot fill, stored in `slotContentExamples`.
-- [`SlotContentRef`](/specs/schema/slot-content-ref/) — the `$slotContent` pointer that references a fill.
-- [`Composition`](/specs/schema/composition/) — a named, authored unit of composed content (system-scoped, external composition files).
-- [`Children`](/specs/schema/children/) — an element's children, including slot bindings that carry example fills.
+- [`InstanceExamples`](/schema/instance-examples/) — pre-configured whole-component usages.
+- [`SlotContent`](/schema/slot-content/) — the `anatomy + elements + layout` triplet used as a named slot fill, stored in `slotContentExamples`.
+- [`SlotContentRef`](/schema/slot-content-ref/) — the `$slotContent` pointer that references a fill.
+- [`Composition`](/schema/composition/) — a named, authored unit of composed content (system-scoped, external composition files).
+- [`Children`](/schema/children/) — an element's children, including slot bindings that carry example fills.

--- a/site/src/content/docs/schema/composition.md
+++ b/site/src/content/docs/schema/composition.md
@@ -6,7 +6,7 @@ description: "A named, authored unit of composed content"
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge pro-badge">Pro</span>')</script>
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
 
-A `Composition` is a named, authored unit of composed content. The top-level [`anatomy`](/specs/schema/anatomy/) + [`elements`](/specs/schema/elements/) + [`layout`](/specs/schema/layout/) triplet **is** the primary content — there is no wrapper and no reserved `main` key. An optional `slotContent` map bundles named slot fills alongside that primary content for authoring convenience.
+A `Composition` is a named, authored unit of composed content. The top-level [`anatomy`](/schema/anatomy/) + [`elements`](/schema/elements/) + [`layout`](/schema/layout/) triplet **is** the primary content — there is no wrapper and no reserved `main` key. An optional `slotContent` map bundles named slot fills alongside that primary content for authoring convenience.
 
 ```ts
 interface Composition {
@@ -27,23 +27,23 @@ type Compositions = Record<string, Composition>;
 |----------|------|----------|-------------|
 | `title` | `string` | No | Human-readable label for the composition |
 | `description` | `string` | No | Purpose and usage notes for documentation tooling |
-| `anatomy` | [`Anatomy`](/specs/schema/anatomy/) | Yes | Element type map for the primary content |
-| `elements` | [`Elements`](/specs/schema/elements/) | Yes | Element-level content, styles, and prop configurations |
-| `layout` | [`Layout`](/specs/schema/layout/) | Yes | Tree ordering of the primary content |
-| `slotContent` | `Record<string, `[`SlotContent`](/specs/schema/slot-content/)`>` | No | Named slot fills bundled with this composition |
+| `anatomy` | [`Anatomy`](/schema/anatomy/) | Yes | Element type map for the primary content |
+| `elements` | [`Elements`](/schema/elements/) | Yes | Element-level content, styles, and prop configurations |
+| `layout` | [`Layout`](/schema/layout/) | Yes | Tree ordering of the primary content |
+| `slotContent` | `Record<string, `[`SlotContent`](/schema/slot-content/)`>` | No | Named slot fills bundled with this composition |
 
-`slotContent` is an authoring convenience, not a scope boundary — fills there may reference entries in other compositions via [`SlotContentRef`](/specs/schema/slot-content-ref/).
+`slotContent` is an authoring convenience, not a scope boundary — fills there may reference entries in other compositions via [`SlotContentRef`](/schema/slot-content-ref/).
 
 ## Registry and references
 
 `Compositions` (`Record<string, Composition>`) is the registry shape used by external composition files, keyed `compositions:` (system-scoped).
 
-A [`SlotContentRef`](/specs/schema/slot-content-ref/) pointing at a composition resolves as follows:
+A [`SlotContentRef`](/schema/slot-content-ref/) pointing at a composition resolves as follows:
 
 | Pointer | Resolves to |
 |---------|-------------|
 | `#/compositions/pageGrid` | the composition's top-level `anatomy + elements + layout` |
-| `#/compositions/filterResultsPage/slotContent/pageHeader` | that bundled [`SlotContent`](/specs/schema/slot-content/) |
+| `#/compositions/filterResultsPage/slotContent/pageHeader` | that bundled [`SlotContent`](/schema/slot-content/) |
 
 ## Further Reading
 

--- a/site/src/content/docs/schema/conditional.md
+++ b/site/src/content/docs/schema/conditional.md
@@ -28,7 +28,7 @@ interface Conditional {
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `operation` | `string` | Yes | Operation to perform |
-| `args.value` | [`PropBinding`](/specs/schema/prop-binding/) | Yes | The prop to test |
+| `args.value` | [`PropBinding`](/schema/prop-binding/) | Yes | The prop to test |
 | `args.compareTo` | `string \| number \| boolean \| null` | No | Comparison value (omitted for unary operations) |
 
 ### Operations

--- a/site/src/content/docs/schema/config.md
+++ b/site/src/content/docs/schema/config.md
@@ -3,7 +3,7 @@ title: "Config"
 description: "Generation configuration — processing, format, and inclusion options"
 ---
 
-Controls how specs are generated. See the [feature guides](/specs/features/) for detailed explanations of each option.
+Controls how specs are generated. See the [feature guides](/features/) for detailed explanations of each option.
 
 ## `processing`
 

--- a/site/src/content/docs/schema/corners.md
+++ b/site/src/content/docs/schema/corners.md
@@ -18,10 +18,10 @@ interface Corners {
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `topStart` | [`Style`](/specs/schema/styles.md/#values) | No | Top-start corner |
-| `topEnd` | [`Style`](/specs/schema/styles.md/#values) | No | Top-end corner |
-| `bottomEnd` | [`Style`](/specs/schema/styles.md/#values) | No | Bottom-end corner |
-| `bottomStart` | [`Style`](/specs/schema/styles.md/#values) | No | Bottom-start corner |
+| `topStart` | [`Style`](/schema/styles.md/#values) | No | Top-start corner |
+| `topEnd` | [`Style`](/schema/styles.md/#values) | No | Top-end corner |
+| `bottomEnd` | [`Style`](/schema/styles.md/#values) | No | Bottom-end corner |
+| `bottomStart` | [`Style`](/schema/styles.md/#values) | No | Bottom-start corner |
 
 Corner names use logical directions (`topStart`/`bottomEnd`) rather than physical (`topLeft`/`bottomRight`) for bidirectional layout support.
 

--- a/site/src/content/docs/schema/effects.md
+++ b/site/src/content/docs/schema/effects.md
@@ -3,7 +3,7 @@ title: "Effects"
 description: "Shadows and blur effects"
 ---
 
-An `Effects` object holds shadow and blur definitions. It appears on the `effects` style property as an alternative to a [`TokenReference`](/specs/schema/token-reference/).
+An `Effects` object holds shadow and blur definitions. It appears on the `effects` style property as an alternative to a [`TokenReference`](/schema/token-reference/).
 
 ```ts
 interface Effects {
@@ -38,7 +38,7 @@ interface Effects {
 | `offsetY` | `number \| TokenReference` | Yes | Vertical offset |
 | `blur` | `number \| TokenReference` | Yes | Blur radius |
 | `spread` | `number \| TokenReference` | Yes | Spread distance |
-| `color` | `string \| TokenReference` | Yes | Shadow color (`#RRGGBBAA` or [token](/specs/schema/token-reference/)) |
+| `color` | `string \| TokenReference` | Yes | Shadow color (`#RRGGBBAA` or [token](/schema/token-reference/)) |
 
 ### Blur
 

--- a/site/src/content/docs/schema/elements.md
+++ b/site/src/content/docs/schema/elements.md
@@ -3,7 +3,7 @@ title: "Elements"
 description: "Element runtime properties and children"
 ---
 
-Within a [variant](/specs/schema/variants/), each element is described by the `Element` type. This carries the element's runtime properties — its children, parent, styles, content, and any prop-driven behavior.
+Within a [variant](/schema/variants/), each element is described by the `Element` type. This carries the element's runtime properties — its children, parent, styles, content, and any prop-driven behavior.
 
 ```ts
 type Elements = Record<string, Element>;
@@ -15,8 +15,8 @@ type Elements = Record<string, Element>;
 |----------|------|----------|-------------|
 | `children` | `string[] \| SlotBinding` | No | Child element names, or a `SlotBinding` to a slot prop. `SlotBinding` extends `PropBinding` with optional `examples?: SlotContentRef[]` — authored sample fills for the slot (e.g. Figma's authoring default at index 0). Non-contractual; code consumers may ignore. |
 | `parent` | `string \| null` | No | Parent element key (`null` for root) |
-| `styles` | [`Styles`](/specs/schema/styles/) | No | Visual style properties |
-| `propConfigurations` | [`PropConfigurations`](/specs/schema/prop-configurations/) | No | Prop values that must hold for this element to appear |
+| `styles` | [`Styles`](/schema/styles/) | No | Visual style properties |
+| `propConfigurations` | [`PropConfigurations`](/schema/prop-configurations/) | No | Prop values that must hold for this element to appear |
 | `instanceOf` | `string \| PropBinding \| SubcomponentRef` | No | Component name, binding, or subcomponent ref |
 | `content` | `string \| PropBinding` | No | Text content or glyph name, or a binding to a prop |
 

--- a/site/src/content/docs/schema/gradient-value.md
+++ b/site/src/content/docs/schema/gradient-value.md
@@ -91,7 +91,7 @@ stops:
 | Property | Type | Description |
 |----------|------|-------------|
 | `position` | `number` | Position along the gradient vector (0–1) |
-| `color` | `string \| TokenReference` | Hex color (`#RRGGBBAA`) or [token reference](/specs/schema/token-reference/) |
+| `color` | `string \| TokenReference` | Hex color (`#RRGGBBAA`) or [token reference](/schema/token-reference/) |
 
 ### GradientCenter
 

--- a/site/src/content/docs/schema/index.md
+++ b/site/src/content/docs/schema/index.md
@@ -11,53 +11,53 @@ Every generated spec follows this tree — from a single-element icon to a compl
 
 <pre style="line-height:1.6">
 components:
-└─ {component name}                        → <a href="/specs/schema/component/">Component</a>
-  ├─ <a href="/specs/schema/anatomy/">anatomy</a>:
+└─ {component name}                        → <a href="/schema/component/">Component</a>
+  ├─ <a href="/schema/anatomy/">anatomy</a>:
   │ └─ {element name}: { type, slot }
-  ├─ <a href="/specs/schema/props/">props</a>:
+  ├─ <a href="/schema/props/">props</a>:
   │ └─ {prop name}: { type, default, … }
-  ├─ default:                              → <a href="/specs/schema/variants/">Variant</a>
-  │ ├─ <a href="/specs/schema/layout/">layout</a>:
+  ├─ default:                              → <a href="/schema/variants/">Variant</a>
+  │ ├─ <a href="/schema/layout/">layout</a>:
   │ │ └─ - {parent}:
   │ │   └─ - {child}
-  │ └─ <a href="/specs/schema/elements/">elements</a>:
+  │ └─ <a href="/schema/elements/">elements</a>:
   │   └─ {element name}:
-  │     ├─ content                         → <a href="/specs/schema/prop-binding/">PropBinding</a>
-  │     ├─ <a href="/specs/schema/children/">children</a>                        → <a href="/specs/schema/children/">Children</a> (slot fills → <a href="/specs/schema/slot-content-ref/">SlotContentRef</a>)
-  │     └─ <a href="/specs/schema/styles/">styles</a>:                      (48 properties)
-  │       ├─ color                         → <a href="/specs/schema/token-reference/">TokenReference</a>, <a href="/specs/schema/gradient-value/">GradientValue</a>
-  │       ├─ spacing, size                 → <a href="/specs/schema/token-reference/">TokenReference</a>, <a href="/specs/schema/conditional/">Conditional</a>
-  │       ├─ layout                        → <a href="/specs/schema/token-reference/">TokenReference</a>, <a href="/specs/schema/conditional/">Conditional</a>
-  │       ├─ <a href="/specs/schema/typography/">typography</a>                  → <a href="/specs/schema/token-reference/">TokenReference</a>
-  │       ├─ <a href="/specs/schema/effects/">effects</a>                     → <a href="/specs/schema/token-reference/">TokenReference</a>
-  │       ├─ cornerRadius                  → <a href="/specs/schema/corners/">Corners</a>
-  │       ├─ padding, strokeWeight         → <a href="/specs/schema/sides/">Sides</a>
-  │       ├─ visibility                    → <a href="/specs/schema/prop-binding/">PropBinding</a>
-  │       └─ …                             <a href="/specs/schema/styles/">see full list</a>
-  ├─ variants:                             → <a href="/specs/schema/variants/">Variant</a>[]
-  │ └─ - <a href="/specs/schema/prop-configurations/">configuration</a>:
-  │     <a href="/specs/schema/layout/">layout</a>:
-  │     <a href="/specs/schema/elements/">elements</a>:                      (layered styling and binding changes)
-  ├─ invalidVariantCombinations:           → <a href="/specs/schema/prop-configurations/">PropConfigurations</a>[]
-  ├─ <a href="/specs/schema/subcomponents/">subcomponents</a>:
+  │     ├─ content                         → <a href="/schema/prop-binding/">PropBinding</a>
+  │     ├─ <a href="/schema/children/">children</a>                        → <a href="/schema/children/">Children</a> (slot fills → <a href="/schema/slot-content-ref/">SlotContentRef</a>)
+  │     └─ <a href="/schema/styles/">styles</a>:                      (48 properties)
+  │       ├─ color                         → <a href="/schema/token-reference/">TokenReference</a>, <a href="/schema/gradient-value/">GradientValue</a>
+  │       ├─ spacing, size                 → <a href="/schema/token-reference/">TokenReference</a>, <a href="/schema/conditional/">Conditional</a>
+  │       ├─ layout                        → <a href="/schema/token-reference/">TokenReference</a>, <a href="/schema/conditional/">Conditional</a>
+  │       ├─ <a href="/schema/typography/">typography</a>                  → <a href="/schema/token-reference/">TokenReference</a>
+  │       ├─ <a href="/schema/effects/">effects</a>                     → <a href="/schema/token-reference/">TokenReference</a>
+  │       ├─ cornerRadius                  → <a href="/schema/corners/">Corners</a>
+  │       ├─ padding, strokeWeight         → <a href="/schema/sides/">Sides</a>
+  │       ├─ visibility                    → <a href="/schema/prop-binding/">PropBinding</a>
+  │       └─ …                             <a href="/schema/styles/">see full list</a>
+  ├─ variants:                             → <a href="/schema/variants/">Variant</a>[]
+  │ └─ - <a href="/schema/prop-configurations/">configuration</a>:
+  │     <a href="/schema/layout/">layout</a>:
+  │     <a href="/schema/elements/">elements</a>:                      (layered styling and binding changes)
+  ├─ invalidVariantCombinations:           → <a href="/schema/prop-configurations/">PropConfigurations</a>[]
+  ├─ <a href="/schema/subcomponents/">subcomponents</a>:
   │ └─ {name}: { …same shape as above }
-  ├─ <a href="/specs/schema/metadata/">metadata</a>:
-  │ └─ <a href="/specs/schema/config/">config</a>:
-  ├─ <a href="/specs/schema/instance-examples/">instanceExamples</a>:                   → <a href="/specs/schema/instance-examples/">InstanceExample</a>  <span class="sl-badge pro-badge">Pro</span>
+  ├─ <a href="/schema/metadata/">metadata</a>:
+  │ └─ <a href="/schema/config/">config</a>:
+  ├─ <a href="/schema/instance-examples/">instanceExamples</a>:                   → <a href="/schema/instance-examples/">InstanceExample</a>  <span class="sl-badge pro-badge">Pro</span>
   │ └─ {name}: { title, propConfigurations }
-  └─ <a href="/specs/schema/slot-content/">slotContentExamples</a>:                → <a href="/specs/schema/slot-content/">SlotContent</a>  <span class="sl-badge pro-badge">Pro</span>
-    └─ {name}: { <a href="/specs/schema/anatomy/">anatomy</a>, <a href="/specs/schema/elements/">elements</a>, <a href="/specs/schema/layout/">layout</a> }
+  └─ <a href="/schema/slot-content/">slotContentExamples</a>:                → <a href="/schema/slot-content/">SlotContent</a>  <span class="sl-badge pro-badge">Pro</span>
+    └─ {name}: { <a href="/schema/anatomy/">anatomy</a>, <a href="/schema/elements/">elements</a>, <a href="/schema/layout/">layout</a> }
 </pre>
 
 **Start at `default`.** The default variant is the complete baseline — every element fully described with styles, content, and layout. This is the component at rest.
 
-**Variants are deltas.** Each entry in `variants` carries a [`configuration`](/specs/schema/prop-configurations/) (which prop values activate it) and only the properties that *change*. Consumers resolve the final state by merging applicable overrides onto the default, in order. See [Variants](/specs/schema/variants/) and the [Variant Layering](/specs/guides/variant-layering/) guide.
+**Variants are deltas.** Each entry in `variants` carries a [`configuration`](/schema/prop-configurations/) (which prop values activate it) and only the properties that *change*. Consumers resolve the final state by merging applicable overrides onto the default, in order. See [Variants](/schema/variants/) and the [Variant Layering](/guides/variant-layering/) guide.
 
-**Style values can be rich.** Any style property might be a raw literal, a [`TokenReference`](/specs/schema/token-reference/) pointing to a design token, a [`PropBinding`](/specs/schema/prop-binding/) driven by a prop, or a [`Conditional`](/specs/schema/conditional/) that switches on prop state. Composite values like [`Typography`](/specs/schema/typography/), [`Effects`](/specs/schema/effects/), [`GradientValue`](/specs/schema/gradient-value/), [`Corners`](/specs/schema/corners/), and [`Sides`](/specs/schema/sides/) have their own shapes.
+**Style values can be rich.** Any style property might be a raw literal, a [`TokenReference`](/schema/token-reference/) pointing to a design token, a [`PropBinding`](/schema/prop-binding/) driven by a prop, or a [`Conditional`](/schema/conditional/) that switches on prop state. Composite values like [`Typography`](/schema/typography/), [`Effects`](/schema/effects/), [`GradientValue`](/schema/gradient-value/), [`Corners`](/schema/corners/), and [`Sides`](/schema/sides/) have their own shapes.
 
 ### Conventions
 
-- **`Style`** — A value that can be a literal (`string | number | boolean | null`), a [`TokenReference`](/specs/schema/token-reference/), a [`PropBinding`](/specs/schema/prop-binding/), or a [`Conditional`](/specs/schema/conditional/).
+- **`Style`** — A value that can be a literal (`string | number | boolean | null`), a [`TokenReference`](/schema/token-reference/), a [`PropBinding`](/schema/prop-binding/), or a [`Conditional`](/schema/conditional/).
 - **`Record<string, T>`** — An object keyed by user-defined names (element names, prop names, etc.) with values of type `T`.
 - **`$ref`** — A JSON Pointer or URI reference linking to another part of the spec or an external definition.
 - **`$binding`** — A JSON Pointer to a prop (e.g. `#/props/label`), creating a dynamic link between a prop value and a style or element property.

--- a/site/src/content/docs/schema/instance-examples.md
+++ b/site/src/content/docs/schema/instance-examples.md
@@ -6,7 +6,7 @@ description: "Pre-configured whole-component usages for documentation"
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge pro-badge">Pro</span>')</script>
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
 
-An `InstanceExample` is a pre-configured usage of a *whole* component — a documented configuration for human readers and tooling, not a live data flow. Scalar props are set directly; slot props are filled with a [`SlotContentRef`](/specs/schema/slot-content-ref/). They live on [`Component.instanceExamples`](/specs/schema/component/) and are emitted only with a Pro license.
+An `InstanceExample` is a pre-configured usage of a *whole* component — a documented configuration for human readers and tooling, not a live data flow. Scalar props are set directly; slot props are filled with a [`SlotContentRef`](/schema/slot-content-ref/). They live on [`Component.instanceExamples`](/schema/component/) and are emitted only with a Pro license.
 
 ```ts
 type InstanceExample = {
@@ -22,11 +22,11 @@ type InstanceExamples = Record<string, InstanceExample>;
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `title` | `string` | No | Human-readable label for this example |
-| `propConfigurations` | `Record<string, string \| number \| boolean \| `[`SlotContentRef`](/specs/schema/slot-content-ref/)`>` | No | Prop values — scalars for scalar props, a `SlotContentRef` for slot props |
+| `propConfigurations` | `Record<string, string \| number \| boolean \| `[`SlotContentRef`](/schema/slot-content-ref/)`>` | No | Prop values — scalars for scalar props, a `SlotContentRef` for slot props |
 
-A [`PropBinding`](/specs/schema/prop-binding/) is **not** permitted in `propConfigurations` — an instance example is a static configuration, not a binding.
+A [`PropBinding`](/schema/prop-binding/) is **not** permitted in `propConfigurations` — an instance example is a static configuration, not a binding.
 
-Slot fills encountered inside an example instance are contributed to the shared [`slotContentExamples`](/specs/schema/slot-content/) registry (de-duplicated against existing entries), so an `InstanceExample` holds no slot content of its own — only a `SlotContentRef` into that registry.
+Slot fills encountered inside an example instance are contributed to the shared [`slotContentExamples`](/schema/slot-content/) registry (de-duplicated against existing entries), so an `InstanceExample` holds no slot content of its own — only a `SlotContentRef` into that registry.
 
 ## Registry shape
 
@@ -34,11 +34,11 @@ Slot fills encountered inside an example instance are contributed to the shared 
 
 ## Detection
 
-How example instances are harvested from a Figma file is controlled by [`processing.instanceExamples`](/specs/settings/instance-examples/).
+How example instances are harvested from a Figma file is controlled by [`processing.instanceExamples`](/settings/instance-examples/).
 
 ## Further Reading
 
 - [Component Examples as Data](https://nathanacurtis.substack.com/p/component-examples-as-data) — the thinking behind examples in the spec
 - [ADR 048 — Component Instance Examples](https://github.com/DirectedEdges/specs/blob/main/adr/048-component-instance-examples.md)
-- [Instance Examples (config)](/specs/settings/instance-examples/) — detection setup
-- [Instance Examples (guide)](/specs/guides/instance-examples/)
+- [Instance Examples (config)](/settings/instance-examples/) — detection setup
+- [Instance Examples (guide)](/guides/instance-examples/)

--- a/site/src/content/docs/schema/layout.md
+++ b/site/src/content/docs/schema/layout.md
@@ -3,7 +3,7 @@ title: "Layout"
 description: "Recursive tree representation of element nesting"
 ---
 
-The `Layout` type provides a recursive tree representation of element nesting. It's an alternative to `parent`/`children` on [`Element`](/specs/schema/elements/) for expressing hierarchy.
+The `Layout` type provides a recursive tree representation of element nesting. It's an alternative to `parent`/`children` on [`Element`](/schema/elements/) for expressing hierarchy.
 
 ```ts
 type LayoutNode = string | { [nodeName: string]: LayoutNode[] };
@@ -20,7 +20,7 @@ A leaf is a plain string (element name). A branch is an object mapping a parent 
     - control
 ```
 
-The [`format.layout`](/specs/schema/config.md/#format) config option controls which representation appears in the output: `LAYOUT` (tree only), `PARENT_CHILDREN` (flat parent/children on each element), or `BOTH`.
+The [`format.layout`](/schema/config.md/#format) config option controls which representation appears in the output: `LAYOUT` (tree only), `PARENT_CHILDREN` (flat parent/children on each element), or `BOTH`.
 
 ## Example
 

--- a/site/src/content/docs/schema/metadata.md
+++ b/site/src/content/docs/schema/metadata.md
@@ -16,7 +16,7 @@ Generation metadata attached to the spec. Present when the spec was produced by 
 | `generator.license` | `object` | No | License status (`status`: VALID/EXPIRED/NONE) and `level` (FREE/PRO/EXTENDED) |
 | `schema` | `object` | Yes | Schema version info — `url`, `version`, and optional `latest` URL |
 | `source` | `object` | Yes | Figma source — `pageId`, `nodeId`, `nodeType` (COMPONENT, COMPONENT_SET, or FRAME) |
-| `config` | [`Config`](/specs/schema/config/) | Yes | The configuration used to generate this spec |
+| `config` | [`Config`](/schema/config/) | Yes | The configuration used to generate this spec |
 
 ## Further Reading
 

--- a/site/src/content/docs/schema/prop-binding.md
+++ b/site/src/content/docs/schema/prop-binding.md
@@ -24,7 +24,7 @@ PropBindings are accepted on these element properties:
 | `visible` | Element visibility is controlled by a prop |
 | `content` | Text or glyph content is bound to a prop |
 
-PropBindings can also appear as style values anywhere a [`Style`](/specs/schema/styles.md/#values) is accepted.
+PropBindings can also appear as style values anywhere a [`Style`](/schema/styles.md/#values) is accepted.
 
 ## Further Reading
 

--- a/site/src/content/docs/schema/prop-configurations.md
+++ b/site/src/content/docs/schema/prop-configurations.md
@@ -24,8 +24,8 @@ type PropConfigurations = Record<
 
 PropConfigurations appear in four places:
 
-- **Variant `configuration`** — declares which prop combination activates a [variant](/specs/schema/variants.md/#variant). When all listed props match their specified values, the variant's overrides are applied.
-- **`invalidVariantCombinations`** — an array on the [Component](/specs/schema/component/) root that declares prop combinations which should never occur together.
+- **Variant `configuration`** — declares which prop combination activates a [variant](/schema/variants.md/#variant). When all listed props match their specified values, the variant's overrides are applied.
+- **`invalidVariantCombinations`** — an array on the [Component](/schema/component/) root that declares prop combinations which should never occur together.
 - **`Element.propConfigurations`** — sets prop values on a nested instance element; accepts the full union (scalars, `PropBinding`, `CompositionRef`).
 - **`InstanceExample.propConfigurations`** — documents a complete scalar-prop configuration; scalars only.
 

--- a/site/src/content/docs/schema/props.md
+++ b/site/src/content/docs/schema/props.md
@@ -50,7 +50,7 @@ A `StringProp` is distinguished from an `EnumProp` by the absence of `enum`.
 | `default` | `number` | No | Default value |
 | `examples` | `number[]` | No | Example values |
 
-Inferred from Figma variant values when [`inferNumberProps`](/specs/schema/config.md/#processing) is enabled.
+Inferred from Figma variant values when [`inferNumberProps`](/schema/config.md/#processing) is enabled.
 
 ### SlotProp
 
@@ -64,7 +64,7 @@ Inferred from Figma variant values when [`inferNumberProps`](/specs/schema/confi
 | `anyOf` | `string[]` | No | Permitted component type names (since 0.14.0) |
 | `$extensions` | `PropExtensions` | No | Vendor extensions |
 
-Slot constraint properties (`minChildren`, `maxChildren`, `anyOf`) are emitted when [`slotConstraints`](/specs/schema/config.md/#processing) is enabled in config.
+Slot constraint properties (`minChildren`, `maxChildren`, `anyOf`) are emitted when [`slotConstraints`](/schema/config.md/#processing) is enabled in config.
 
 ## Extensions
 

--- a/site/src/content/docs/schema/sides.md
+++ b/site/src/content/docs/schema/sides.md
@@ -18,10 +18,10 @@ interface Sides {
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `top` | [`Style`](/specs/schema/styles.md/#values) | No | Top edge |
-| `end` | [`Style`](/specs/schema/styles.md/#values) | No | Inline-end (right in LTR) |
-| `bottom` | [`Style`](/specs/schema/styles.md/#values) | No | Bottom edge |
-| `start` | [`Style`](/specs/schema/styles.md/#values) | No | Inline-start (left in LTR) |
+| `top` | [`Style`](/schema/styles.md/#values) | No | Top edge |
+| `end` | [`Style`](/schema/styles.md/#values) | No | Inline-end (right in LTR) |
+| `bottom` | [`Style`](/schema/styles.md/#values) | No | Bottom edge |
+| `start` | [`Style`](/schema/styles.md/#values) | No | Inline-start (left in LTR) |
 
 Side names use logical directions (`start`/`end`) rather than physical (`left`/`right`) for bidirectional layout support.
 

--- a/site/src/content/docs/schema/slot-content-ref.md
+++ b/site/src/content/docs/schema/slot-content-ref.md
@@ -26,17 +26,17 @@ The pointer resolves to one of three targets — all yielding an `anatomy + elem
 
 | Target | Example pointer | Resolves to |
 |--------|-----------------|-------------|
-| [`Component.slotContentExamples`](/specs/schema/slot-content/) entry | `#/components/pill/slotContentExamples/composedLabel` | that [`SlotContent`](/specs/schema/slot-content/) |
-| [`Composition`](/specs/schema/composition/) entry | `#/compositions/pageGrid` | the composition's top-level triplet |
-| [`Composition.slotContent`](/specs/schema/composition/) entry | `#/compositions/filterResultsPage/slotContent/pageHeader` | that [`SlotContent`](/specs/schema/slot-content/) |
+| [`Component.slotContentExamples`](/schema/slot-content/) entry | `#/components/pill/slotContentExamples/composedLabel` | that [`SlotContent`](/schema/slot-content/) |
+| [`Composition`](/schema/composition/) entry | `#/compositions/pageGrid` | the composition's top-level triplet |
+| [`Composition.slotContent`](/schema/composition/) entry | `#/compositions/filterResultsPage/slotContent/pageHeader` | that [`SlotContent`](/schema/slot-content/) |
 
 The `$slotContent` key discriminates the reference — it names the *act of filling a slot*, not the target type.
 
 ## Where it appears
 
-- **[`SlotBinding.examples`](/specs/schema/children/)** — Figma's authoring default for a slot layer.
-- **`Element.propConfigurations`** slot-prop entries — see [Prop Configurations](/specs/schema/prop-configurations/).
-- **[`InstanceExample.propConfigurations`](/specs/schema/instance-examples/)** — the slot-prop value in a documented whole-component usage.
+- **[`SlotBinding.examples`](/schema/children/)** — Figma's authoring default for a slot layer.
+- **`Element.propConfigurations`** slot-prop entries — see [Prop Configurations](/schema/prop-configurations/).
+- **[`InstanceExample.propConfigurations`](/schema/instance-examples/)** — the slot-prop value in a documented whole-component usage.
 
 ## Further Reading
 

--- a/site/src/content/docs/schema/slot-content.md
+++ b/site/src/content/docs/schema/slot-content.md
@@ -6,7 +6,7 @@ description: "The anatomy + elements + layout triplet used as a named slot fill"
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge pro-badge">Pro</span>')</script>
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
 
-A `SlotContent` is the anonymous structural triplet — [`anatomy`](/specs/schema/anatomy/), [`elements`](/specs/schema/elements/), and [`layout`](/specs/schema/layout/) — used as a named fill for a slot. It carries no metadata of its own; its identity lives at the key under which it is stored.
+A `SlotContent` is the anonymous structural triplet — [`anatomy`](/schema/anatomy/), [`elements`](/schema/elements/), and [`layout`](/schema/layout/) — used as a named fill for a slot. It carries no metadata of its own; its identity lives at the key under which it is stored.
 
 ```ts
 interface SlotContent {
@@ -20,16 +20,16 @@ interface SlotContent {
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `anatomy` | [`Anatomy`](/specs/schema/anatomy/) | Yes | Element type map for this fill |
-| `elements` | [`Elements`](/specs/schema/elements/) | Yes | Element-level content, styles, and prop configurations |
-| `layout` | [`Layout`](/specs/schema/layout/) | Yes | Tree ordering of the elements |
+| `anatomy` | [`Anatomy`](/schema/anatomy/) | Yes | Element type map for this fill |
+| `elements` | [`Elements`](/schema/elements/) | Yes | Element-level content, styles, and prop configurations |
+| `layout` | [`Layout`](/schema/layout/) | Yes | Tree ordering of the elements |
 
 ## Where it lives
 
-`SlotContent` entries are stored in named registries and referenced — never inlined — by a [`SlotContentRef`](/specs/schema/slot-content-ref/) (`$slotContent` pointer):
+`SlotContent` entries are stored in named registries and referenced — never inlined — by a [`SlotContentRef`](/schema/slot-content-ref/) (`$slotContent` pointer):
 
-- **`Component.slotContentExamples`** — component-scoped fills, e.g. `"#/components/pill/slotContentExamples/composedLabel"`. Emitted when [`include.defaultSlotContent`](/specs/settings/default-slot-content/) is on.
-- **`Composition.slotContent`** — fills bundled alongside a [`Composition`](/specs/schema/composition/)'s primary content, e.g. `"#/compositions/filterResultsPage/slotContent/pageHeader"`.
+- **`Component.slotContentExamples`** — component-scoped fills, e.g. `"#/components/pill/slotContentExamples/composedLabel"`. Emitted when [`include.defaultSlotContent`](/settings/default-slot-content/) is on.
+- **`Composition.slotContent`** — fills bundled alongside a [`Composition`](/schema/composition/)'s primary content, e.g. `"#/compositions/filterResultsPage/slotContent/pageHeader"`.
 
 specs-from-figma de-duplicates entries by structural equality across variants and slots — identical fills share a single registry entry.
 

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -96,14 +96,14 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 | `number` | Literal number value | `16` |
 | `boolean` | Literal boolean value | `true` |
 | `null` | Absent or cleared value | `null` |
-| [`TokenReference`](/specs/schema/token-reference/) | Reference to a design token | `{ $token: "DS.Space.400", $type: "dimension" }` |
-| [`PropBinding`](/specs/schema/prop-binding/) | Dynamic link to a prop value | `{ $binding: "#/props/label" }` |
-| [`Conditional`](/specs/schema/conditional/) | Value that depends on a prop's state | `{ if: { condition: ..., then: 8, else: 12 } }` |
-| [`GradientValue`](/specs/schema/gradient-value/) | Linear, radial, or angular gradient | `{ type: "LINEAR", angle: 90, stops: [...] }` |
-| [`Typography`](/specs/schema/typography/) | Text style object with individual properties | `{ fontSize: 14, fontFamily: "Inter" }` |
-| [`Effects`](/specs/schema/effects/) | Shadows and blurs | `{ shadows: [...], layerBlur: { ... } }` |
-| [`Sides`](/specs/schema/sides/) | Per-side values for padding or stroke weight | `{ top: 8, end: 12, bottom: 8, start: 12 }` |
-| [`Corners`](/specs/schema/corners/) | Per-corner values for corner radius | `{ topStart: 4, topEnd: 4, bottomEnd: 0, bottomStart: 0 }` |
+| [`TokenReference`](/schema/token-reference/) | Reference to a design token | `{ $token: "DS.Space.400", $type: "dimension" }` |
+| [`PropBinding`](/schema/prop-binding/) | Dynamic link to a prop value | `{ $binding: "#/props/label" }` |
+| [`Conditional`](/schema/conditional/) | Value that depends on a prop's state | `{ if: { condition: ..., then: 8, else: 12 } }` |
+| [`GradientValue`](/schema/gradient-value/) | Linear, radial, or angular gradient | `{ type: "LINEAR", angle: 90, stops: [...] }` |
+| [`Typography`](/schema/typography/) | Text style object with individual properties | `{ fontSize: 14, fontFamily: "Inter" }` |
+| [`Effects`](/schema/effects/) | Shadows and blurs | `{ shadows: [...], layerBlur: { ... } }` |
+| [`Sides`](/schema/sides/) | Per-side values for padding or stroke weight | `{ top: 8, end: 12, bottom: 8, start: 12 }` |
+| [`Corners`](/schema/corners/) | Per-corner values for corner radius | `{ topStart: 4, topEnd: 4, bottomEnd: 0, bottomStart: 0 }` |
 | `ItemSpacing` | Per-axis gap values | `{ horizontal: 16, vertical: 8 }` |
 | `LayoutMode` | Auto-layout direction enum | `"NONE"`, `"HORIZONTAL"`, `"VERTICAL"` |
 | `WrapAlignment` | Wrap line distribution enum | `"START"`, `"SPACE_BETWEEN"` |

--- a/site/src/content/docs/schema/subcomponents.md
+++ b/site/src/content/docs/schema/subcomponents.md
@@ -21,9 +21,9 @@ A `Subcomponent` contains:
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `title` | `string` | Yes | Subcomponent name |
-| `anatomy` | [`Anatomy`](/specs/schema/anatomy/) | Yes | Element map |
-| `props` | [`Props`](/specs/schema/props/) | No | Prop definitions |
-| `default` | [`Variant`](/specs/schema/variants.md/#variant) | Yes | Default variant |
+| `anatomy` | [`Anatomy`](/schema/anatomy/) | Yes | Element map |
+| `props` | [`Props`](/schema/props/) | No | Prop definitions |
+| `default` | [`Variant`](/schema/variants.md/#variant) | Yes | Default variant |
 | `variants` | [`Variant[]`](variants.md) | No | Variant overrides |
 | `invalidVariantCombinations` | [`PropConfigurations[]`](prop-configurations.md) | No | Invalid prop combinations |
 | `source` | `SubcomponentSource` | No | Figma source identity for this subcomponent's node |
@@ -70,7 +70,7 @@ The `$ref` is a JSON Pointer into the same spec document.
 
 ## Detection
 
-Subcomponent detection is controlled by [`config.processing.subcomponents`](/specs/schema/config.md/#processing):
+Subcomponent detection is controlled by [`config.processing.subcomponents`](/schema/config.md/#processing):
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/site/src/content/docs/schema/typography.md
+++ b/site/src/content/docs/schema/typography.md
@@ -3,7 +3,7 @@ title: "Typography"
 description: "Text style properties for font, spacing, and alignment"
 ---
 
-A `Typography` object holds individual text style properties. It appears on the `typography` style property as an alternative to a [`TokenReference`](/specs/schema/token-reference/) — when the text style is not backed by a single token, the individual properties are listed instead.
+A `Typography` object holds individual text style properties. It appears on the `typography` style property as an alternative to a [`TokenReference`](/schema/token-reference/) — when the text style is not backed by a single token, the individual properties are listed instead.
 
 ```ts
 interface Typography {
@@ -49,7 +49,7 @@ interface Typography {
 | `string` | Literal string value | `"Inter"` |
 | `boolean` | Literal boolean value | `true` |
 | `'mixed'` | Multiple conflicting values within a single text node | `"mixed"` |
-| [`TokenReference`](/specs/schema/token-reference/) | Reference to a design token | `{ $token: "DS.Font.Size.400", $type: "dimension" }` |
+| [`TokenReference`](/schema/token-reference/) | Reference to a design token | `{ $token: "DS.Font.Size.400", $type: "dimension" }` |
 | `'NONE' \| 'CAP_HEIGHT'` | Leading trim enum (for `leadingTrim` only) | `"CAP_HEIGHT"` |
 
 ## Example

--- a/site/src/content/docs/schema/variants.md
+++ b/site/src/content/docs/schema/variants.md
@@ -19,9 +19,9 @@ This keeps specs compact. A component with 5 boolean props would need 32 flat va
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `configuration` | [`PropConfigurations`](/specs/schema/prop-configurations/) | No | Prop values that activate this variant |
-| `layout` | [`Layout`](/specs/schema/layout/) | No | Layout tree for this variant |
-| `elements` | [`Elements`](/specs/schema/elements/) | No | Element overrides — only changed properties |
+| `configuration` | [`PropConfigurations`](/schema/prop-configurations/) | No | Prop values that activate this variant |
+| `layout` | [`Layout`](/schema/layout/) | No | Layout tree for this variant |
+| `elements` | [`Elements`](/schema/elements/) | No | Element overrides — only changed properties |
 | `invalid` | `boolean` | No | `true` for invalid/excluded variant combinations |
 
 ## Resolution
@@ -30,6 +30,6 @@ When a variant's `configuration` matches the current prop values, its `elements`
 
 ## Invalid Variants
 
-Variants with `invalid: true` represent prop combinations that exist in Figma but are semantically invalid. They are excluded from output by default (controlled by [`include.invalidVariants`](/specs/schema/config.md/#include) in config).
+Variants with `invalid: true` represent prop combinations that exist in Figma but are semantically invalid. They are excluded from output by default (controlled by [`include.invalidVariants`](/schema/config.md/#include) in config).
 
 The top-level `invalidVariantCombinations` array lists prop combinations that should never occur together, separately from the variant list.

--- a/site/src/content/docs/settings/code-only-props-pattern.md
+++ b/site/src/content/docs/settings/code-only-props-pattern.md
@@ -6,7 +6,7 @@ description: "Naming pattern used to detect the code-only props container layer"
 Naming pattern used to detect the code-only props container layer. When absent, no code-only prop extraction is performed. A `Code only props` layer is a tiny, clipped container parked at `(0,0)` that holds child layers bound to behavioral component properties with no visual representation — for example, a Text Area's `minRows`/`maxRows` sizing bounds and a `minLength` constraint.
 
 :::tip[Guide]
-See the [Code-Only Props](/specs/guides/code-only-props/) guide as well as the [Code-Only Props in Figma](https://nathanacurtis.substack.com/p/code-only-props-in-figma) blog post for how detection and extraction works.
+See the [Code-Only Props](/guides/code-only-props/) guide as well as the [Code-Only Props in Figma](https://nathanacurtis.substack.com/p/code-only-props-in-figma) blog post for how detection and extraction works.
 :::
 
 ## Configuration
@@ -40,7 +40,7 @@ When the pattern matches, the container **and all of its children are omitted fr
 
 `minRows`, `maxRows`, and `minLength` appear in `props` but **not** in `anatomy` — the only trace of the code-only props layer is the props themselves.
 
-Their numeric values (`"2"`, `"6"`, `"3"`) remain strings here. Pair this with [`inferNumberProps`](/specs/settings/infer-number-props/) to emit them as `NumberProp` (`2`, `6`, `3`) instead.
+Their numeric values (`"2"`, `"6"`, `"3"`) remain strings here. Pair this with [`inferNumberProps`](/settings/infer-number-props/) to emit them as `NumberProp` (`2`, `6`, `3`) instead.
 
 Without `codeOnlyPropsPattern`, the container and its children are treated as ordinary layout elements — they appear in `anatomy`/`elements` and no props are extracted.
 

--- a/site/src/content/docs/settings/color.md
+++ b/site/src/content/docs/settings/color.md
@@ -39,4 +39,4 @@ config:
 
 ## See Also
 
-- [Config schema reference](/specs/schema/config/) - Full configuration documentation
+- [Config schema reference](/schema/config/) - Full configuration documentation

--- a/site/src/content/docs/settings/data-sources.md
+++ b/site/src/content/docs/settings/data-sources.md
@@ -63,4 +63,4 @@ sources:
     data: ['file', 'variables', 'styles']
 ```
 
-Branch data includes unpublished changes — variables, styles, and components that haven't been merged or published to main. See [Fetching Figma Branches](/specs/cli/commands/fetch/#fetching-figma-branches) for implications.
+Branch data includes unpublished changes — variables, styles, and components that haven't been merged or published to main. See [Fetching Figma Branches](/cli/commands/fetch/#fetching-figma-branches) for implications.

--- a/site/src/content/docs/settings/default-slot-content.md
+++ b/site/src/content/docs/settings/default-slot-content.md
@@ -8,7 +8,7 @@ description: "Emit the component's structurally-detected default slot content as
 
 When `true`, the generator emits `Component.slotContentExamples` — the **default content placed inside a component's slot layers**, captured structurally and referenced from each slot binding via `$slotContent`. Defaults to `false`, so output for unannotated components is unchanged until you opt in.
 
-Unlike [`instanceExamples`](/specs/settings/instance-examples/), slot content examples need **no detection config** — they are derived structurally from whatever content sits inside slot layers. This flag is the only control.
+Unlike [`instanceExamples`](/settings/instance-examples/), slot content examples need **no detection config** — they are derived structurally from whatever content sits inside slot layers. This flag is the only control.
 
 ## Configuration
 
@@ -78,10 +78,10 @@ With `defaultSlotContent: false` (the default), the slot binding carries no `$sl
 
 ## Licensing
 
-`defaultSlotContent` output requires a [Pro license](/specs/overview/licensing/). On the free tier the flag is silently ignored — slot content is neither stamped nor emitted, regardless of config. This applies to the CLI, the REST API, and the Figma plugin (where the control is hidden until a Pro license is active).
+`defaultSlotContent` output requires a [Pro license](/overview/licensing/). On the free tier the flag is silently ignored — slot content is neither stamped nor emitted, regardless of config. This applies to the CLI, the REST API, and the Figma plugin (where the control is hidden until a Pro license is active).
 
 ## See Also
 
-- [Guide: Default Slot Content](/specs/guides/default-slot-content/) — what it captures and how to author it
-- [`processing.instanceExamples`](/specs/settings/instance-examples/) — the separate, presence-driven instance-example feature
-- [Schema: Component](/specs/schema/component/) — `slotContentExamples` registry shape
+- [Guide: Default Slot Content](/guides/default-slot-content/) — what it captures and how to author it
+- [`processing.instanceExamples`](/settings/instance-examples/) — the separate, presence-driven instance-example feature
+- [Schema: Component](/schema/component/) — `slotContentExamples` registry shape

--- a/site/src/content/docs/settings/details.md
+++ b/site/src/content/docs/settings/details.md
@@ -26,4 +26,4 @@ config:
 
 ## See Also
 
-- [Variant Layering guide](/specs/guides/variant-layering/) - How layered format works
+- [Variant Layering guide](/guides/variant-layering/) - How layered format works

--- a/site/src/content/docs/settings/glyph-name-pattern.md
+++ b/site/src/content/docs/settings/glyph-name-pattern.md
@@ -6,7 +6,7 @@ description: "Naming pattern used to detect glyph content assets"
 Naming pattern used to detect glyph content assets (e.g. icon glyphs). When absent, no glyph detection is performed.
 
 :::tip[Guide]
-See [Icon Glyphs](/specs/guides/glyph-name-pattern/) for naming strategies and worked examples.
+See [Icon Glyphs](/guides/glyph-name-pattern/) for naming strategies and worked examples.
 :::
 
 ## Configuration
@@ -49,7 +49,7 @@ Without `glyphNamePattern`, the layer is treated as an ordinary element and no `
 - **Default**: absent (disabled)
 - **Effect**: When set, layers whose names match the pattern are detected as glyph assets. When absent, glyph detection is skipped entirely.
 
-The pattern must include the `{i}` placeholder, which marks where the glyph name appears in the component name. Internally `{i}` becomes a `(.+)` capture group and the matched text is used as the glyph's `content` value. See [Icon Glyphs](/specs/guides/glyph-name-pattern/) for the full pattern syntax.
+The pattern must include the `{i}` placeholder, which marks where the glyph name appears in the component name. Internally `{i}` becomes a `(.+)` capture group and the matched text is used as the glyph's `content` value. See [Icon Glyphs](/guides/glyph-name-pattern/) for the full pattern syntax.
 
 ## Path
 

--- a/site/src/content/docs/settings/index.mdx
+++ b/site/src/content/docs/settings/index.mdx
@@ -23,43 +23,43 @@ The plugin's **Settings** tab exposes the same options as the CLI's config file,
 
 The **Format** section controls how spec data is serialized once it's extracted:
 
-- [Output Format](/specs/settings/output-format/) — Serializes specs as `YAML` or `JSON`
-- [Keys](/specs/settings/keys/) — Renames keys, such as `camelCase` or `snake_case`
-- [Tokens](/specs/settings/tokens/) — Serializes as forms such as a name string or `{ $token, $type }` object
-- [Color](/specs/settings/color/) — Formats color, such as `#FF6600` or `{ colorSpace, components }`
+- [Output Format](/settings/output-format/) — Serializes specs as `YAML` or `JSON`
+- [Keys](/settings/keys/) — Renames keys, such as `camelCase` or `snake_case`
+- [Tokens](/settings/tokens/) — Serializes as forms such as a name string or `{ $token, $type }` object
+- [Color](/settings/color/) — Formats color, such as `#FF6600` or `{ colorSpace, components }`
 
 ### Variants
 
 The **Variants** section controls how variant property combinations are compared and included:
 
-- [Variant Depth](/specs/settings/variant-depth/) — Compares depths such as `1` prop at a time or `9999` (all combos)
-- [Empty Variants](/specs/settings/empty-variants/) — Includes variants like `{ a:2, b:2 }` with no overrides
-- [Invalid Variants](/specs/settings/invalid-variants/) — Includes invalid combos, e.g. `disabled:true, hover:true`
-- [Invalid Combinations](/specs/settings/invalid-combinations/) — Summarizes as `invalidPropConfigurations: { disabled:true }`
+- [Variant Depth](/settings/variant-depth/) — Compares depths such as `1` prop at a time or `9999` (all combos)
+- [Empty Variants](/settings/empty-variants/) — Includes variants like `{ a:2, b:2 }` with no overrides
+- [Invalid Variants](/settings/invalid-variants/) — Includes invalid combos, e.g. `disabled:true, hover:true`
+- [Invalid Combinations](/settings/invalid-combinations/) — Summarizes as `invalidPropConfigurations: { disabled:true }`
 
 ### Elements
 
 The **Elements** section controls which layers are detected as special-purpose content:
 
-- [Glyph Name Pattern](/specs/settings/glyph-name-pattern/) — Matches names like `DS Icon Glyph / check`
-- [Subcomponents](/specs/settings/subcomponents/) — Matches names like `Card / _ / Header` within `NESTED` or `PAGE`
-- [Collapse Primitive Wrapper](/specs/settings/collapse-primitive-wrapper/) — Collapses a wrapper around a lone `text` or `glyph` child
-- [Default Slot Content](/specs/settings/default-slot-content/) — Emits authored defaults as `slotContentExamples`
-- [Instance Examples](/specs/settings/instance-examples/) — Detects frames like `{C} Example` as `instanceExamples`
+- [Glyph Name Pattern](/settings/glyph-name-pattern/) — Matches names like `DS Icon Glyph / check`
+- [Subcomponents](/settings/subcomponents/) — Matches names like `Card / _ / Header` within `NESTED` or `PAGE`
+- [Collapse Primitive Wrapper](/settings/collapse-primitive-wrapper/) — Collapses a wrapper around a lone `text` or `glyph` child
+- [Default Slot Content](/settings/default-slot-content/) — Emits authored defaults as `slotContentExamples`
+- [Instance Examples](/settings/instance-examples/) — Detects frames like `{C} Example` as `instanceExamples`
 
 ### Props
 
 The **Props** section controls how code-only and inferred props are detected:
 
-- [Code-Only Props Pattern](/specs/settings/code-only-props-pattern/) — Detects a layer like `Code only props`
-- [Slot Constraints](/specs/settings/slot-constraints/) — Merges `anyOf`, `minChildren`, `maxChildren` into the slot prop
-- [Infer Number Props](/specs/settings/infer-number-props/) — Emits `minRows: 2` as `NumberProp` instead of `StringProp`
+- [Code-Only Props Pattern](/settings/code-only-props-pattern/) — Detects a layer like `Code only props`
+- [Slot Constraints](/settings/slot-constraints/) — Merges `anyOf`, `minChildren`, `maxChildren` into the slot prop
+- [Infer Number Props](/settings/infer-number-props/) — Emits `minRows: 2` as `NumberProp` instead of `StringProp`
 
 ### Layout
 
 The **Layout** section controls how element hierarchy is represented:
 
-- [Layout](/specs/settings/layout/) — Nests such as `layout:` or flattens as `elements: { parent, children }`
+- [Layout](/settings/layout/) — Nests such as `layout:` or flattens as `elements: { parent, children }`
 
 </TabItem>
 <TabItem label="Command Line (CLI)">
@@ -240,8 +240,8 @@ config:
 
 ## See Also
 
-- [CLI Overview](/specs/cli/) - CLI command options
-- [Getting Started](/specs/cli/getting-started/) - Installation and setup
+- [CLI Overview](/cli/) - CLI command options
+- [Getting Started](/cli/getting-started/) - Installation and setup
 
 </TabItem>
 </Tabs>

--- a/site/src/content/docs/settings/infer-number-props.md
+++ b/site/src/content/docs/settings/infer-number-props.md
@@ -3,10 +3,10 @@ title: "Infer Number Props"
 description: "Automatically emit numeric code-only props as NumberProp instead of StringProp"
 ---
 
-When enabled, TEXT code-only props whose default and all examples parse as valid numbers (no leading zeros) are emitted as `NumberProp` instead of `StringProp`. The example below uses a Text Area that exposes [code-only props](/specs/settings/code-only-props/) whose values are purely numeric strings — `minRows` = `"2"`, `maxRows` = `"6"`, `minLength` = `"3"`.
+When enabled, TEXT code-only props whose default and all examples parse as valid numbers (no leading zeros) are emitted as `NumberProp` instead of `StringProp`. The example below uses a Text Area that exposes [code-only props](/settings/code-only-props/) whose values are purely numeric strings — `minRows` = `"2"`, `maxRows` = `"6"`, `minLength` = `"3"`.
 
 :::tip[Guide]
-See [Number Inference](/specs/guides/number-inference/) for how inference works and when to use it.
+See [Number Inference](/guides/number-inference/) for how inference works and when to use it.
 :::
 
 ## Configuration

--- a/site/src/content/docs/settings/instance-examples.md
+++ b/site/src/content/docs/settings/instance-examples.md
@@ -10,7 +10,7 @@ Instance examples are real-world usages of a component placed in your Figma file
 
 A candidate qualifies primarily by **identity**: it must be an *instance of the component being generated* (one of its variants). Naming is not the relevance test — that's what `match` is for, and `match` is optional. This means example instances can be named anything; they don't need to reference the component name.
 
-The **presence** of `processing.instanceExamples` is the on-switch — the same opt-in model as [`subcomponents`](/specs/settings/subcomponents/). There is no separate `include` flag: when the block is present (and the license is Pro), examples are detected *and* emitted. When it is absent, no detection runs.
+The **presence** of `processing.instanceExamples` is the on-switch — the same opt-in model as [`subcomponents`](/settings/subcomponents/). There is no separate `include` flag: when the block is present (and the license is Pro), examples are detected *and* emitted. When it is absent, no detection runs.
 
 ## Configuration
 
@@ -109,11 +109,11 @@ The relevance test is **identity**: a candidate qualifies when it's an instance 
 
 ## Licensing
 
-Instance example detection and output requires a [Pro license](/specs/overview/licensing/). On the free tier `processing.instanceExamples` is silently ignored — no detection runs and nothing is emitted. The Figma plugin hides these controls until a Pro license is active.
+Instance example detection and output requires a [Pro license](/overview/licensing/). On the free tier `processing.instanceExamples` is silently ignored — no detection runs and nothing is emitted. The Figma plugin hides these controls until a Pro license is active.
 
 ## See Also
 
-- [Guide: Instance (Ready-Made) Examples](/specs/guides/instance-examples/) — authoring example frames end to end
-- [`defaultSlotContent`](/specs/settings/default-slot-content/) — the separate default-slot-content output flag
-- [Schema: Component](/specs/schema/component/) — the `instanceExamples` registry shape
-- [`subcomponents`](/specs/settings/subcomponents/) — the presence-driven detection model this mirrors
+- [Guide: Instance (Ready-Made) Examples](/guides/instance-examples/) — authoring example frames end to end
+- [`defaultSlotContent`](/settings/default-slot-content/) — the separate default-slot-content output flag
+- [Schema: Component](/schema/component/) — the `instanceExamples` registry shape
+- [`subcomponents`](/settings/subcomponents/) — the presence-driven detection model this mirrors

--- a/site/src/content/docs/settings/invalid-combinations.md
+++ b/site/src/content/docs/settings/invalid-combinations.md
@@ -6,7 +6,7 @@ description: "Calculate and include invalid property combinations"
 <script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge pro-badge">Pro</span>')</script>
 
 :::tip[Guide]
-See [Invalid Variant Combinations](/specs/guides/invalid-variant-combinations/) for what invalid combinations are, why they matter, and worked examples.
+See [Invalid Variant Combinations](/guides/invalid-variant-combinations/) for what invalid combinations are, why they matter, and worked examples.
 :::
 
 Calculate and include invalid property combinations.

--- a/site/src/content/docs/settings/keys.md
+++ b/site/src/content/docs/settings/keys.md
@@ -43,4 +43,4 @@ config:
 
 ## See Also
 
-- [Key Formatting guide](/specs/guides/key-formatting/) - Detailed formatting behavior and edge cases
+- [Key Formatting guide](/guides/key-formatting/) - Detailed formatting behavior and edge cases

--- a/site/src/content/docs/settings/layout.md
+++ b/site/src/content/docs/settings/layout.md
@@ -59,4 +59,4 @@ The same `DS Alert` hierarchy — a `root` containing `decorativeIcon` and `chil
 
 ## See Also
 
-- [Data Layout guide](/specs/guides/data-layout/) - Comparison of layout representations
+- [Data Layout guide](/guides/data-layout/) - Comparison of layout representations

--- a/site/src/content/docs/settings/output.md
+++ b/site/src/content/docs/settings/output.md
@@ -87,7 +87,7 @@ components:
 or `instanceExamples`; components without examples are omitted from it. Without this
 file the `$slotContent` references in `default`/`variants` would have no target.
 
-Example output is a [Pro feature](/specs/settings/default-slot-content/) — on the free tier no example data is produced, so `examples.yaml` is never written.
+Example output is a [Pro feature](/settings/default-slot-content/) — on the free tier no example data is produced, so `examples.yaml` is never written.
 
 ## `useSubfolders`
 
@@ -160,7 +160,7 @@ specs/
 
 ## CLI Flag Priority
 
-Output configuration follows the standard [priority system](/specs/settings/#priority-system):
+Output configuration follows the standard [priority system](/settings/#priority-system):
 
 1. **CLI flags** (highest): `--split-components`, `--split-concerns`, `--use-subfolders`
 2. **Config file**: `output` field in `specs.config.yaml`

--- a/site/src/content/docs/settings/slot-constraints.md
+++ b/site/src/content/docs/settings/slot-constraints.md
@@ -6,7 +6,7 @@ description: "Consolidate slot constraints from code-only props into the slot pr
 Consolidate slot constraints (`anyOf`, `minChildren`, `maxChildren`) into the slot property. Constraints are read from two sources — Figma's native `slotSettings` API (when the slot has native settings configured) and code-only props (the legacy naming convention). Both sources produce the same output fields.
 
 :::tip[Guide]
-See the [Slot Constraints](/specs/guides/slot-constraints/) guide as well as the [Figma Slots for Repeating Items](https://nathanacurtis.substack.com/p/figma-slots-for-repeating-items) blog post for how constraint consolidation works.
+See the [Slot Constraints](/guides/slot-constraints/) guide as well as the [Figma Slots for Repeating Items](https://nathanacurtis.substack.com/p/figma-slots-for-repeating-items) blog post for how constraint consolidation works.
 :::
 
 ## Configuration

--- a/site/src/content/docs/settings/states.md
+++ b/site/src/content/docs/settings/states.md
@@ -5,8 +5,8 @@ description: "Classify Figma variant props as browser-driven or consumer-control
 
 `processing.states` classifies your library's Figma variant props as semantic states, enabling two downstream behaviors:
 
-- The [`css` transformer](/specs/cli/transforms/css/) emits real CSS pseudo-classes and ARIA attribute selectors instead of `data-*` attributes for classified props.
-- The [`contract` transformer](/specs/cli/transforms/contract/) omits browser-driven props from generated Props interfaces.
+- The [`css` transformer](/cli/transforms/css/) emits real CSS pseudo-classes and ARIA attribute selectors instead of `data-*` attributes for classified props.
+- The [`contract` transformer](/cli/transforms/contract/) omits browser-driven props from generated Props interfaces.
 
 Declare the classification once and both transforms apply it consistently.
 
@@ -159,7 +159,7 @@ config:
 | `contract` | `"omit"` \| `"keep"` | No | concept default | Override the concept's default contract behavior. Rarely needed. |
 
 
-Run [`specs transform css`](/specs/cli/commands/transform/) to regenerate stylesheets after updating this config. Absence of `processing.states` is safe — all variant props continue to emit as `data-*` selectors.
+Run [`specs transform css`](/cli/commands/transform/) to regenerate stylesheets after updating this config. Absence of `processing.states` is safe — all variant props continue to emit as `data-*` selectors.
 
 ## Path
 
@@ -167,6 +167,6 @@ Run [`specs transform css`](/specs/cli/commands/transform/) to regenerate styles
 
 ## See Also
 
-- [`css` transformer](/specs/cli/transforms/css/) — CSS output affected by this classification
-- [`contract` transformer](/specs/cli/transforms/contract/) — Props interface affected by `contract: omit`
-- [`subcomponents`](/specs/settings/subcomponents/) — another presence-driven `processing` option
+- [`css` transformer](/cli/transforms/css/) — CSS output affected by this classification
+- [`contract` transformer](/cli/transforms/contract/) — Props interface affected by `contract: omit`
+- [`subcomponents`](/settings/subcomponents/) — another presence-driven `processing` option

--- a/site/src/content/docs/settings/subcomponents.md
+++ b/site/src/content/docs/settings/subcomponents.md
@@ -59,5 +59,5 @@ An asset must match at least one `match` pattern to be considered a subcomponent
 
 ## See Also
 
-- [Subcomponents guide](/specs/guides/subcomponent-scoping/) - Detailed patterns and strategies
-- [Schema: Subcomponents](/specs/schema/subcomponents/) - Subcomponent schema reference
+- [Subcomponents guide](/guides/subcomponent-scoping/) - Detailed patterns and strategies
+- [Schema: Subcomponents](/schema/subcomponents/) - Subcomponent schema reference

--- a/site/src/content/docs/settings/tokens.md
+++ b/site/src/content/docs/settings/tokens.md
@@ -82,7 +82,7 @@ The full shape adds raw Figma provenance under `$extensions`. For variables the 
 
 ### CUSTOM
 
-`CUSTOM` substitutes your own token shapes for Specs' built-in ones. Before generating, run [`applyCustomTokens`](/specs/cli/commands/apply-custom-tokens/) to inject a `$custom` object onto each variable and style in your fetched data; when `CUSTOM` is active, that object becomes the property value verbatim. References that never received a `$custom` object fall back to the `TOKEN_FIGMA_EXTENSIONS` shape.
+`CUSTOM` substitutes your own token shapes for Specs' built-in ones. Before generating, run [`applyCustomTokens`](/cli/commands/apply-custom-tokens/) to inject a `$custom` object onto each variable and style in your fetched data; when `CUSTOM` is active, that object becomes the property value verbatim. References that never received a `$custom` object fall back to the `TOKEN_FIGMA_EXTENSIONS` shape.
 
 ```json
 {
@@ -103,7 +103,7 @@ specs applyCustomTokens mapping.json     # 2. Inject $custom objects into the da
 specs generate                           # 3. Generate — uses $custom objects verbatim
 ```
 
-The `applyCustomTokens` command auto-discovers variables/styles files from `dataDirectory` and `sources` in this config, or accepts explicit `-v`/`-s` paths. See [`applyCustomTokens` command](/specs/cli/commands/apply-custom-tokens/) for the full mapping file format and pipeline details.
+The `applyCustomTokens` command auto-discovers variables/styles files from `dataDirectory` and `sources` in this config, or accepts explicit `-v`/`-s` paths. See [`applyCustomTokens` command](/cli/commands/apply-custom-tokens/) for the full mapping file format and pipeline details.
 
 ### FIGMA_SYNTAX_WEB / FIGMA_SYNTAX_IOS / FIGMA_SYNTAX_ANDROID
 
@@ -132,5 +132,5 @@ When a token has no code syntax defined for the chosen platform, the profile **f
 
 ## See Also
 
-- [`applyCustomTokens` command](/specs/cli/commands/apply-custom-tokens/) — mapping file format and pipeline for the `CUSTOM` profile
+- [`applyCustomTokens` command](/cli/commands/apply-custom-tokens/) — mapping file format and pipeline for the `CUSTOM` profile
 - [ADR 007 — Token Reference Config](https://github.com/DirectedEdges/specs/blob/main/adr/007-token-reference-config.md) — the decision consolidating token formatting into a single enum

--- a/site/src/content/docs/settings/transform.md
+++ b/site/src/content/docs/settings/transform.md
@@ -43,5 +43,5 @@ Omitting `config.transform` entirely is equivalent to running `specs transform c
 
 ## See Also
 
-- [`transform` command](/specs/cli/commands/transform/) — CLI usage, arguments, and options
-- [tokens config](/specs/settings/tokens/) — control how token references are serialized in spec output
+- [`transform` command](/cli/commands/transform/) — CLI usage, arguments, and options
+- [tokens config](/settings/tokens/) — control how token references are serialized in spec output

--- a/site/src/content/docs/settings/variant-depth.md
+++ b/site/src/content/docs/settings/variant-depth.md
@@ -24,5 +24,5 @@ config:
 
 ## See Also
 
-- [Variant Depth guide](/specs/guides/variant-depth/) - How depth affects variant expansion
-- [Variant Layering guide](/specs/guides/variant-layering/) - How properties accumulate across variants
+- [Variant Depth guide](/guides/variant-depth/) - How depth affects variant expansion
+- [Variant Layering guide](/guides/variant-layering/) - How properties accumulate across variants


### PR DESCRIPTION
## What
**Project 015 — specsplugin.com → specs GitHub Pages migration.**

Prepares `specs/site` to serve from the root custom domain `https://www.specsplugin.com/`
instead of the `directededges.github.io/specs/` project subpath.

- Rewrite **427 internal `/specs/…` links → `/…`** across `site/src` (markdown, JSX `href`,
  `Header.astro`/`Footer.astro`, hero `link:`). GitHub URLs (58) and absolute
  `directededges.github.io/specs/` refs (3) preserved.
- `astro.config.mjs`: `site → https://www.specsplugin.com`, **remove `base: '/specs'`**.
- Add `site/public/CNAME` = `www.specsplugin.com`.
- Repoint `README` / `ONBOARDING` / `TERMS_OF_SERVICE` doc links to the new domain.
- Fix one root-relative `/specs/` link in `packages/schema/CHANGELOG.md` (feeds the generated releases page).

Verified: `astro build` produces 100 pages served at root, **0 leftover `/specs/` hrefs**, CNAME in `dist`, canonical + sitemap on the new host.

## ⚠️ DO NOT MERGE until the cutover is scheduled
Merging redeploys the site with `base` dropped, which **breaks the live `directededges.github.io/specs/`
project page** (root build served under the `/specs/` path). Merge must happen in the **same window** as:
1. releasing the custom domain from the `specsplugin-com` repo, and
2. attaching `www.specsplugin.com` to this repo's Pages settings + enforcing HTTPS.

Held as a **draft** until then. Plan: `specs-local-workspace/projects/015-specs-site-migration/plan.md`.

## Out of scope (tracked separately)
- CLI config-template URLs → issue #190.
- `directededges.github.io/specs/config/…` in `ConfigTemplates.ts` and the mirrored `init.md`
  lines move with #190 (they also need `/config/` → `/settings/` reconciliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
