### PR TITLE
fix(schema): NestedPropConfiguration.path minItems keyword typo

### DIFF
--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Color token references no longer fail validation on their resolved raw value** — the `rawValue` provenance field on a token reference now accepts a DTCG Color object (the shape the generator emits for color tokens) alongside string, number, and boolean, clearing false schema violations on token-bound fills and gradient stops.
 - **Subcomponent source identity no longer fails validation** — subcomponent entries carrying the ADR-060 `source` field (pageId/nodeId/nodeType) were rejected because the closed Component definition composed via allOf could not admit it; the property is now declared where draft-07 requires it.
 - **Collapsed-root anatomy provenance no longer fails validation** — anatomy elements now accept `$extensions['com.figma'].originalName` (written by primitive-wrapper collapse, ADR-058) in both the JSON schema and the `AnatomyElement` type.
+- **Nested-path configurations now enforce a non-empty path** — the schema declared the constraint with a misspelled keyword (`minChildren` instead of `minItems`), so validators silently skipped it; an empty `path` on a `$nested` entry is now rejected as ADR-052 intends.
 
 
 ## [0.27.0] - 2026-07-01

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -556,7 +556,7 @@
       "properties": {
         "path": {
           "type": "array",
-          "minChildren": 1,
+          "minItems": 1,
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
## Summary
`component.schema.json` declared the ADR-052 non-empty-path constraint as `minChildren` — SlotProp vocabulary, not a JSON Schema keyword — so validators silently ignored it. One word: `minChildren` → `minItems`.

## Test coverage
`SlotContentExamples.test.ts` (the pre-existing release-branch failure) now passes 13/13; build tsc and schema JSON validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)