### PR TITLE
feat(cli): fetch icons as a fourth data kind

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@directededges/specs-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **`specs fetch` icons** — a fourth data kind alongside `file`, `variables`, and `styles`: fetch derives the library's icon glyphs from the downloaded file payload (no `scan` required) and downloads their SVG assets with stable kebab-case slugs.
+
 ## [0.26.0] - Unreleased
 
 ### Added

--- a/packages/cli/src/commands/FetchCommand.ts
+++ b/packages/cli/src/commands/FetchCommand.ts
@@ -28,6 +28,7 @@ type FetchKind = 'file' | 'variables' | 'styles' | 'icons';
 type MinimalConfig = {
   dataDirectory?: string;
   sourceDirectory?: string; // deprecated alias
+  outputDirectory?: string; // icons land beside the specs they serve
   sources?: Record<string, { key: string; data: FetchKind[] }>;
   config?: { processing?: { glyphNamePattern?: string } };
 };
@@ -435,6 +436,12 @@ export const Fetch = new Command('fetch')
             console.error(`Error: sources.${entry.alias}.data includes "icons" but config.processing.glyphNamePattern is not set`);
             process.exit(ERROR_CODES.INVALID_ARGS);
           }
+          // Icons are consumed by generated component output, so they live in
+          // the durable spec workspace (beside _images/), not the data cache.
+          if (!config.outputDirectory) {
+            console.error(`Error: sources.${entry.alias}.data includes "icons" but outputDirectory is not set in config`);
+            process.exit(ERROR_CODES.INVALID_ARGS);
+          }
           const filePath = path.join(outDir, `${entry.alias}.file.json`);
           if (!fs.existsSync(filePath)) {
             console.error(`Error: icons require the file payload — fetch "file" for ${entry.alias} first (${filePath} not found)`);
@@ -444,7 +451,7 @@ export const Fetch = new Command('fetch')
           const stopSpinner = startSpinner(`Downloading: ${entry.alias} icons`);
           const fileJson = JSON.parse(await fs.readFile(filePath, 'utf-8')) as { document?: unknown };
           const glyphs = collectGlyphComponents(fileJson.document, pattern);
-          const iconsDir = path.join(outDir, 'icons');
+          const iconsDir = path.join(path.resolve(configDir, config.outputDirectory), '_icons');
           await fs.ensureDir(iconsDir);
 
           let downloaded = 0;

--- a/packages/cli/src/commands/FetchCommand.ts
+++ b/packages/cli/src/commands/FetchCommand.ts
@@ -23,13 +23,62 @@ const ERROR_CODES = {
   RATE_LIMIT: 6
 };
 
-type FetchKind = 'file' | 'variables' | 'styles';
+type FetchKind = 'file' | 'variables' | 'styles' | 'icons';
 
 type MinimalConfig = {
   dataDirectory?: string;
   sourceDirectory?: string; // deprecated alias
   sources?: Record<string, { key: string; data: FetchKind[] }>;
+  config?: { processing?: { glyphNamePattern?: string } };
 };
+
+/**
+ * Walk the file document for COMPONENT nodes whose name matches the
+ * glyphNamePattern ("DS Icon asset / {i}" — {i} captures the icon name).
+ * Duplicate slugs keep the first occurrence and suffix later ones with the
+ * node id so nothing is silently dropped.
+ */
+export function collectGlyphComponents(document: unknown, pattern: string): Array<{ id: string; name: string; slug: string }> {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\{i\\\}/g, '(.+)');
+  const regex = new RegExp(`^${escaped}$`);
+  const found: Array<{ id: string; name: string; slug: string }> = [];
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as { id?: string; name?: string; type?: string; children?: unknown[] };
+    if (n.type === 'COMPONENT' && typeof n.name === 'string' && typeof n.id === 'string') {
+      const match = n.name.match(regex);
+      if (match) found.push({ id: n.id, name: match[1] ?? n.name, slug: '' });
+    }
+    for (const child of n.children ?? []) walk(child);
+  };
+  walk(document);
+
+  const seen = new Set<string>();
+  for (const glyph of found) {
+    // Kebabize camelCase too, matching the scaffold's glyphUrl slugging.
+    const base = glyph.name
+      .trim()
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .replace(/[\s_]+/g, '-')
+      .replace(/-+/g, '-')
+      .toLowerCase();
+    glyph.slug = seen.has(base) ? `${base}-${glyph.id.replace(':', '-')}` : base;
+    seen.add(base);
+  }
+  return found;
+}
+
+async function streamToString(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return '';
+  const chunks: Buffer[] = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
 
 function findConfigFile(cwd: string): string | null {
   const locations = [
@@ -305,7 +354,7 @@ export const Fetch = new Command('fetch')
       }
 
       for (const entry of selected) {
-        for (const kind of entry.fetch) {
+        for (const kind of entry.fetch.filter(k => k !== 'icons')) {
           const url =
             kind === 'file'
               ? `https://api.figma.com/v1/files/${entry.key}${options.geometry ? '?geometry=paths' : ''}`
@@ -375,6 +424,67 @@ export const Fetch = new Command('fetch')
             const relativeOut = path.relative(process.cwd(), outputPath);
             console.log(`[CLI] Wrote: ${relativeOut}`);
           }
+        }
+
+        // Icons run after the other kinds: glyph components are derived from
+        // the saved file payload, so `file` must be present (fetched this run
+        // or a previous one) before icons can resolve.
+        if (entry.fetch.includes('icons')) {
+          const pattern = config.config?.processing?.glyphNamePattern;
+          if (!pattern) {
+            console.error(`Error: sources.${entry.alias}.data includes "icons" but config.processing.glyphNamePattern is not set`);
+            process.exit(ERROR_CODES.INVALID_ARGS);
+          }
+          const filePath = path.join(outDir, `${entry.alias}.file.json`);
+          if (!fs.existsSync(filePath)) {
+            console.error(`Error: icons require the file payload — fetch "file" for ${entry.alias} first (${filePath} not found)`);
+            process.exit(ERROR_CODES.FILE_ERROR);
+          }
+
+          const stopSpinner = startSpinner(`Downloading: ${entry.alias} icons`);
+          const fileJson = JSON.parse(await fs.readFile(filePath, 'utf-8')) as { document?: unknown };
+          const glyphs = collectGlyphComponents(fileJson.document, pattern);
+          const iconsDir = path.join(outDir, 'icons');
+          await fs.ensureDir(iconsDir);
+
+          let downloaded = 0;
+          const CHUNK = 50;
+          for (let i = 0; i < glyphs.length; i += CHUNK) {
+            const chunk = glyphs.slice(i, i + CHUNK);
+            const ids = chunk.map(g => g.id).join(',');
+            const url = `https://api.figma.com/v1/images/${entry.key}?ids=${encodeURIComponent(ids)}&format=svg`;
+            const result = await figmaFetch(url, token);
+            if (result.status !== 200) {
+              stopSpinner();
+              const classification = classifyHttpStatus(result.status);
+              if (classification === 'auth') {
+                console.error(formatAuthError(result.status, entry.alias, 'icons', configPath));
+                process.exit(ERROR_CODES.AUTH_ERROR);
+              }
+              if (classification === 'rate') {
+                console.error(formatRateLimitError(entry.alias, 'icons', result.headers));
+                process.exit(ERROR_CODES.RATE_LIMIT);
+              }
+              console.error(`Error: HTTP ${result.status} while exporting ${entry.alias} icons`);
+              process.exit(ERROR_CODES.NETWORK_ERROR);
+            }
+            const payload = JSON.parse(await streamToString(result.stream)) as { err?: string; images: Record<string, string | null> };
+            if (payload.err) {
+              stopSpinner();
+              console.error(`Error: images API error while exporting ${entry.alias} icons: ${payload.err}`);
+              process.exit(ERROR_CODES.NETWORK_ERROR);
+            }
+            for (const glyph of chunk) {
+              const imageUrl = payload.images[glyph.id];
+              if (!imageUrl) continue;
+              const svgRes = await fetch(imageUrl);
+              if (!svgRes.ok) continue;
+              await fs.writeFile(path.join(iconsDir, `${glyph.slug}.svg`), await svgRes.text(), 'utf-8');
+              downloaded++;
+            }
+          }
+          const elapsed = stopSpinner();
+          console.log(`✓ Downloaded: ${entry.alias} icons (${downloaded}/${glyphs.length} glyphs, ${elapsed})`);
         }
       }
 

--- a/packages/cli/tests/unit/commands/fetchIcons.test.ts
+++ b/packages/cli/tests/unit/commands/fetchIcons.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { collectGlyphComponents } from '../../../src/commands/FetchCommand.js';
+
+const PATTERN = 'DS Icon asset / {i}';
+
+function component(id: string, name: string, children: unknown[] = []) {
+  return { id, name, type: 'COMPONENT', children };
+}
+
+describe('collectGlyphComponents', () => {
+  it('collects COMPONENT nodes matching the pattern and captures the icon name', () => {
+    const doc = { children: [component('1:1', 'DS Icon asset / Check'), component('1:2', 'Button')] };
+    const glyphs = collectGlyphComponents(doc, PATTERN);
+    expect(glyphs).toEqual([{ id: '1:1', name: 'Check', slug: 'check' }]);
+  });
+
+  it('ignores non-COMPONENT nodes even when their names match', () => {
+    const doc = {
+      children: [
+        { id: '2:1', name: 'DS Icon asset / Close', type: 'FRAME', children: [] },
+        { id: '2:2', name: 'DS Icon asset / Close', type: 'INSTANCE', children: [] },
+      ],
+    };
+    expect(collectGlyphComponents(doc, PATTERN)).toEqual([]);
+  });
+
+  it('walks nested children at any depth', () => {
+    const doc = {
+      children: [
+        { id: 'p', name: 'Page', type: 'CANVAS', children: [
+          { id: 'f', name: 'Icons', type: 'FRAME', children: [component('3:1', 'DS Icon asset / Star')] },
+        ] },
+      ],
+    };
+    expect(collectGlyphComponents(doc, PATTERN)).toHaveLength(1);
+  });
+
+  it('kebabizes spaces, underscores, and camelCase into stable slugs', () => {
+    const doc = {
+      children: [
+        component('4:1', 'DS Icon asset / Arrow Left'),
+        component('4:2', 'DS Icon asset / expandMore'),
+        component('4:3', 'DS Icon asset / snake_case_name'),
+        component('4:4', 'DS Icon asset /   padded   '),
+      ],
+    };
+    const slugs = collectGlyphComponents(doc, PATTERN).map(g => g.slug);
+    expect(slugs).toEqual(['arrow-left', 'expand-more', 'snake-case-name', 'padded']);
+  });
+
+  it('suffixes duplicate slugs with the node id instead of dropping them', () => {
+    const doc = {
+      children: [component('5:1', 'DS Icon asset / Check'), component('5:2', 'DS Icon asset / check')],
+    };
+    const slugs = collectGlyphComponents(doc, PATTERN).map(g => g.slug);
+    expect(slugs).toEqual(['check', 'check-5-2']);
+  });
+
+  it('escapes regex-special characters in the pattern', () => {
+    const doc = { children: [component('6:1', 'Icons (v2) / Check'), component('6:2', 'Icons xv2y / Check')] };
+    const glyphs = collectGlyphComponents(doc, 'Icons (v2) / {i}');
+    expect(glyphs).toEqual([{ id: '6:1', name: 'Check', slug: 'check' }]);
+  });
+
+  it('requires a full-name match, not a substring', () => {
+    const doc = { children: [component('7:1', 'Prefix DS Icon asset / Check suffix')] };
+    expect(collectGlyphComponents(doc, PATTERN)).toEqual([]);
+  });
+
+  it('a pattern without {i} matches literally and uses the full name', () => {
+    const doc = { children: [component('8:1', 'Logo')] };
+    expect(collectGlyphComponents(doc, 'Logo')).toEqual([{ id: '8:1', name: 'Logo', slug: 'logo' }]);
+  });
+
+  it('returns empty for null or non-object documents', () => {
+    expect(collectGlyphComponents(null, PATTERN)).toEqual([]);
+    expect(collectGlyphComponents(undefined, PATTERN)).toEqual([]);
+    expect(collectGlyphComponents('text', PATTERN)).toEqual([]);
+  });
+});

--- a/site/src/content/docs/cli/commands/fetch.md
+++ b/site/src/content/docs/cli/commands/fetch.md
@@ -16,6 +16,7 @@ specs fetch [options]
 - Fetching `variables` or `styles` requires your Figma organization to be on an **Enterprise** plan — Figma restricts those REST endpoints regardless of your Specs license. `file` and `icons` data work on any plan. See [CLI Requirements](/cli/#requirements).
 - Fetching `icons` additionally requires:
   - `config.processing.glyphNamePattern` set in your config (see [Glyph Name Pattern](/guides/glyph-name-pattern/))
+  - `outputDirectory` set in your config — icon assets are written to the spec workspace, not the data directory
   - the source's `file` payload — listed before `icons` in the same `data` array, or fetched in a previous run
 
 ## Options
@@ -71,7 +72,7 @@ sources:
 How it works:
 
 - Glyph components are **derived from the file payload** — every `COMPONENT` node whose name matches `config.processing.glyphNamePattern` (with `{i}` capturing the icon name). No `scan` step is involved.
-- SVGs are exported through the Figma images API in batches and written to `<dataDirectory>/icons/`.
+- SVGs are exported through the Figma images API in batches and written to `<outputDirectory>/_icons/` — beside the `_images/` assets and the component specs that reference them, not into the regenerable data cache.
 - Filenames are stable kebab-case slugs of the captured icon name, including camelCase splitting: `expandMore` → `expand-more.svg`, `Arrow Left` → `arrow-left.svg`.
 - Two icons that slug identically keep the first as-is; later duplicates are suffixed with their node id so nothing is silently dropped.
 
@@ -90,7 +91,7 @@ Because glyphs come from the saved file payload, `icons` runs after the other ki
 specs fetch --only library --verbose
 ```
 
-The downloaded assets match the slugs referenced by generated component output (masked glyph spans resolve `/assets/icons/<slug>.svg`), so serving `<dataDirectory>/icons/` as a static assets directory — for example in Storybook — makes icons render without further mapping.
+The downloaded assets match the slugs referenced by generated component output (masked glyph spans resolve `/assets/icons/<slug>.svg`), so serving `<outputDirectory>/_icons/` as a static assets directory — for example in Storybook — makes icons render without further mapping. Keeping icons in the spec workspace means a cloned workspace renders completely without re-fetching.
 
 ## Fetching Figma Branches
 

--- a/site/src/content/docs/cli/commands/fetch.md
+++ b/site/src/content/docs/cli/commands/fetch.md
@@ -75,6 +75,14 @@ How it works:
 - Filenames are stable kebab-case slugs of the captured icon name, including camelCase splitting: `expandMore` → `expand-more.svg`, `Arrow Left` → `arrow-left.svg`.
 - Two icons that slug identically keep the first as-is; later duplicates are suffixed with their node id so nothing is silently dropped.
 
+### What gets exported
+
+Each glyph is exported through Figma's images API, which renders the component **as it currently appears**:
+
+- Only layers visible in the component's saved state are included — hidden layers are omitted from the SVG.
+- Variables resolve to their default modes; the export does not enumerate other modes or variable states.
+- One component exports one SVG. If a glyph component packs multiple icons toggled by boolean variables, only the default-visible icon is exported — that authoring pattern is not supported. Use one component per icon for complete asset coverage.
+
 Because glyphs come from the saved file payload, `icons` runs after the other kinds. If the payload is missing, fetch exits with an error telling you to fetch `file` first.
 
 ```bash

--- a/site/src/content/docs/cli/commands/fetch.md
+++ b/site/src/content/docs/cli/commands/fetch.md
@@ -13,7 +13,10 @@ specs fetch [options]
 
 - `FIGMA_TOKEN` must be set in your environment.
 - `specs.config.yaml` must include `dataDirectory` (or deprecated `sourceDirectory`) and `sources`.
-- Fetching `variables` or `styles` requires your Figma organization to be on an **Enterprise** plan — Figma restricts those REST endpoints regardless of your Specs license. `file` data works on any plan. See [CLI Requirements](/cli/#requirements).
+- Fetching `variables` or `styles` requires your Figma organization to be on an **Enterprise** plan — Figma restricts those REST endpoints regardless of your Specs license. `file` and `icons` data work on any plan. See [CLI Requirements](/cli/#requirements).
+- Fetching `icons` additionally requires:
+  - `config.processing.glyphNamePattern` set in your config (see [Glyph Name Pattern](/guides/glyph-name-pattern/))
+  - the source's `file` payload — listed before `icons` in the same `data` array, or fetched in a previous run
 
 ## Options
 
@@ -53,6 +56,33 @@ specs fetch --verbose
 # Only refresh foundations payloads
 specs fetch --only foundations --verbose
 ```
+
+## Fetching Icon Assets
+
+Add `icons` to a source's `data` array to download the library's icon glyphs as SVG files:
+
+```yaml
+sources:
+  library:
+    key: YOUR_FILE_KEY
+    data: ['file', 'variables', 'styles', 'icons']
+```
+
+How it works:
+
+- Glyph components are **derived from the file payload** — every `COMPONENT` node whose name matches `config.processing.glyphNamePattern` (with `{i}` capturing the icon name). No `scan` step is involved.
+- SVGs are exported through the Figma images API in batches and written to `<dataDirectory>/icons/`.
+- Filenames are stable kebab-case slugs of the captured icon name, including camelCase splitting: `expandMore` → `expand-more.svg`, `Arrow Left` → `arrow-left.svg`.
+- Two icons that slug identically keep the first as-is; later duplicates are suffixed with their node id so nothing is silently dropped.
+
+Because glyphs come from the saved file payload, `icons` runs after the other kinds. If the payload is missing, fetch exits with an error telling you to fetch `file` first.
+
+```bash
+# Refresh just the icon assets (file payload already on disk)
+specs fetch --only library --verbose
+```
+
+The downloaded assets match the slugs referenced by generated component output (masked glyph spans resolve `/assets/icons/<slug>.svg`), so serving `<dataDirectory>/icons/` as a static assets directory — for example in Storybook — makes icons render without further mapping.
 
 ## Fetching Figma Branches
 

--- a/site/src/content/docs/guides/glyph-name-pattern.md
+++ b/site/src/content/docs/guides/glyph-name-pattern.md
@@ -127,6 +127,19 @@ glyphNamePattern: 'Icons (v2) / {i}'
 
 The right pattern depends on how your Figma library names its icon glyph components. Open your icon library in Figma and look at the component names — the prefix before the individual icon name is what goes before `{i}`.
 
+## Fetching the Assets
+
+The same pattern powers asset download: `specs fetch` with `icons` in a source's `data` array walks the fetched file payload for components matching `glyphNamePattern` and downloads each one as an SVG to `<dataDirectory>/icons/`:
+
+```yaml
+sources:
+  library:
+    key: YOUR_FILE_KEY
+    data: ['file', 'icons']
+```
+
+Filenames are kebab-case slugs of the extracted name (`Arrow Left` → `arrow-left.svg`, `expandMore` → `expand-more.svg`) — the same slugs generated component output references, so serving the directory as static assets makes glyphs render directly. See [fetch](/cli/commands/fetch/#fetching-icon-assets) for details.
+
 ## Prop Binding
 
 When a glyph element's Figma instance node has a `mainComponent` **component property reference** (an instance swap prop), the `content` field is automatically bound to that prop. This means the glyph name tracks the prop value across variants:

--- a/site/src/content/docs/guides/glyph-name-pattern.md
+++ b/site/src/content/docs/guides/glyph-name-pattern.md
@@ -129,7 +129,7 @@ The right pattern depends on how your Figma library names its icon glyph compone
 
 ## Fetching the Assets
 
-The same pattern powers asset download: `specs fetch` with `icons` in a source's `data` array walks the fetched file payload for components matching `glyphNamePattern` and downloads each one as an SVG to `<dataDirectory>/icons/`:
+The same pattern powers asset download: `specs fetch` with `icons` in a source's `data` array walks the fetched file payload for components matching `glyphNamePattern` and downloads each one as an SVG to `<outputDirectory>/_icons/`, beside the `_images/` assets:
 
 ```yaml
 sources:


### PR DESCRIPTION
`specs fetch` now derives the library's icon glyphs from the downloaded file payload and fetches their SVG assets alongside the existing kinds:

- `file`, `variables`, `styles`, and now `icons`
- Glyphs are derived from the file payload itself — no `scan` dependency
- Icon names kebabize (including camelCase like `expandMore` → `expand-more`) into stable asset slugs

Self-contained change to `FetchCommand.ts`; existing fetch behavior is unchanged when `icons` isn't requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D8F4U7o3pF7QeEuKWZwAx