### PR TITLE
ADR-064: Tighten textAlignHorizontal to a logical-direction string enum

### DIFF
--- a/adr/064-text-align-horizontal.md
+++ b/adr/064-text-align-horizontal.md
@@ -2,7 +2,7 @@
 
 **Branch**: `064-text-align-horizontal`
 **Created**: 2026-08-03
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/064-text-align-horizontal.md
+++ b/adr/064-text-align-horizontal.md
@@ -1,0 +1,199 @@
+# ADR: Tighten `textAlignHorizontal` to a Logical-Direction String Enum
+
+**Branch**: `064-text-align-horizontal`
+**Created**: 2026-08-03
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The Figma Plugin API exposes horizontal text alignment on text nodes as a closed set of physical-direction values:
+
+```yaml
+# Figma Plugin API
+textAlignHorizontal: 'LEFT' | 'CENTER' | 'RIGHT' | 'JUSTIFIED'
+```
+
+The `Styles` type currently models this property as the wide-open `Style` union:
+
+```yaml
+# types/Styles.ts — current
+Styles:
+  textAlignHorizontal?: Style   # string | boolean | number | null | TokenReference | PropBinding | Conditional
+```
+
+```yaml
+# schema/styles.schema.json — current
+textAlignHorizontal:
+  $ref: "#/definitions/StringStyleValue"
+```
+
+This is wrong on two axes:
+
+- **Overly wide typing**: The value is a closed, known set and is **not token-bindable** — Figma does not support variable binding on text alignment. Per the constitution's structural-enum rule, such properties MUST be typed as a named string-literal union rather than `Style`. Established precedent: `LayoutMode` (ADR-038), `MainAxisAlignment`/`CrossAxisAlignment` (ADR-040), `WrapAlignment` (ADR-039), `Position` (ADR-041), `TextOverflow` (ADR-062).
+- **Physical direction names**: Figma's `LEFT`/`RIGHT` values embed an LTR writing-direction assumption. ADR-010 established logical inline-axis terminology (`start`/`end`) for the spec contract; passing Figma's physical values through unmapped contradicts that model and forces every RTL-aware consumer to translate.
+
+---
+
+## Decision Drivers
+
+- **Structural-enum constitution rule**: Closed, non-token-bindable value sets MUST be named string-literal unions typed as `TypeName | null`, not `Style` (Additional Constraints — "Typing — structural enums vs. `Style`")
+- **Logical direction model**: ADR-010 selected `start`/`end` over `left`/`right` for the inline axis; new properties must not reintroduce physical directions
+- **Naming governance (Constitution VI, rule 1)**: Favor code-platform consensus — CSS Logical Properties (`text-align: start | end | justify`), Android Compose (`TextAlign.Start/End/Justify`), and Flutter (`TextAlign.start/end/justify`) all agree on logical values for horizontal text alignment
+- **Enum casing**: `Styles` enum values use `SCREAMING_CASE` (Additional Constraints — "Naming — enum casing in Styles")
+- **Type–schema symmetry**: Every type change must have a corresponding schema change (Constitution I)
+- **Stable, intentional API**: Narrowing an exported field's type and renaming its observable values is a breaking change (Constitution III)
+
+---
+
+## Options Considered
+
+### Option A: Named structural enum with logical direction values *(Selected)*
+
+Define `TextAlignHorizontal` as a string-literal union using logical inline-axis terminology, typed `TextAlignHorizontal | null`, excluding `TokenReference`/`PropBinding`/`Conditional`:
+
+```yaml
+TextAlignHorizontal: 'START' | 'CENTER' | 'END' | 'JUSTIFY'
+```
+
+**Pros**:
+- Satisfies the structural-enum constitution rule — mechanical validation of the closed value set in both type and schema
+- Logical `START`/`END` aligns with ADR-010's inline-axis model and the existing `MainAxisAlignment`/`CrossAxisAlignment` value vocabulary
+- `JUSTIFY` follows code-platform consensus (CSS `justify`, Compose `TextAlign.Justify`, Flutter `TextAlign.justify`) per Constitution VI rule 1 — Figma's `JUSTIFIED` is the outlier
+- SwiftUI consumers map trivially (`START` → `.leading`, `END` → `.trailing`)
+
+**Cons / Trade-offs**:
+- Breaking — previously valid arbitrary strings (including Figma-raw `LEFT`/`RIGHT`/`JUSTIFIED`) become invalid against the schema
+- Extraction requires a value mapping (`LEFT` → `START`, `RIGHT` → `END`, `JUSTIFIED` → `JUSTIFY`) — a transformer concern, consistent with ADR-010's conclusion that physical→logical mapping belongs at extraction time
+
+---
+
+### Option B: Keep `Style`, document the value set in descriptions only *(Rejected)*
+
+Leave `textAlignHorizontal: Style` and enumerate the permitted values in the JSDoc comment and schema `description`.
+
+**Rejected because**: Violates the structural-enum constitution rule outright — the property is a closed, non-token-bindable set and MUST be a named union. Documentation-only constraints are not mechanically verifiable (Constitution IV), so invalid values pass validation silently.
+
+---
+
+### Option C: Named enum with Figma's physical values *(Rejected)*
+
+Define the union as Figma's raw value set:
+
+```yaml
+TextAlignHorizontal: 'LEFT' | 'CENTER' | 'RIGHT' | 'JUSTIFIED'
+```
+
+**Rejected because**: Reintroduces the physical-direction model ADR-010 explicitly rejected for the spec contract. `LEFT`/`RIGHT` embed an LTR assumption that every RTL-aware consumer must undo, and the vocabulary diverges from the logical `START`/`END` already used by `MainAxisAlignment`, `CrossAxisAlignment`, `WrapAlignment`, and the `Sides` composite. Constitution VI rule 3 permits deferring to Figma's vocabulary only when no code platform expresses a strong opinion — here CSS, Compose, and Flutter all agree on the logical model.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Styles.ts` | Add `TextAlignHorizontal` string-literal union type | MINOR |
+| `Styles.ts` | Change `textAlignHorizontal` from `Style` to `TextAlignHorizontal \| null` | MAJOR |
+
+**New type** (`types/Styles.ts`):
+
+```yaml
+# Horizontal text alignment using logical inline-axis directions.
+# Structural property — not token-bindable.
+TextAlignHorizontal: 'START' | 'CENTER' | 'END' | 'JUSTIFY'
+```
+
+**`Styles` change** (`types/Styles.ts`):
+
+```yaml
+# Before
+Styles:
+  textAlignHorizontal?: Style
+
+# After
+Styles:
+  textAlignHorizontal?: TextAlignHorizontal | null
+```
+
+`StyleKey` is unchanged — the key `textAlignHorizontal` remains in the union.
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `styles.schema.json` | Add `TextAlignHorizontalStyleValue` definition | MINOR |
+| `styles.schema.json` | Change `textAlignHorizontal` property `$ref` from `StringStyleValue` to `TextAlignHorizontalStyleValue` | MAJOR |
+
+**New schema definition** (`schema/styles.schema.json`):
+
+```yaml
+TextAlignHorizontalStyleValue:
+  description: "Horizontal text alignment value using logical inline-axis directions. Structural property — not token-bindable."
+  oneOf:
+    - type: string
+      enum: [START, CENTER, END, JUSTIFY]
+    - type: "null"
+```
+
+**Property change** (`schema/styles.schema.json`):
+
+```yaml
+# Before
+textAlignHorizontal:
+  $ref: "#/definitions/StringStyleValue"
+
+# After
+textAlignHorizontal:
+  $ref: "#/definitions/TextAlignHorizontalStyleValue"
+```
+
+### Notes
+
+- **Value mapping** (extraction-time concern, recorded for reference): Figma `LEFT` → `START`, `CENTER` → `CENTER`, `RIGHT` → `END`, `JUSTIFIED` → `JUSTIFY`. In LTR contexts `START` renders as left-aligned and `END` as right-aligned; in RTL contexts the resolution flips without any change to the spec output.
+- **`JUSTIFY` over `JUSTIFIED`**: Constitution VI rule 1 — CSS (`text-align: justify`), Android Compose (`TextAlign.Justify`), and Flutter (`TextAlign.justify`) agree on the term "justify"; Figma's past-tense `JUSTIFIED` is the single outlier and the transformer owns the rename.
+- **No `'mixed'` arm**: `textAlignHorizontal` is a node-level property in Figma — it cannot vary across character ranges within one text node, so no `'mixed'` value is needed.
+- **`textAlignVertical` is out of scope**: It remains `Style` for now. It is a candidate for the same structural-enum treatment in a follow-up ADR, but its block-axis values (`TOP`/`CENTER`/`BOTTOM`) do not flip with writing direction, so it carries no logical-direction urgency and no rename question.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**:
+  - `TextAlignHorizontal` union ↔ `#/definitions/TextAlignHorizontalStyleValue` enum values
+  - `textAlignHorizontal?: TextAlignHorizontal | null` on `Styles` ↔ `#/properties/textAlignHorizontal` referencing `TextAlignHorizontalStyleValue`
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Breaking — emitted values must change from Figma-raw `LEFT`/`RIGHT`/`JUSTIFIED` to `START`/`END`/`JUSTIFY` | Map Figma values to the logical enum at extraction; recompile against the narrowed type |
+| `specs-cli` | Breaking — output validated against the schema must carry the new values | Recompile; any value formatting or docs generation that reads `textAlignHorizontal` handles the closed enum |
+| `specs-plugin-2` | Breaking — same value mapping as `specs-from-figma` (shared engine) | Recompile against the narrowed type |
+
+Existing serialized specs containing `LEFT`/`RIGHT`/`JUSTIFIED` (or any other string) for `textAlignHorizontal` become invalid against the new schema and must be regenerated.
+
+---
+
+## Semver Decision
+
+**Version bump**: ships in the in-flight `0.29.0` release (`0.28.0 → 0.29.0`)
+
+**Justification**: Narrowing `textAlignHorizontal` from `Style` to a closed enum and renaming its observable values is a breaking change per Constitution III (MAJOR-class). Per the package's pre-1.0 convention — established by the equivalent narrowings in ADR-038 (`layoutMode`, 0.18.0) and ADR-041 (`position`, 0.19.0) — breaking changes ride 0.x MINOR releases. The CHANGELOG entry for `0.29.0` must flag the breaking value rename.
+
+---
+
+## Consequences
+
+- `textAlignHorizontal` is mechanically validated against a closed value set in both the type system and the JSON schema — arbitrary strings no longer pass
+- Spec output uses writing-direction-neutral alignment values, consistent with `MainAxisAlignment`, `CrossAxisAlignment`, `WrapAlignment`, and the `Sides`/`Corners` logical model from ADR-010
+- The transformer owns the Figma physical→logical value mapping; every downstream consumer reads one vocabulary
+- Previously serialized output with Figma-raw alignment values becomes invalid against the new schema
+- `textAlignVertical` remains the last text-alignment property typed as `Style` — a follow-up ADR can apply the same structural-enum treatment

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | |
 | 062 | Text Overflow & Max Lines — `textOverflow` and `maxLines` on `Styles` | |
 | 061 | Schema Entry Points for Concern-Split Output | |
 | 059 | Border Style and Dash Pattern — `borderStyle` and `borderDashPattern` on `Styles` | |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | |
 | 062 | Text Overflow & Max Lines — `textOverflow` and `maxLines` on `Styles` | |
 | 061 | Schema Entry Points for Concern-Split Output | |
 | 059 | Border Style and Dash Pattern — `borderStyle` and `borderDashPattern` on `Styles` | |
@@ -38,6 +37,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | Narrow from `Style` to `TextAlignHorizontal \| null` (`'START' \| 'CENTER' \| 'END' \| 'JUSTIFY'`); Figma `LEFT`/`RIGHT`/`JUSTIFIED` remapped |
 | 063 | Image Content — `backgroundImage` fill, an `images` registry, `ImageProp`, and `ImageBinding` | Add `backgroundImage` fills, a `Component.images` registry (Figma identity + optional `src`), `ImageProp`/`ImageBinding`, and presence-switched `processing.images` |
 | 060 | Subcomponent Figma Source Identity — `Subcomponent.source` | Add optional `SubcomponentSource` (`pageId`, `nodeId`, `nodeType`) to `Subcomponent`; enables reverse-direction tools to resolve `SubcomponentRef` to Figma nodes |
 | 059 | Stroke Dash Pattern — `strokeDashPattern` on `Styles` | Add `StrokeDashPattern { dash, gap }` structural type; presence = dashed stroke, null/absent = solid; not token-bindable |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Styles.textAlignHorizontal` — narrowed from `Style` to `TextAlignHorizontal` (`'START' | 'CENTER' | 'END' | 'JUSTIFY'`) or `null`; logical inline-axis directions, not token-bindable (ADR-064)
+
 ### Removed
+
+### Migration
+
+- `Styles.textAlignHorizontal` values `LEFT`/`RIGHT`/`JUSTIFIED` → `START`/`END`/`JUSTIFY`: read the logical enum; resolve `START`/`END` by writing direction and regenerate any stored specs
 
 
 ## [0.28.0] - 2026-07-16

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -40,7 +40,7 @@
         "strokeWeight": { "$ref": "#/definitions/SidesStyleValue", "description": "Stroke weight. Scalar when uniform; Sides object when per-side values differ." },
         "strokeDashPattern": { "$ref": "#/definitions/StrokeDashPatternStyleValue", "description": "Dash pattern for a stroke. Present (non-null) when the stroke is dashed; null or absent when solid." },
         "typography": { "$ref": "#/definitions/TypographyStyleValue", "description": "Typography properties. TokenReference when the node references a named text style; Typography when defined inline." },
-        "textAlignHorizontal": { "$ref": "#/definitions/StringStyleValue", "description": "Horizontal text alignment" },
+        "textAlignHorizontal": { "$ref": "#/definitions/TextAlignHorizontalStyleValue", "description": "Horizontal text alignment using logical inline-axis directions — START (left in LTR), CENTER, END (right in LTR), or JUSTIFY. Structural property — not token-bindable." },
         "textAlignVertical": { "$ref": "#/definitions/StringStyleValue", "description": "Vertical text alignment" },
         "textOverflow": { "$ref": "#/definitions/TextOverflowStyleValue", "description": "How overflowing text is handled — CLIP (cut off) or ELLIPSIS (trailing ellipsis). Structural property — not token-bindable." },
         "maxLines": { "$ref": "#/definitions/NumberStyleValue", "description": "Maximum number of lines before ELLIPSIS text overflow applies; null or absent means no limit." },
@@ -404,6 +404,13 @@
       "description": "Cross axis alignment value. Structural property — not token-bindable.",
       "oneOf": [
         { "type": "string", "enum": ["START", "END", "CENTER", "STRETCH", "BASELINE"] },
+        { "type": "null" }
+      ]
+    },
+    "TextAlignHorizontalStyleValue": {
+      "description": "Horizontal text alignment value using logical inline-axis directions. Structural property — not token-bindable.",
+      "oneOf": [
+        { "type": "string", "enum": ["START", "CENTER", "END", "JUSTIFY"] },
         { "type": "null" }
       ]
     },

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -9,7 +9,7 @@ import type {
   AngularGradient, GradientValue, AspectRatioValue, AspectRatioStyle,
   Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment,
   MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset,
-  StrokeDashPattern, TextOverflow,
+  StrokeDashPattern, TextAlignHorizontal, TextOverflow,
 } from '../types/index.js';
 
 // ─── ColorStyle ────────────────────────────────────────────────────────────
@@ -839,6 +839,56 @@ const _dashNumber: Styles = { strokeDashPattern: 8 };
 
 // @ts-expect-error: string is not valid for strokeDashPattern
 const _dashString: Styles = { strokeDashPattern: 'dashed' };
+
+// ─── TextAlignHorizontal ──────────────────────────────────────────────────────
+
+// Valid enum values
+const _taStart: TextAlignHorizontal = 'START';
+const _taCenter: TextAlignHorizontal = 'CENTER';
+const _taEnd: TextAlignHorizontal = 'END';
+const _taJustify: TextAlignHorizontal = 'JUSTIFY';
+
+// Figma's physical raw values must NOT compile — remapped in the generator
+// @ts-expect-error: LEFT is not valid TextAlignHorizontal (maps to START)
+const _taLeft: TextAlignHorizontal = 'LEFT';
+
+// @ts-expect-error: RIGHT is not valid TextAlignHorizontal (maps to END)
+const _taRight: TextAlignHorizontal = 'RIGHT';
+
+// @ts-expect-error: JUSTIFIED is not valid TextAlignHorizontal (maps to JUSTIFY)
+const _taJustified: TextAlignHorizontal = 'JUSTIFIED';
+
+// @ts-expect-error: number is not valid TextAlignHorizontal
+const _taNumber: TextAlignHorizontal = 0;
+
+// @ts-expect-error: lowercase is not valid (SCREAMING_CASE required)
+const _taLowercase: TextAlignHorizontal = 'start';
+
+// ─── Styles.textAlignHorizontal (TextAlignHorizontal | null) ─────────────────
+
+// Valid enum values on Styles
+const withAlignStart: Styles = { textAlignHorizontal: 'START' };
+const withAlignCenter: Styles = { textAlignHorizontal: 'CENTER' };
+const withAlignEnd: Styles = { textAlignHorizontal: 'END' };
+const withAlignJustify: Styles = { textAlignHorizontal: 'JUSTIFY' };
+
+// null is valid
+const withAlignNull: Styles = { textAlignHorizontal: null };
+
+// absent is valid (all Styles fields optional)
+const withNoAlign: Styles = {};
+
+// @ts-expect-error: TokenReference is not valid for textAlignHorizontal (not token-bindable)
+const _taToken: Styles = { textAlignHorizontal: { $token: 'Text.Align', $type: 'string' } satisfies TokenReference };
+
+// @ts-expect-error: arbitrary string is not valid for textAlignHorizontal
+const _taArbitrary: Styles = { textAlignHorizontal: 'MIDDLE' };
+
+// @ts-expect-error: Figma-raw LEFT is not valid for textAlignHorizontal
+const _taStyleLeft: Styles = { textAlignHorizontal: 'LEFT' };
+
+// @ts-expect-error: number is not valid for textAlignHorizontal
+const _taStyleNumber: Styles = { textAlignHorizontal: 1 };
 
 // ─── TextOverflow ─────────────────────────────────────────────────────────────
 

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -47,7 +47,8 @@ export type Styles = Partial<{
   /** Dash pattern for a stroke. Present (non-null) when the stroke is dashed; null or absent when solid. Structural property — not token-bindable. @since 0.27.0 */
   strokeDashPattern: StrokeDashPattern | null;
   typography: TokenReference | Typography;
-  textAlignHorizontal: Style;
+  /** Horizontal text alignment using logical inline-axis directions (`START`/`END`). `JUSTIFY` maps from Figma's `JUSTIFIED`. Structural property — not token-bindable. Present on TEXT element type only. @since 0.29.0 */
+  textAlignHorizontal: TextAlignHorizontal | null;
   textAlignVertical: Style;
   /** How overflowing text is handled — `CLIP` (cut off) or `ELLIPSIS` (trailing ellipsis). Structural property — not token-bindable. Present on TEXT element type only. @since 0.28.0 */
   textOverflow: TextOverflow | null;
@@ -267,6 +268,17 @@ export type MainAxisAlignment = 'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN';
  * @since 0.18.0
  */
 export type CrossAxisAlignment = 'START' | 'END' | 'CENTER' | 'STRETCH' | 'BASELINE';
+
+/**
+ * Horizontal text alignment using logical inline-axis directions.
+ * `START` resolves to left in LTR and right in RTL; `END` is the inverse.
+ * Structural property that cannot be token-bound.
+ * Values follow CSS Logical Properties (`text-align: start | end | justify`),
+ * Jetpack Compose (`TextAlign.Start/End/Justify`), and Flutter; Figma's
+ * physical `LEFT`/`RIGHT`/`JUSTIFIED` values are mapped at extraction time.
+ * @since 0.29.0
+ */
+export type TextAlignHorizontal = 'START' | 'CENTER' | 'END' | 'JUSTIFY';
 
 /**
  * How text is handled when it overflows its bounds. Structural property that cannot be token-bound.

--- a/packages/schema/types/index.ts
+++ b/packages/schema/types/index.ts
@@ -28,7 +28,7 @@ export type { Config, ResolvedConfig, ColorFormat, VariantStateEntry, TransformE
 export { DEFAULT_CONFIG } from './Config.js';
 
 // Style types
-export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextOverflow } from './Styles.js';
+export type { Styles, Style, ColorStyle, ColorObject, StyleKey, TokenReference, AspectRatioValue, AspectRatioStyle, Typography, Sides, Corners, ItemSpacing, LayoutMode, WrapAlignment, MainAxisAlignment, CrossAxisAlignment, Position, PositionOffset, StrokeDashPattern, TextAlignHorizontal, TextOverflow } from './Styles.js';
 export type { Shadow, Blur, Effects } from './Effects.js';
 export type { GradientStop, GradientCenter, LinearGradient, RadialGradient, AngularGradient, GradientValue } from './Gradient.js';
 

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -88,6 +88,7 @@ Several spec style keys differ from the Figma node property they read from. Spec
 
 | `strokeDashPattern` | `strokeDashes` | [ADR 059](https://github.com/DirectedEdges/specs/blob/main/adr/059-border-style.md) |
 | `textOverflow` | `textTruncation` (values remapped: `DISABLED`→`CLIP`, `ENDING`→`ELLIPSIS`) | [ADR 062](https://github.com/DirectedEdges/specs/blob/main/adr/062-text-truncation.md) |
+| `textAlignHorizontal` | `textAlignHorizontal` (values remapped to logical directions: `LEFT`→`START`, `RIGHT`→`END`, `JUSTIFIED`→`JUSTIFY`) | [ADR 064](https://github.com/DirectedEdges/specs/blob/main/adr/064-text-align-horizontal.md) |
 
 All other style keys — `width`, `height`, `opacity`, `padding`, `itemSpacing`, `cornerRadius`, `strokeWeight`, `rotation`, etc. — use the same name as the Figma node property.
 
@@ -118,6 +119,7 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 | `PositionOffset` | Positional offset value | `24` (px), `"25%"` (SCALE), `null` |
 | `AspectRatio` | Width-to-height ratio | `{ x: 16, y: 9 }` |
 | `StrokeDashPattern` | Dash geometry for a dashed stroke — presence signals dashed; null or absent signals solid | `{ dash: 8, gap: 4 }` |
+| `TextAlignHorizontal` | Horizontal text alignment enum using logical inline-axis directions | `"START"`, `"CENTER"`, `"END"`, `"JUSTIFY"` |
 | `TextOverflow` | Text overflow handling enum | `"CLIP"`, `"ELLIPSIS"` |
 | `ImageValue` | Image fill — registry reference plus optional fit | `{ $image: "#/images/hero", objectFit: "COVER" }` |
 | `ObjectFit` | Image fit enum (CSS `object-fit` vocabulary) | `"COVER"`, `"CONTAIN"` |
@@ -140,5 +142,6 @@ Most properties accept a `Style` value. Some properties accept specialized shape
 - `top`, `bottom`, `start`, `end`, `centerHorizontalOffset`, `centerVerticalOffset` accept `PositionOffset` (`number | string | null`) — not token-bindable.
 - `aspectRatio` accepts `AspectRatio | null`.
 - `strokeDashPattern` accepts `StrokeDashPattern | null` — not token-bindable; presence signals a dashed stroke, null or absent signals solid.
+- `textAlignHorizontal` accepts `TextAlignHorizontal | null` (`"START" | "CENTER" | "END" | "JUSTIFY"`) — not token-bindable; logical directions resolve by writing direction (`"START"` is left in LTR, right in RTL). Figma's `LEFT`/`RIGHT`/`JUSTIFIED` are remapped at extraction.
 - `textOverflow` accepts `TextOverflow | null` (`"CLIP" | "ELLIPSIS"`) — not token-bindable; `"ELLIPSIS"` truncates overflowing text with a trailing ellipsis, `"CLIP"` cuts it off. Named after CSS `text-overflow` / Compose `TextOverflow`.
 - `maxLines` accepts any `Style` (a plain number like other sizes); the line limit before `textOverflow: "ELLIPSIS"` applies, or `null` for no limit.


### PR DESCRIPTION
## Summary

Implements [ADR-064](adr/064-text-align-horizontal.md) (ACCEPTED): narrows `Styles.textAlignHorizontal` from the wide-open `Style` union to a structural string-literal enum using logical inline-axis directions.

## Changes

- `types/Styles.ts` — new `TextAlignHorizontal` type (`'START' | 'CENTER' | 'END' | 'JUSTIFY'`); `textAlignHorizontal` narrowed to `TextAlignHorizontal | null`
- `types/index.ts` — export `TextAlignHorizontal`
- `schema/styles.schema.json` — new `TextAlignHorizontalStyleValue` definition; `textAlignHorizontal` now references it instead of `StringStyleValue`
- `tests/Styles.test-d.ts` — positive assertions for the four values and `null`; `@ts-expect-error` guards against Figma-raw `LEFT`/`RIGHT`/`JUSTIFIED`, arbitrary strings, and `TokenReference`
- `site/src/content/docs/schema/styles.md` — key-mapping row, Values-table row, and property-to-value bullet
- `CHANGELOG.md` — Changed + Migration entries under `[0.29.0] - Unreleased`
- `adr/064-text-align-horizontal.md` + `adr/INDEX.md` — status ACCEPTED, INDEX row moved to Accepted

## Value mapping (extraction-time)

- `LEFT` → `START`
- `CENTER` → `CENTER`
- `RIGHT` → `END`
- `JUSTIFIED` → `JUSTIFY`

## Gates

- `tsc -p tsconfig.build.json --noEmit` — clean
- Schema validation — 5/5 pass
- `tsc --noEmit --strict tests/*.test-d.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtBHLa8cCNVRfeaB4PmeuZ