### PR TITLE
ADR-066: Lossless key formatting — safe key grammar and Figma name preservation

### DIFF
--- a/.github/agents/Specs.adr.accept.agent.md
+++ b/.github/agents/Specs.adr.accept.agent.md
@@ -17,12 +17,25 @@ You **MUST** consider the user input before proceeding (if not empty).
      - Use `BRANCH` directly as `ADR_NAME` (e.g., `011-icon-glyph-as-content`).
    - The branch name must match an ADR name pattern (starts with a number sequence followed by a hyphen, e.g., `011-`). If no ADR number is found, halt: "Branch does not appear to be an ADR branch."
 
-2. **Load context**:
-   - **REQUIRED**: Read `$REPO_ROOT/adr/$ADR_NAME.md` — confirm Status is `DRAFT` (if already `ACCEPTED`, report and halt)
-   - Confirm that `types/`, `schema/`, `package.json`, and `CHANGELOG.md` have been modified by the implement agent (check git status or file timestamps)
-   - If no changes are detected, halt: "Run the implement agent first."
+2. **Check for an existing PR — do this before any other work.** An ADR branch may already be in review from an earlier session; this command must never open a second PR for the same branch.
 
-3. **Re-run validation gates**:
+   ```bash
+   gh pr list --head "$BRANCH" --state all --json number,title,state,baseRefName,url
+   ```
+
+   - **An OPEN PR exists** → set `EXISTING_PR` to its number and `$RELEASE_BRANCH` to its `baseRefName`. This run is an *update*, not a creation. Skip step 7 (release-branch determination) — the existing PR's base is authoritative. Report the PR number and base to the user before continuing.
+   - **A MERGED PR exists** → halt: "This ADR branch was already merged in PR #N. Accepting again would need a new branch."
+   - **A CLOSED (unmerged) PR exists** → do not reopen or replace it silently. Report it and ask the user whether to open a new PR or reopen that one.
+   - **No PR exists** → normal path; `EXISTING_PR` is unset.
+
+3. **Load context**:
+   - **REQUIRED**: Read `$REPO_ROOT/adr/$ADR_NAME.md` — confirm Status is `DRAFT`.
+     - If already `ACCEPTED` **and** `EXISTING_PR` is set with no uncommitted changes, halt: "ADR is already accepted and PR #N is open — nothing to do."
+     - If already `ACCEPTED` and there *are* uncommitted changes, this is a follow-up edit: skip the status flip in step 5, and continue so the changes are validated, committed, and pushed to the existing PR.
+   - Confirm that `types/`, `schema/`, `package.json`, and `CHANGELOG.md` have been modified by the implement agent (check git status or file timestamps)
+   - If no changes are detected **and** `EXISTING_PR` is unset, halt: "Run the implement agent first."
+
+4. **Re-run validation gates**:
    - Run: `tsc -p tsconfig.build.json --noEmit`
      - If exit code ≠ 0: halt and display errors. Do not set ACCEPTED.
    - Run: `scripts/validate-schema.sh`
@@ -30,29 +43,34 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Run: `tsc --noEmit --strict tests/*.test-d.ts` (if `tests/*.test-d.ts` files exist)
      - If exit code ≠ 0: halt and display errors. Do not set ACCEPTED.
 
-4. **Mark ADR ACCEPTED**: In `$REPO_ROOT/adr/$ADR_NAME.md` header, change `Status: DRAFT` to `Status: ACCEPTED`.
+5. **Mark ADR ACCEPTED**: In `$REPO_ROOT/adr/$ADR_NAME.md` header, change `Status: DRAFT` to `Status: ACCEPTED`. Skip if step 3 determined the ADR is already `ACCEPTED`.
 
-5. **Update INDEX**: Read `adr/INDEX.md` and update the entry for this ADR:
+6. **Update INDEX**: Read `adr/INDEX.md` and update the entry for this ADR:
    - Move the row from the **Draft** table to the **Accepted** table (descending by number).
    - Update the **Title** to match the final ADR heading (it may have changed during implementation).
    - Add a **Highlights** summary (max 144 characters) describing the key change as accepted.
    - If no entry exists in the Draft table (older ADR created before INDEX tracking), add the row directly to the Accepted table.
 
-6. **Determine release branch**: Release branches follow the `release/<pkg>-<version>` convention and may jointly cover multiple published packages (e.g., `release/schema-0.21.0-cli-0.16.0`). Do **not** invent a bare version-number branch (e.g., `0.21.0`).
+7. **Determine release branch** *(skip entirely if `EXISTING_PR` is set — use that PR's base)*: Release branches follow the `release/<pkg>-<version>` convention and may jointly cover multiple published packages (e.g., `release/schema-0.21.0-cli-0.16.0`). Do **not** invent a bare version-number branch (e.g., `0.21.0`).
    1. Find active in-flight release branches with `git branch -r --list 'origin/release/*'`.
    2. **Default: use the existing active release branch.** ADR branches are started from the current release branch, so the active branch is the correct target. Do not cross-reference the ADR's semver version against the branch name — the branch name reflects where the release *started*, not the final published version.
    3. If exactly one release branch exists, use it as `$RELEASE_BRANCH` without asking.
    4. If multiple release branches exist, pick the one the ADR branch was based on (`git merge-base --fork-point` or ask the user).
    5. Only if **no** release branch exists at all, create one from `main` following the `release/<pkg>-<version>` convention, naming every package the release will publish.
 
-7. **Create PR**: Commit any uncommitted changes (the status flip and INDEX update), push `$BRANCH`, and open a PR into the release branch using `gh pr create --base $RELEASE_BRANCH`.
+8. **Push, and create the PR only if there isn't one**: Commit any uncommitted changes (the status flip and INDEX update) and push `$BRANCH`.
+   - **`EXISTING_PR` set** → the push updates that PR. Do **not** run `gh pr create`. Read the PR's current body (`gh pr view $EXISTING_PR --json body`) and, if it no longer describes what is on the branch, offer to update it with `gh pr edit $EXISTING_PR --body-file <path>` — ask first, since the user may have written it by hand.
+   - **`EXISTING_PR` unset** → open a PR into the release branch with `gh pr create --base $RELEASE_BRANCH`.
+   - Pass long PR bodies via `--body-file`, not an inline heredoc — bodies containing backticks and quotes break shell parsing.
 
-8. **Report**: Confirm all gates passed, the ADR is ACCEPTED, and the PR has been created. List the next steps:
+9. **Report**: Confirm all gates passed, the ADR is ACCEPTED, and state whether the PR was **created** or an **existing PR was updated** (with its number). List the next steps:
    - Review and merge the PR into the release branch
    - When all ADRs for the release are complete, merge `$RELEASE_BRANCH` into `main` and `npm publish`
 
 ## Key rules
 
 - This command only flips the ADR status — it does not apply any code changes.
-- Status MUST only move to `ACCEPTED` after all three validation gates pass in step 3.
+- Status MUST only move to `ACCEPTED` after all three validation gates pass in step 4.
+- **Never open a second PR for a branch that already has one.** Step 2 runs before everything else for this reason. This command is re-runnable: an ADR branch may already be in review from an earlier session, and re-running must update that PR, not duplicate it.
+- Verify repo and PR state by querying it — never infer from the conversation or assume a branch is fresh.
 - Use absolute paths for all file operations.

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -2,7 +2,7 @@
 
 **Branch**: `066-lossless-key-formatting`
 **Created**: 2026-08-10
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — extends ADR-058)*
 

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -126,25 +126,34 @@ Ship both spellings, remove `originalName` at the next MAJOR.
 
 Reversal needs a stated target: given `iconLeading`, a renderer can only reconstruct the Figma name if it knows what convention that file's names follow. Three ways to supply it.
 
-#### Option A: New `format.figmaKeys` config field, defaulting to `SENTENCE` *(Selected)*
+#### Option A: New `format.figmaKeys` config field, defaulting to `NONE` *(Selected)*
 
 Add a sibling to `format.keys` declaring the naming convention the Figma file itself uses, so `format.keys` describes the *output* convention and `format.figmaKeys` describes the *source* convention. Reversal is defined as: format the key back into `format.figmaKeys`.
 
 ```yaml
 format:
-  figmaKeys: SENTENCE   # what the Figma file uses    — new, defaults to SENTENCE
+  figmaKeys: SENTENCE   # what the Figma file uses    — new, defaults to NONE
   keys: KEBAB           # what the spec emits         — existing
 ```
 
-The accepted values are `SENTENCE` and `TITLE` only — the two conventions observed in practice for Figma layer and component-property names. This is deliberately narrower than `format.keys`; values are added when a real file requires them, not in anticipation.
+The accepted values are `NONE`, `SENTENCE`, and `TITLE`. `SENTENCE` and `TITLE` are the two conventions observed in practice for Figma layer and component-property names — deliberately narrower than `format.keys`; values are added when a real file requires them, not in anticipation.
+
+`NONE` is the default and means **no source convention is declared**. Under `NONE` the producer asserts nothing about the file's names, so the safe key grammar is not evaluated, no `name` is emitted for format divergence, and no reversal target exists. The ADR-058 wrapper-collapse trigger for `name` is unaffected — it does not depend on a declared convention.
+
+Everything this ADR adds is therefore **opt-in**: a catalog gets the grammar check, the divergence extension, and reversible rendering by declaring `figmaKeys: SENTENCE | TITLE`, and keeps today's *behavior* by leaving it alone.
+
+`NONE` is not byte-identical to today's output. The `originalName` → `name` rename applies unconditionally, so any catalog with a wrapper-collapsed element emits a differently-spelled extension under `NONE` too. What `NONE` preserves is the behavior — which names are formatted, which extensions are triggered — not the bytes.
+
+Opting in is a real trade, not a free upgrade. A catalog that declares `SENTENCE` buys lossless round-tripping and pays for it in spec complexity: every name outside the safe grammar, and every name already written in the destination format, grows a `$extensions` block. On a catalog with inconsistent Figma naming that is a lot of new noise in the output. That cost is the reason the default is `NONE` — the author decides whether the fidelity is worth the specs it produces.
 
 **Pros**:
 - Reversal becomes a declared, symmetric pair rather than a hardcoded assumption.
 - Files authored in `Title Case` become losslessly reversible without emitting `name` on every key.
-- Defaulting to `SENTENCE` keeps current behavior for every existing config — the field is optional and additive.
-- Both accepted values use single-space separators, so the safe grammar's character rules stay uniform and only its casing clause varies.
+- Defaulting to `NONE` makes the checks and preservation behavior opt-in. No existing catalog changes output, and no catalog is told its layer names are "unsafe" against a convention it never claimed.
+- Both non-`NONE` values use single-space separators, so the safe grammar's character rules stay uniform and only its casing clause varies.
 
 **Cons / Trade-offs**:
+- The default is the *un*safe setting: a catalog gets lossy keys until someone opts in. This is deliberate — the alternative is asserting a convention on the author's behalf and emitting extensions against an assumption they never made.
 - A file with mixed conventions still diverges from whatever single value is declared, so `name` remains necessary as the escape hatch.
 - A future file using an unlisted convention needs a schema change to declare it, rather than picking an already-present enum value.
 
@@ -194,6 +203,53 @@ Preserve selected symbols through formatting rather than deleting them.
 
 ---
 
+### Decision 5 — Names already written in the destination format
+
+A real Figma file is rarely uniform. A library that is largely `Sentence case` may still carry property names authored as code identifiers — `isDisabled`, `hasIcon` — because they were named for the engineers consuming them. Under `figmaKeys: SENTENCE`, `keys: CAMEL`, `isDisabled` is *unsafe* by the grammar (its first character is lowercase), yet `format.keys` leaves it exactly as it found it, and it is already the name the author wants on both sides.
+
+The forward direction is not the problem — `CAMEL` is idempotent over an already-camel name. The problem is **reversal**: a renderer told to reconstruct the Figma name by formatting `isDisabled` into `SENTENCE` produces `Is disabled` and renames a property the author deliberately spelled `isDisabled`.
+
+#### Option A: Detect destination-format names, pass through, and record `name` *(Selected)*
+
+A source name that does not match the declared `figmaKeys` grammar but *does* match the grammar of the declared `format.keys` value is **already in the destination format**. It is passed through unformatted, and `com.figma.name` is emitted so reversal restores it verbatim rather than re-deriving it.
+
+```yaml
+# figmaKeys: SENTENCE, keys: CAMEL
+props:
+  iconLeading:            # from "Icon leading" — SENTENCE-safe, formatted, quiet
+    type: glyph
+  isDisabled:             # authored as "isDisabled" in Figma — already CAMEL
+    type: boolean
+    $extensions:
+      com.figma:
+        name: isDisabled  # reversal is identity, not "Is disabled"
+```
+
+**Pros**:
+- Answers the case directly: mixed-convention files stop being rewritten on render.
+- Requires no new field — the escape hatch this ADR already adds carries it.
+- The detection is a pure predicate over two declared grammars, not inference about the file.
+
+**Cons / Trade-offs**:
+- **Detection alone cannot make it quiet.** `iconLeading` (formatted from `Icon leading`) and `isDisabled` (authored as-is) are both valid `CAMEL` and both invalid `SENTENCE`. Nothing in the emitted key distinguishes them, so the pass-through case *must* record `name`. Under a lossy `format.keys`, a catalog with many destination-format names will not be extension-free.
+- Only meaningful when a convention is declared. Under `figmaKeys: NONE` there is no grammar to fail, so there is nothing to detect and no reversal to protect.
+
+---
+
+#### Option B: Format everything, as today *(Rejected)*
+
+**Rejected because**: it makes the render direction actively destructive on exactly the files most likely to adopt it — the ones already naming properties for their code consumers. Renaming `isDisabled` to `Is disabled` is a silent, unrequested edit to the author's file.
+
+---
+
+#### Option C: Pass through silently, without `name` *(Rejected)*
+
+**Rejected because**: it is undecidable at read time, as Option A's trade-off shows. A consumer seeing `isDisabled` cannot tell whether the Figma name is `isDisabled` or `Is disabled`, which is the precise ambiguity this ADR exists to eliminate. Quiet output is a driver, but not at the cost of the round-trip guarantee.
+
+This is not the same ambiguity as `figmaKeys: NONE`. Under `NONE` no convention is declared, so a consumer knows reversal is undefined and has no license to reconstruct anything — the spec makes no promise it cannot keep. Option C declares `SENTENCE`, invites a consumer to reverse into it, and then silently exempts some keys from that promise. Undeclared is safe; declared-and-selectively-violated is not.
+
+---
+
 ## Decision
 
 ### The source convention — `format.figmaKeys`
@@ -202,12 +258,24 @@ Preserve selected symbols through formatting rather than deleting them.
 
 | Value | Shape | Example |
 |-------|-------|---------|
-| `SENTENCE` *(default)* | First word capitalized, rest lowercase, single spaces | `Icon leading` |
+| `NONE` *(default)* | No convention declared — grammar not evaluated, no reversal target | — |
+| `SENTENCE` | First word capitalized, rest lowercase, single spaces | `Icon leading` |
 | `TITLE` | Every word capitalized, single spaces | `Icon Leading` |
 
-Both are source conventions only; neither is accepted by `format.keys`, which describes what the spec emits.
+`SENTENCE` and `TITLE` are source conventions only; neither is accepted by `format.keys`, which describes what the spec emits.
+
+`NONE` is the default, and everything below is gated on a value other than `NONE`:
+
+- The safe key grammar is not evaluated.
+- `com.figma.name` is not emitted for format divergence. The ADR-058 wrapper-collapse trigger is independent of `figmaKeys` and continues to emit it.
+- Destination-format pass-through (below) does not apply — there is no grammar for a name to fail.
+- Reversal is undefined. A renderer reading a spec produced under `NONE` has no declared target and MUST fall back to `com.figma.name` where present and the formatted key otherwise — today's behavior.
+
+Declaring `SENTENCE` or `TITLE` opts the catalog into all of it.
 
 ### The safe key grammar
+
+*Applies only when `format.figmaKeys` is `SENTENCE` or `TITLE`.*
 
 A name is **round-trip safe** when it satisfies both the character rules and the casing rule for the declared `format.figmaKeys`.
 
@@ -215,16 +283,52 @@ Character and word rules, identical for both `figmaKeys` values:
 
 - ASCII letters and digits only — no `&`, `+`, `/`, `.`, parentheses, punctuation, or non-ASCII letters.
 - Exactly one space between words. No leading, trailing, or repeated spaces.
-- No word begins with a digit — a digit-leading word loses its boundary under `CAMEL` and `PASCAL`.
+- A word is either all letters or all digits. A digit run is always its own word — `Badge count 2` is three words; `Badge count2` is not safe.
+- The name does not begin with a digit — the first word is always a letter word.
 
 Casing rule, per declared convention:
 
 | `figmaKeys` | Pattern |
 |-------------|---------|
-| `SENTENCE` | `^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$` |
-| `TITLE` | `^[A-Z][a-z0-9]*( [A-Z][a-z0-9]*)*$` |
+| `SENTENCE` | `^[A-Z][a-z]*( ([a-z]+\|[0-9]+))*$` |
+| `TITLE` | `^[A-Z][a-z]*( ([A-Z][a-z]*\|[0-9]+))*$` |
+
+### The word-splitting rule
+
+Reversal is only deterministic if formatting and reversal split words the same way. Both directions split on:
+
+- **Spaces**, in the source name.
+- **Case transitions**, lower→upper (`iconLeading` → `icon` + `Leading`).
+- **Letter↔digit transitions**, in both directions (`badgeCount2` → `badge` + `count` + `2`).
+
+The letter↔digit clause is what makes `Badge count 2` safe: it formats to `badgeCount2` and splits back to `badge` / `count` / `2`, recovering the boundary. It is also why `Badge count2` is *not* safe — it formats to the same `badgeCount2`, which reverses to `Badge count 2`, not to the authored name. The grammar excludes mixed letter-digit words precisely so that no two safe names collapse onto one key by this route.
 
 Names satisfying the grammar reconstruct identically from the output of any `format.keys` value. Names that do not satisfy it require `com.figma.name` to be recoverable.
+
+### Destination-format pass-through
+
+*Applies only when `format.figmaKeys` is `SENTENCE` or `TITLE`.*
+
+A source name is **already in the destination format** when it satisfies all three:
+
+1. `format.keys` is not `SAFE`.
+2. The name fails the safe key grammar for the declared `figmaKeys`.
+3. Formatting is a no-op — `formatKey(name, format.keys) === name`.
+
+Such a name is **passed through unformatted** and records `com.figma.name` with its verbatim value. Reversal for it is identity, not re-derivation.
+
+Clause 3 is deliberately an idempotence test rather than a per-format grammar. Defining "a well-formed `CAMEL` key" would mean writing and maintaining six grammars the schema does not otherwise need, and the producer already owns the one function that decides it. The test is mechanically checkable by any consumer holding the same formatter, which is what the driver requires.
+
+Clause 1 exists because `SAFE` is the identity format: `formatKey(name, SAFE) === name` for every name, so clause 3 alone would classify every grammar-failing name as pass-through and emit `name` on all of them. Under `SAFE` the key *is* the Figma name, reversal is already identity, and no extension is warranted.
+
+```yaml
+# figmaKeys: SENTENCE, keys: CAMEL
+Icon leading   → iconLeading   # grammar-safe: formatted, no extension, reverses to "Icon leading"
+isDisabled     → isDisabled    # formatting is a no-op: passed through, name: isDisabled, reverses to itself
+URL field      → urlField      # fails the grammar, formatting changes it: formatted, name: URL field
+```
+
+The pass-through case always emits `name`. `iconLeading` and `isDisabled` are both valid `CAMEL` and both invalid `SENTENCE`, so the emitted key carries no signal a consumer could use to tell a formatted key from a natively-formatted one — the extension is the only thing that distinguishes them.
 
 ```yaml
 # figmaKeys: SENTENCE
@@ -232,13 +336,15 @@ Names satisfying the grammar reconstruct identically from the output of any `for
 # Safe — survives every format.keys value
 Icon leading        # → iconLeading | icon_leading | icon-leading | IconLeading | Icon-Leading
 Label
-Badge count 2
+Badge count 2       # → badgeCount2 — the digit is its own word, boundary recovered
+Icon 2 leading      # → icon2Leading — same rule
 
 # Unsafe — requires $extensions.com.figma.name
 Icon-leading        # separator is not a space
 Icon Leading        # casing diverges from SENTENCE (safe under figmaKeys: TITLE)
 URL field           # inner capitals lost
-Icon 2 leading      # digit-leading word — boundary lost under CAMEL/PASCAL
+Badge count2        # mixed letter-digit word — reverses to "Badge count 2"
+2 icons             # name begins with a digit
 Cut & paste         # symbol deleted, word boundary lost
 Size (large)        # parentheses deleted
 Étiquette           # non-ASCII letter deleted
@@ -250,7 +356,7 @@ Size (large)        # parentheses deleted
 |------|--------|------|
 | `Anatomy.ts` | Renamed `FigmaAnatomyElementExtension.originalName` → `name`, widened to record the Figma name whenever the anatomy key diverges from it (format projection or wrapper collapse) | MAJOR |
 | `Props.ts` | Added optional field `name` to `FigmaPropExtension` | MINOR |
-| `Config.ts` | Added optional field `format.figmaKeys` to `Config`, required field `format.figmaKeys` to `ResolvedConfig`, and `figmaKeys: 'SENTENCE'` to `DEFAULT_CONFIG` | MINOR |
+| `Config.ts` | Added optional field `format.figmaKeys` to `Config`, required field `format.figmaKeys` to `ResolvedConfig`, and `figmaKeys: 'NONE'` to `DEFAULT_CONFIG` | MINOR |
 | `Config.ts` | Expanded `format.keys` documentation to reference `format.figmaKeys` and the safe key grammar | PATCH |
 
 **Example — anatomy extension** (`types/Anatomy.ts`):
@@ -292,7 +398,7 @@ Config.format:
 Config.format:
   output?: 'JSON' | 'YAML'
   keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
-  figmaKeys?: 'SENTENCE' | 'TITLE'   # optional — defaults to SENTENCE
+  figmaKeys?: 'NONE' | 'SENTENCE' | 'TITLE'   # optional — defaults to NONE
 ```
 
 **Example — emitted spec under `format.keys: KEBAB`, `format.figmaKeys: SENTENCE`**:
@@ -329,26 +435,27 @@ elements:
 | `component.schema.json` | Added property `name` to `FigmaPropExtension` | MINOR |
 | `component.schema.json` | Added definitions `SafeKeySentence` and `SafeKeyTitle` with their `pattern`s and descriptions | MINOR |
 | `component.schema.json` | Expanded descriptions of `Anatomy` and `Props` to reference the safe key definitions | PATCH |
-| `workspace.schema.json` | Added property `figmaKeys` under `format`, enum `[SENTENCE, TITLE]`, default `SENTENCE` | MINOR |
+| `workspace.schema.json` | Added property `figmaKeys` under `format`, enum `[NONE, SENTENCE, TITLE]`, default `NONE` | MINOR |
 
 **Example — new definitions** (`schema/component.schema.json`):
 
 ```yaml
 SafeKeySentence:
   type: string
-  pattern: "^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$"
+  pattern: "^[A-Z][a-z]*( ([a-z]+|[0-9]+))*$"
   description: >-
     A round-trip-safe Figma name under format.figmaKeys SENTENCE: ASCII letters
-    and digits, single-space word separators, sentence case, no digit-leading
-    words. Names matching this pattern reconstruct identically from the output
-    of any format.keys value; names that do not require
-    $extensions.com.figma.name.
+    and digits, single-space word separators, sentence case, each word all
+    letters or all digits, never digit-initial. Names matching this pattern
+    reconstruct identically from the output of any format.keys value; names
+    that do not require $extensions.com.figma.name.
 
 SafeKeyTitle:
   type: string
-  pattern: "^[A-Z][a-z0-9]*( [A-Z][a-z0-9]*)*$"
+  pattern: "^[A-Z][a-z]*( ([A-Z][a-z]*|[0-9]+))*$"
   description: >-
-    As SafeKeySentence, but for format.figmaKeys TITLE — every word capitalized.
+    As SafeKeySentence, but for format.figmaKeys TITLE — every letter word
+    capitalized.
 ```
 
 ```yaml
@@ -364,18 +471,21 @@ name:
 # New property under #/definitions/.../format/properties (workspace.schema.json)
 figmaKeys:
   type: string
-  enum: [SENTENCE, TITLE]
-  default: SENTENCE
+  enum: [NONE, SENTENCE, TITLE]
+  default: NONE
   description: >-
     Naming convention the Figma file uses for layer names and component
-    property names. Reversal target for format.keys.
+    property names. Reversal target for format.keys. NONE (the default)
+    declares no convention — the safe key grammar is not evaluated, no
+    com.figma.name is emitted for format divergence, and reversal is undefined.
 ```
 
 ### Notes
 
 - `format.figmaKeys` describes the source, `format.keys` describes the output. They are independent; `figmaKeys: SENTENCE` with `keys: SAFE` is the identity case where keys are emitted as authored.
+- `figmaKeys: NONE` (the default) preserves today's behavior, though not today's bytes — the `originalName` → `name` rename applies under it. It is the "I have not told you what my file looks like" value, not a claim that the file has no convention.
 - `SafeKeySentence` and `SafeKeyTitle` are definitions, not applied constraints on `Anatomy`/`Props` property names. They describe the *Figma-side* name shape, while the keys in a document are in `format.keys` space.
-- `name` remains optional on both surfaces so that conforming catalogs emit no extensions at all.
+- `name` remains optional on both surfaces, so a catalog whose names all satisfy the grammar emits no *format-divergence* extensions. Wrapper collapse still emits `name` on its own trigger, independent of `figmaKeys` and of the grammar.
 - Reference sites are deliberately unchanged. A consumer resolving `elements.url-field` looks up `anatomy['url-field']` and reads `name` there.
 - On `AnatomyElement`, `name` has two triggers — wrapper-collapse promotion and format divergence — that are not distinguished. When both apply, the pre-collapse Figma name is the correct value for both purposes.
 
@@ -405,11 +515,78 @@ The read site in `figma-from-specs` is the one hazard: because it declares the e
 
 ---
 
+## Coverage inventory — every named space in a spec
+
+Two fields (`AnatomyElement.$extensions['com.figma'].name` and `FigmaPropExtension.name`) are claimed to cover all Figma-derived naming in a spec. This inventory is the basis of that claim: every keyed space in the schema, what its keys are, and why it is or is not covered.
+
+| Space | Type | Keys are | Status |
+|-------|------|----------|--------|
+| `anatomy` | `Record<string, AnatomyElement>` | Figma layer names, formatted | **Covered** — `name` on the definition |
+| `props` | `Record<string, AnyProp>` | Figma component-property names, formatted | **Covered** — `name` on the definition |
+| `elements` | `Record<string, Element>` | References to anatomy keys | **Covered by reference** — resolves through `anatomy` (Decision 1) |
+| `propConfigurations` | `Record<string, …>` | References to prop keys | **Covered by reference** — resolves through `props` |
+| `children`, `slotContent` refs, `layout` | key references | References to anatomy keys | **Covered by reference** |
+| `compositions[].anatomy` / `.elements` | nested `Anatomy` / `Elements` | Figma layer names, formatted | **Covered recursively** — same `AnatomyElement` type (`Composition.ts:26-27`) |
+| `slotContentExamples[].anatomy` / `.elements` | nested `Anatomy` / `Elements` | Figma layer names, formatted | **Covered recursively** — same `AnatomyElement` type (`SlotContent.ts:12-13`) |
+| `props.<key>.options` values | string values | Figma variant option values, formatted | **Not covered — gap.** No per-option preservation surface |
+| `subcomponents` | `Record<string, Subcomponent>` | Formatted from `sub.title` | **Not needed** — unformatted `title` sits alongside |
+| `title` (component, composition, instance example) | `string` | Verbatim Figma node name, never formatted | **Not needed** — nothing was projected |
+| `instanceExamples` | `Record<string, InstanceExample>` | Authored identifiers (`^[a-zA-Z0-9_-]+$`), not Figma names | **Out of scope** — carries its own `title` for the label |
+| `compositions` (registry keys) | `Record<string, Composition>` | Authored identifiers | **Out of scope** — carries its own `title` |
+| `slotContentExamples` (registry keys) | `Record<string, SlotContent>` | Authored registry identifiers | **Out of scope** |
+| `images` | `Record<string, ImageData>` | Authored / content-derived identifiers | **Out of scope** |
+| `config.format.states` | `Record<string, VariantStateEntry>` | Config-declared state names | **Out of scope** — config vocabulary, not a Figma name |
+
+Three consequences of this inventory are normative:
+
+- **Reference sites need no schema change.** Because every reference is in formatted key space and resolves to a definition, adding `name` in two places covers every use of those names throughout the document. This is the whole reason Decision 1 selected the definition site.
+- **Producers MUST recurse.** `Anatomy` appears at the top level, inside every `Composition`, and inside every `SlotContent`. A producer that evaluates only the top-level `anatomy` map silently leaves composed and slot-filled elements unprotected, and because the nested type is identical, nothing in the type system catches the omission. Implementation must walk all three.
+- **The out-of-scope rows are out of scope because nothing was projected**, not because the loss is tolerated. They hold authored identifiers or verbatim names, so there is no source name to reconstruct. If a producer ever derives one of these keys from a Figma name, it moves into the covered set and needs its own decision.
+
+This inventory is derived from the schema types and the render-direction write sites. It has not been confirmed against a full sweep of what `specs-from-figma` emits into each registry.
+
+---
+
+## Key application surfaces in `figma-from-specs`
+
+Audited on `feat/figma-from-specs`. Every place the render direction either formats a key or writes a spec key back into Figma as a name, and whether `AnatomyElement.name` / `FigmaPropExtension.name` covers it.
+
+| Surface | Site | Direction | Covered by this ADR |
+|---------|------|-----------|---------------------|
+| Anatomy layer names | `Elements/Elements.ts:231` — `childNode.name = name` | Spec key written to Figma **verbatim, unformatted** | **Yes** — anatomy `name` becomes the value to use here, replacing the raw key |
+| Collapsed-root leaf name | `Elements/Elements.ts:122,131` — reads `originalName` | Extension read | **Yes** — the ADR-058 site; rename to `name` (see Migration) |
+| Component property names | `Props/Props.ts:48,50,53` — `addComponentProperty(name, …)` | Spec prop key written to Figma **verbatim** | **Yes** — prop `name` becomes the value to use |
+| Boolean-pairing property names | `Props/Props.ts:63` — `addComponentProperty(pair.booleanPropName, …)` | Derived from a prop key | **Yes**, transitively — resolves through the same prop `name` |
+| Code-only property names | `Props/CodeOnlyProps.ts:76-77,188,206` — property, container, and layer names | Derived from prop keys and `$extensions.com.figma.source` | **Partly** — the property name resolves through prop `name`, but the layer/pattern names at `:188,206` come from the code-only source block and are not a key-format surface |
+| Prop-configuration property matching | `PropConfigurations/PropConfigurations.ts:103` — `matchFormatted` | Formats the *Figma* name forward and compares | **Yes** — becomes a `name` lookup with the format comparison as fallback |
+| **Variant option values** | `PropConfigurations/PropConfigurations.ts:72` — `formatKey(option, fmt) === specVal` | Formats Figma enum *values* forward and compares | **No — gap.** Enum option values pass through `format.keys` too, and neither `name` field records them. See below |
+| Glyph content keys | `Elements/GlyphElement.ts:32` — `formatKey(rawName, glyphKeyFormat) === contentKey` | Formats a glyph library name forward and compares | **No — out of scope.** Matches against a live glyph manifest, not a spec key; the source name is external to the component |
+| Subcomponent titles | `Subcomponents/Subcomponents.ts:28,42` — `formatKey(sub.title, keyFormat)` | Formats a title into key space to resolve a manifest entry | **Not needed.** `title` is stored unformatted and stays available to reverse from |
+| Component / variant frame names | `Component.ts:83,108,114`, `Variants/Variants.ts:78` | Writes `title` back as the Figma name | **Not needed** — `title` is never in key space (see note below) |
+
+### What this ADR deliberately leaves untouched
+
+The contract covers **anatomy element keys and prop keys**. Three other naming surfaces are explicitly out of scope, for two different reasons.
+
+**Variant option values — a real gap, not fixed here.**
+
+`props.<key>.options` entries are formatted by `format.keys`, and the render direction matches them back by re-formatting the live Figma enum value (`PropConfigurations.ts:72`). `Cut & paste` as an *option value* is exactly as lossy as it is as a key, and `FigmaPropExtension.name` records only the property name — there is no per-option preservation surface. Adding one means a keyed structure under the prop extension, which is a separate decision about the prop extension's shape and is not made here.
+
+**Component titles and subcomponent titles — already lossless, no change needed.**
+
+`title` is not in key space, which is a fact about the read direction: `specs-from-figma` sets `title: this.node.name` verbatim (`Component/Component.ts:283`), so the Figma component name reaches the spec unformatted and no `format.keys` value touches it. Nothing needs preserving, because nothing was ever projected.
+
+In the write direction, `figma-from-specs` formats a title only at the *consumption* site — `Subcomponents.ts:28,42` derives a key from `sub.title` to resolve a manifest entry — and the unformatted `title` remains alongside. Frame naming writes `title` back as-is.
+
+So titles already do what `com.figma.name` does for keys — they record the original name — and they do it in the schema's own field rather than an extension. No `name` extension is added for titles, and none is needed.
+
+---
+
 ## Downstream Impact
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | Must evaluate each anatomy element name and prop name against the safe key grammar for the declared `format.figmaKeys` and emit `name` when it diverges; existing `originalName` write site breaks | Update key formatting to read `format.figmaKeys` and record divergence; rename the emitted extension key; recompile |
+| `specs-from-figma` | When `format.figmaKeys` is not `NONE`, must evaluate each anatomy element name and prop name against the safe key grammar, apply the pass-through test, and emit `name` on divergence or pass-through; existing `originalName` write site breaks under every value including `NONE` | Rename the emitted extension key unconditionally; add the grammar and pass-through evaluation gated on `format.figmaKeys`; align the word splitter with the stated letter↔digit rule; recompile |
 | `specs-cli` | Emits and validates specs carrying the new optional field; the new config key is accepted in workspace config | Recompile against the new schema version; surface `format.figmaKeys` in config resolution and documentation |
 | `specs-plugin-2` | Same emission path as the CLI in the plugin runtime; the render direction reconstructs Figma names by formatting into `format.figmaKeys`, preferring `name` where present | Recompile; use `name` in preference to the formatted key when matching Figma nodes |
 
@@ -419,18 +596,33 @@ The read site in `figma-from-specs` is the one hazard: because it declares the e
 
 **Version bump**: none — lands in the in-flight `0.30.0` (`MAJOR`-class change, released as a pre-1.0 minor)
 
-**Justification**: Renaming `originalName` → `name` removes a published field name, which the constitution classes as `MAJOR`. The package is pre-1.0 and already releases breaking narrowing changes as minors — `0.29.0` narrowed `Styles.textAlignHorizontal` from `Style` to a string enum. `0.30.0` is unreleased and is the version this ADR lands in, so it absorbs the change and `package.json` is unchanged. All other changes are additive: `FigmaPropExtension.name` and `Config.format.figmaKeys` are optional, and the safe-key definitions are referenced only from descriptions. `ResolvedConfig.format.figmaKeys` is required, but `ResolvedConfig` is the post-defaulting shape and `DEFAULT_CONFIG` supplies `SENTENCE`, so no caller loses a valid construction.
+**Justification**: Renaming `originalName` → `name` removes a published field name, which the constitution classes as `MAJOR`. The package is pre-1.0 and already releases breaking narrowing changes as minors — `0.29.0` narrowed `Styles.textAlignHorizontal` from `Style` to a string enum. `0.30.0` is unreleased and is the version this ADR lands in, so it absorbs the change and `package.json` is unchanged. All other changes are additive: `FigmaPropExtension.name` and `Config.format.figmaKeys` are optional, and the safe-key definitions are referenced only from descriptions. `ResolvedConfig.format.figmaKeys` is required, and adding a required field to a published type is `MAJOR`-class in its own right — a caller assembling a `ResolvedConfig` literal rather than spreading `DEFAULT_CONFIG` loses compilation. It is absorbed by the same pre-1.0 `0.30.0` as the rename, and `DEFAULT_CONFIG` supplies `NONE` so the spread path is unaffected.
 
 ---
 
 ## Consequences
 
-- The schema states, for the first time, what an unformatted Figma-side name looks like — declared per workspace via `format.figmaKeys`, defaulting to sentence case.
+- The schema states, for the first time, what an unformatted Figma-side name looks like — declared per workspace via `format.figmaKeys`.
+- No existing catalog changes behavior. `figmaKeys` defaults to `NONE`, so the grammar check, the divergence extension, and reversal are opt-in; a catalog adopts them by naming its convention. Output is not byte-identical — the `originalName` → `name` rename applies regardless of `figmaKeys`.
+- Solving the problem costs spec complexity, and the author chooses whether to pay it. Opting in adds a `$extensions` block to every name outside the safe grammar and every name already written in the destination format. On a catalog with inconsistent Figma naming, that is substantial noise in exchange for fidelity — which is why it is opt-in rather than the default.
+- The default being `NONE` means most catalogs stay lossy until someone opts in. Adoption depends on the value being visible, which is what the analyze report below is for.
 - Key formatting becomes a declared pair — `figmaKeys` in, `keys` out — so reversal is defined by config rather than inferred.
 - The set of names that survive every `format.keys` value is defined by two mechanically checkable patterns rather than by the behavior of one producer.
-- Specs produced with a lossy `format.keys` value carry enough information to reconstruct Figma names, making the spec → Figma direction lossless for anatomy and prop identity.
-- Well-formed catalogs are unchanged — no `$extensions` appear unless a name falls outside the safe grammar, so the field doubles as a signal that a Figma name needs attention.
+- **When `figmaKeys` is declared**, specs produced with a lossy `format.keys` value carry enough information to reconstruct Figma names, making the spec → Figma direction lossless for anatomy and prop identity. Under the `NONE` default they do not, and reversal stays undefined.
+- Well-formed catalogs stay quiet — no format-divergence `$extensions` appear unless a name falls outside the safe grammar, so the field doubles as a signal that a Figma name needs attention. Wrapper collapse emits `name` on its own trigger, so a grammar-conforming catalog is not necessarily extension-free.
+- Two distinct Figma names can still format to the same key — `Cut & paste` and `Cut paste` both reach `cutPaste`, and a pass-through name can collide with a formatted one. This is pre-existing behavior and is not changed here: a keyed record holds one entry per key, so one name wins and the other's `name` is not recorded. The loss belongs to the author who named two things the same in key space, not to the system. The safe grammar is collision-free among safe names, and `analyze keys` is the place to surface the rest.
 - Consumers that match Figma nodes by name MUST prefer `com.figma.name` over the formatted key when it is present; ignoring it reintroduces the divergence this ADR removes.
 - Names outside the safe grammar remain fully supported — they are recorded, not rejected. Narrowing them is an authoring recommendation, not a validation gate.
 - `&`, `+`, and `/` will always trigger the extension. Catalogs wanting extension-free output must avoid them in layer and property names.
 - `format.figmaKeys` starts deliberately narrow at `SENTENCE | TITLE`; encountering a file with another convention is a schema change, not a config choice.
+- The grammar makes naming quality **reportable**, which suggests a follow-on `specs analyze keys` report: run the safe key grammar across a catalog and surface every anatomy element, prop, and option whose Figma name falls outside it — grouped by cause (separator, casing, symbol, mixed letter-digit word, digit-initial, non-ASCII) and by the convention the name *would* be safe under. Two audiences:
+  - **Design-system teams** get a list of layer and property names to fix in Figma, ranked by how many components each affects.
+  - **Adopters of `figmaKeys`** get the evidence for which value to declare — a catalog that is 94% `SENTENCE`-safe and 3% `TITLE`-safe has an obvious answer, and the residue is the exact list of names that will emit `com.figma.name`.
+  The report is also the honest way to run under `figmaKeys: NONE`: no extension is emitted, but the divergence is still measurable and can be shown.
+- Deriving the pass-through and divergence signals is producer behavior (Constitution II). The schema declares the grammar; `analyze keys` is CLI work, out of scope for this ADR.
+- Two fields cover every Figma-derived name in a spec, at every nesting depth, because reference sites resolve through definitions — see the Coverage inventory for the full enumeration and the recursion requirement it places on producers.
+- The contract covers anatomy and prop *identity* only, and three surfaces stay as they are:
+  - **Variant option values** pass through `format.keys` with no preservation field and remain lossy. Closing this needs a per-option surface on the prop extension — a separate decision.
+  - **Component titles** are already the verbatim Figma node name and are never formatted.
+  - **Subcomponent titles** are likewise verbatim; they are formatted only when read, and the unformatted title remains alongside.
+  Titles therefore already record the original name in a first-class field, which is why no extension is added for them.

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -417,9 +417,9 @@ The read site in `figma-from-specs` is the one hazard: because it declares the e
 
 ## Semver Decision
 
-**Version bump**: `0.30.0 → 0.31.0` (`MAJOR`-class, released as a pre-1.0 minor)
+**Version bump**: none — lands in the in-flight `0.30.0` (`MAJOR`-class change, released as a pre-1.0 minor)
 
-**Justification**: Renaming `originalName` → `name` removes a published field name, which the constitution classes as `MAJOR`. The package is pre-1.0 and already releases breaking narrowing changes as minors — `0.29.0` narrowed `Styles.textAlignHorizontal` from `Style` to a string enum — so this ships as `0.31.0` under that established convention. All other changes are additive: `FigmaPropExtension.name` and `Config.format.figmaKeys` are optional, and the safe-key definitions are referenced only from descriptions. `ResolvedConfig.format.figmaKeys` is required, but `ResolvedConfig` is the post-defaulting shape and `DEFAULT_CONFIG` supplies `SENTENCE`, so no caller loses a valid construction.
+**Justification**: Renaming `originalName` → `name` removes a published field name, which the constitution classes as `MAJOR`. The package is pre-1.0 and already releases breaking narrowing changes as minors — `0.29.0` narrowed `Styles.textAlignHorizontal` from `Style` to a string enum. `0.30.0` is unreleased and is the version this ADR lands in, so it absorbs the change and `package.json` is unchanged. All other changes are additive: `FigmaPropExtension.name` and `Config.format.figmaKeys` are optional, and the safe-key definitions are referenced only from descriptions. `ResolvedConfig.format.figmaKeys` is required, but `ResolvedConfig` is the post-defaulting shape and `DEFAULT_CONFIG` supplies `SENTENCE`, so no caller loses a valid construction.
 
 ---
 

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -1,0 +1,363 @@
+# ADR: Lossless key formatting — safe key grammar and original-name preservation
+
+**Branch**: `066-lossless-key-formatting`
+**Created**: 2026-08-10
+**Status**: DRAFT
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+`config.format.keys` selects a naming convention (`SAFE`, `CAMEL`, `SNAKE`, `KEBAB`, `PASCAL`, `TRAIN`) that is applied to every authored key in a spec: `anatomy` keys, `props` keys, and every reference to them — `elements`, `propConfigurations`, `children`, `slotContent`, `instanceExamples`, `compositions`.
+
+Every format other than `SAFE` is a lossy projection. The formatted key is derived by splitting the original name into `[A-Za-z0-9]` words and re-joining them, which discards:
+
+- **Separator identity** — `Icon leading`, `Icon-leading`, and `Icon_leading` all become `iconLeading` / `icon-leading` / `icon_leading`. The original separator is unrecoverable.
+- **Casing** — `URL field` and `Url field` both become `urlField`; `Icon Leading` and `Icon leading` are indistinguishable after formatting.
+- **Non-alphanumeric characters** — `+`, `/`, `.`, `()`, `&`, and every non-ASCII letter are deleted outright.
+- **Word boundaries adjacent to digits** — `Icon 2 leading` collapses to `icon2Leading`, and no rule recovers the boundary.
+
+Because the schema has no record of the name a key was derived from, a spec produced with any format other than `SAFE` cannot be rendered back into Figma faithfully. Figma layer names and component property names are the identity used to match existing nodes; a formatted key that no longer reconstructs the Figma name causes the render direction to create duplicates or fail to bind.
+
+Two things are missing from the contract:
+
+1. A stated **source name shape** on the Figma side, so producers and consumers agree on what an unformatted key looks like and what a formatted key reverses to.
+2. A stated **safe key grammar** — the set of names that survive every `format.keys` value unchanged in meaning — plus a place to record the original name whenever a key falls outside it.
+
+The precedent for the second already exists: `AnatomyElement.$extensions['com.figma'].originalName` records the pre-collapse layer name for wrapper-collapsed elements (ADR-058). This ADR generalizes that field to all lossy key derivations and adds the equivalent to props.
+
+---
+
+## Decision Drivers
+
+- **Round-trip fidelity**: a spec must carry enough information to reconstruct the Figma name of every anatomy element and prop, under any `format.keys` value.
+- **Mechanically verifiable contract** (Constitution IV): "which keys are safe" must be expressible in JSON Schema, not only in prose.
+- **Quiet by default**: the preservation field must not appear on well-formed specs. A catalog that follows the safe grammar emits no extensions at all.
+- **No logic in this package** (Constitution II): the schema declares the grammar and the field; deriving and emitting them is producer behavior.
+- **Types and schema symmetry** (Constitution I): every added field lands in both `types/` and `schema/`.
+- **Naming without abbreviation** and reverse-domain extension keys, consistent with the existing `$extensions` surface.
+- **References must stay resolvable**: `elements`, `propConfigurations`, and other key references continue to point at formatted keys — no reference-site duplication of original names.
+
+---
+
+## Options Considered
+
+### Decision 1 — Where the original Figma name is preserved
+
+#### Option A: `$extensions['com.figma'].originalName` on the definition *(Selected)*
+
+Record the original name once, on the `anatomy` element definition and on the prop definition. Reference sites (`elements`, `propConfigurations`, …) continue to use the formatted key and resolve the original through the definition.
+
+**Pros**:
+- Reuses the field ADR-058 already established for exactly this purpose on `AnatomyElement`.
+- Single source of truth — no chance of divergent originals at reference sites.
+- Absent on well-formed specs, satisfying "quiet by default".
+- Additive optional field on both types — no reference-site schema churn.
+
+**Cons / Trade-offs**:
+- Consumers must dereference the definition to recover the original name for a reference.
+- One field now carries two provenance meanings on `AnatomyElement` (wrapper-collapse origin and format-divergence origin). Both are "the Figma name this key came from", so the meaning stays coherent.
+
+---
+
+#### Option B: A parallel key-map block on `Component` *(Rejected)*
+
+A top-level `keyMap: Record<string, string>` mapping formatted key → original Figma name.
+
+**Rejected because**: it introduces a second naming surface outside `$extensions`, with no namespace, and its entries are ambiguous across the anatomy and prop key spaces (a component may have an anatomy element and a prop that format to the same key). It also grows a block on every component rather than staying quiet by default.
+
+---
+
+#### Option C: Emit unformatted keys and store the formatted key in extensions *(Rejected)*
+
+Invert the relationship — keys stay as Figma names, and the `format.keys` result is recorded in `$extensions`.
+
+**Rejected because**: `format.keys` exists so consumers can read keys in their own platform's convention directly. Moving the formatted value into extensions defeats the feature and breaks every existing consumer of formatted output.
+
+---
+
+### Decision 2 — How the safe key grammar is expressed
+
+#### Option A: `propertyNames` pattern on `Anatomy` and `Props`, applied only under `format.keys: SAFE` semantics *(Rejected)*
+
+**Rejected because**: JSON Schema has no access to the config that produced the document, so a conditional constraint cannot be expressed. A single pattern would have to accept the union of all six formats, which admits nothing and rejects nothing useful.
+
+---
+
+#### Option B: A named, documented grammar plus a reusable `SafeKey` definition *(Selected)*
+
+Define the safe grammar once as a schema definition (`#/definitions/SafeKey`) with its `pattern`, and reference it from the description of `Anatomy` and `Props` rather than as a hard constraint on their property names. Producers validate against it to decide whether `originalName` must be emitted; consumers can validate a spec's keys against it deliberately.
+
+**Pros**:
+- The grammar becomes mechanically checkable (Constitution IV) without rejecting legitimate formatted output.
+- One definition governs both anatomy and prop keys — no duplicated regex.
+- Non-breaking: no existing document becomes invalid.
+
+**Cons / Trade-offs**:
+- Conformance is opt-in rather than enforced by ordinary validation.
+
+---
+
+#### Option C: Prose-only definition in the `format.keys` documentation *(Rejected)*
+
+**Rejected because**: the grammar is the thing producers must agree on exactly. Prose leaves the boundary cases (digit-leading words, casing of the second word, non-ASCII letters) unresolved, which is how the current divergence arose.
+
+---
+
+### Decision 3 — How the source-side name shape is declared
+
+Reversal needs a stated target: given `iconLeading`, a renderer can only reconstruct the Figma name if it knows what convention that file's names follow. Three ways to supply it.
+
+#### Option A: New `format.figmaKeys` config field, defaulting to `SENTENCE` *(Selected)*
+
+Add a sibling to `format.keys` declaring the naming convention the Figma file itself uses, so `format.keys` describes the *output* convention and `format.figmaKeys` describes the *source* convention. Reversal is defined as: format the key back into `format.figmaKeys`.
+
+```yaml
+format:
+  figmaKeys: SENTENCE   # what the Figma file uses    — new, defaults to SENTENCE
+  keys: KEBAB           # what the spec emits         — existing
+```
+
+**Pros**:
+- Reversal becomes a declared, symmetric pair rather than a hardcoded assumption.
+- Files that follow a non-sentence convention (`Title Case` layer names, `camelCase` property names) become losslessly reversible without emitting `originalName` on every key.
+- Defaulting to `SENTENCE` keeps current behavior for every existing config — the field is optional and additive.
+- Reuses the existing `format.keys` vocabulary, extended with the two casings that occur in Figma but not in code output.
+
+**Cons / Trade-offs**:
+- A file with mixed conventions still diverges from whatever single value is declared, so `originalName` remains necessary as the escape hatch.
+- `format.figmaKeys` accepts two values `format.keys` does not (`SENTENCE`, `TITLE`), so the two unions are near-siblings rather than identical.
+
+---
+
+#### Option B: Hardcode sentence case in the schema documentation *(Rejected)*
+
+Declare in prose that Figma names are always assumed sentence case, with no config surface.
+
+**Rejected because**: it is wrong for real files. A library whose layer names are `Title Case` or whose component properties are `camelCase` would emit `originalName` on every anatomy element and every prop, making the "quiet by default" driver unachievable for that catalog and burying genuine problems in noise.
+
+---
+
+#### Option C: Infer the source convention per component from the observed names *(Rejected)*
+
+**Rejected because**: inference is producer logic with no stable contract — the same catalog could infer differently as components are added, and the schema would have no way to state what a spec's keys reverse to. It also violates Constitution II if expressed here.
+
+---
+
+## Decision
+
+### The source convention — `format.figmaKeys`
+
+`format.figmaKeys` declares the naming convention the Figma file uses for layer names and component-property names. It is the target of reversal: a renderer reconstructs a Figma name by re-formatting the spec key into `format.figmaKeys`.
+
+| Value | Shape | Example |
+|-------|-------|---------|
+| `SENTENCE` *(default)* | First word capitalized, rest lowercase, single spaces | `Icon leading` |
+| `TITLE` | Every word capitalized, single spaces | `Icon Leading` |
+| `CAMEL` | First word lowercase, rest capitalized, no separators | `iconLeading` |
+| `PASCAL` | Every word capitalized, no separators | `IconLeading` |
+| `KEBAB` | All lowercase, hyphen-separated | `icon-leading` |
+| `SNAKE` | All lowercase, underscore-separated | `icon_leading` |
+| `TRAIN` | Every word capitalized, hyphen-separated | `Icon-Leading` |
+
+`SENTENCE` and `TITLE` are accepted here but not by `format.keys` — they describe how names are authored in Figma, not an output convention the spec emits.
+
+### The safe key grammar
+
+A name is **round-trip safe** when it is composed only of safe characters *and* its casing and separators match the declared `format.figmaKeys`.
+
+Character and word rules, common to every `format.figmaKeys` value:
+
+- ASCII letters and digits only — no `.`, `/`, `+`, `&`, parentheses, punctuation, or non-ASCII letters.
+- Exactly one separator between words, and it is the separator the declared convention uses. No leading, trailing, or repeated separators.
+- No word begins with a digit — a digit-leading word loses its boundary under `CAMEL` and `PASCAL`.
+
+Casing rule, per declared convention: the name's word casing matches the convention's shape in the table above.
+
+Under the default `figmaKeys: SENTENCE`, the grammar is:
+
+```
+^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$
+```
+
+Names satisfying the grammar reconstruct identically from the output of any `format.keys` value. Names that do not satisfy it require `originalName` to be recoverable.
+
+```yaml
+# figmaKeys: SENTENCE
+
+# Safe — survives every format.keys value
+Icon leading        # → iconLeading | icon_leading | icon-leading | IconLeading | Icon-Leading
+Label
+Badge count 2
+
+# Unsafe — requires $extensions.com.figma.originalName
+Icon-leading        # separator is not the declared convention's
+Icon Leading        # casing diverges from SENTENCE (safe under figmaKeys: TITLE)
+URL field           # inner capitals lost
+Icon 2 leading      # digit-leading word — boundary lost under CAMEL/PASCAL
+Size (large)        # parentheses deleted
+Étiquette           # non-ASCII letter deleted
+```
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Anatomy.ts` | Widened documented meaning of `FigmaAnatomyElementExtension.originalName` — now also records the original Figma layer name when the anatomy key diverges from it under `format.keys` | PATCH |
+| `Props.ts` | Added optional field `originalName` to `FigmaPropExtension` | MINOR |
+| `Config.ts` | Added optional field `format.figmaKeys` to `Config`, required field `format.figmaKeys` to `ResolvedConfig`, and `figmaKeys: 'SENTENCE'` to `DEFAULT_CONFIG` | MINOR |
+| `Config.ts` | Expanded `format.keys` documentation to reference `format.figmaKeys` and the safe key grammar | PATCH |
+
+**Example — config** (`types/Config.ts`):
+
+```yaml
+# Before
+Config.format:
+  output?: 'JSON' | 'YAML'
+  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+
+# After
+Config.format:
+  output?: 'JSON' | 'YAML'
+  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+  figmaKeys?: 'SENTENCE' | 'TITLE' | 'CAMEL' | 'PASCAL' | 'KEBAB' | 'SNAKE' | 'TRAIN'   # optional — defaults to SENTENCE
+```
+
+**Example — prop extension** (`types/Props.ts`):
+
+```yaml
+# Before
+FigmaPropExtension:
+  type?: string
+  source?: FigmaCodeOnlySource
+
+# After
+FigmaPropExtension:
+  type?: string
+  source?: FigmaCodeOnlySource
+  originalName?: string   # optional — present only when the prop key diverges from the Figma property name
+```
+
+**Example — emitted spec under `format.keys: KEBAB`**:
+
+```yaml
+anatomy:
+  icon-leading:            # safe — derived from "Icon leading", no extension emitted
+    type: glyph
+  url-field:
+    type: text
+    $extensions:
+      com.figma:
+        originalName: URL field
+props:
+  is-disabled:             # safe — derived from "Is disabled"
+    type: boolean
+    default: false
+  size-large:
+    type: string
+    enum: [small, large]
+    default: small
+    $extensions:
+      com.figma:
+        originalName: Size (large)
+elements:
+  url-field:               # references remain in formatted key space
+    text: Email address
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Added definition `SafeKey` with the round-trip-safe `pattern` and description | MINOR |
+| `workspace.schema.json` | Added property `figmaKeys` under `format`, enum of the seven source conventions, default `SENTENCE` | MINOR |
+| `component.schema.json` | Added property `originalName` to `FigmaPropExtension` | MINOR |
+| `component.schema.json` | Expanded descriptions of `AnatomyElement.$extensions['com.figma'].originalName`, `Anatomy`, and `Props` to reference `SafeKey` | PATCH |
+
+**Example — new definition** (`schema/component.schema.json`):
+
+```yaml
+SafeKey:
+  type: string
+  pattern: "^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$"
+  description: >-
+    A round-trip-safe Figma name under the default format.figmaKeys of
+    SENTENCE: ASCII letters and digits, single-space word separators, sentence
+    case, no digit-leading words. Names matching this pattern reconstruct
+    identically from the output of any format.keys value; names that do not
+    require $extensions.com.figma.originalName. Other format.figmaKeys values
+    substitute that convention's separator and casing.
+```
+
+```yaml
+# New property under #/definitions/.../format/properties (workspace.schema.json)
+figmaKeys:
+  type: string
+  enum: [SENTENCE, TITLE, CAMEL, PASCAL, KEBAB, SNAKE, TRAIN]
+  default: SENTENCE
+  description: >-
+    Naming convention the Figma file uses for layer names and component
+    property names. Reversal target for format.keys.
+```
+
+```yaml
+# New property under #/definitions/FigmaPropExtension/properties
+originalName:
+  type: string
+  description: >-
+    Original Figma component-property name, recorded when the prop key
+    diverges from it under format.keys. Absent when the name matches
+    #/definitions/SafeKey.
+```
+
+### Notes
+
+- `format.figmaKeys` describes the source, `format.keys` describes the output. They are independent; `figmaKeys: SENTENCE` with `keys: SAFE` is the identity case where keys are emitted as authored.
+- `SafeKey` is a definition, not an applied constraint on `Anatomy`/`Props` property names. It describes the *Figma-side* name shape, while the keys in a document are in `format.keys` space.
+- `originalName` remains optional on both surfaces so that conforming catalogs emit no extensions at all.
+- Reference sites are deliberately unchanged. A consumer resolving `elements.url-field` looks up `anatomy['url-field']` and reads `originalName` there.
+- On `AnatomyElement`, `originalName` already exists (ADR-058) and its two triggers — wrapper-collapse promotion and format divergence — are not distinguished. When both apply, the pre-collapse Figma name is the correct value for both purposes.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes.
+- **Parity check**:
+  - `FigmaPropExtension.originalName` (`types/Props.ts`) ↔ `#/definitions/FigmaPropExtension/properties/originalName`
+  - `Config['format']['figmaKeys']` and `ResolvedConfig['format']['figmaKeys']` (`types/Config.ts`) ↔ `format.figmaKeys` in `schema/workspace.schema.json`
+  - `SafeKey` (`schema/component.schema.json` `#/definitions/SafeKey`) has no TypeScript counterpart — a `pattern` constraint on a string is not expressible as a distinct TypeScript type, and introducing a branded type would be logic, not a declaration (Constitution II). This asymmetry is justified and intentional; the type-side contract remains `string`.
+  - `FigmaAnatomyElementExtension.originalName` (`types/Anatomy.ts`) ↔ existing `#/definitions/AnatomyElement/.../originalName` — description-only change on both sides.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Must evaluate each anatomy element name and prop name against the safe key grammar for the declared `format.figmaKeys` and emit `originalName` when it diverges | Update key formatting to read `format.figmaKeys` and record divergence; recompile |
+| `specs-cli` | Emits and validates specs carrying the new optional field; the new config key is accepted in workspace config | Recompile against the new schema version; surface `format.figmaKeys` in config resolution and documentation |
+| `specs-plugin-2` | Same emission path as the CLI in the plugin runtime; the render direction reconstructs Figma names by formatting into `format.figmaKeys`, preferring `originalName` where present | Recompile; use `originalName` in preference to the formatted key when matching Figma nodes |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.30.0 → 0.31.0` (`MINOR`)
+
+**Justification**: All schema and type changes are additive optional fields plus documentation — `FigmaPropExtension.originalName` and `Config.format.figmaKeys` are optional, `SafeKey` is a new definition referenced only from descriptions, and no existing document becomes invalid. `ResolvedConfig.format.figmaKeys` is required, but `ResolvedConfig` is the post-defaulting shape and `DEFAULT_CONFIG` supplies `SENTENCE`, so no caller loses a valid construction. Per the constitution's versioning rule, additive types and new optional fields are `MINOR`.
+
+---
+
+## Consequences
+
+- The schema states, for the first time, what an unformatted Figma-side name looks like — declared per workspace via `format.figmaKeys`, defaulting to sentence case.
+- Key formatting becomes a declared pair — `figmaKeys` in, `keys` out — so reversal is defined by config rather than inferred.
+- Libraries that author layer or property names in `Title Case`, `camelCase`, or another convention can declare it and stay extension-free.
+- The set of names that survive every `format.keys` value is defined by a single mechanically checkable pattern rather than by the behavior of one producer.
+- Specs produced with a lossy `format.keys` value carry enough information to reconstruct Figma names, making the spec → Figma direction lossless for anatomy and prop identity.
+- Well-formed catalogs are unchanged — no `$extensions` appear unless a name falls outside the safe grammar, so the field doubles as a signal that a Figma name needs attention.
+- Consumers that match Figma nodes by name MUST prefer `originalName` over the formatted key when it is present; ignoring it reintroduces the divergence this ADR removes.
+- Names outside the safe grammar remain fully supported — they are recorded, not rejected. Narrowing them is an authoring recommendation, not a validation gate.

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -211,7 +211,7 @@ The forward direction is not the problem — `CAMEL` is idempotent over an alrea
 
 #### Option A: Detect destination-format names, pass through, and record `name` *(Selected)*
 
-A source name that does not match the declared `figmaKeys` grammar but *does* match the grammar of the declared `format.keys` value is **already in the destination format**. It is passed through unformatted, and `com.figma.name` is emitted so reversal restores it verbatim rather than re-deriving it.
+A source name that fails the declared `figmaKeys` grammar but that `format.keys` leaves unchanged — formatting it is a no-op — is **already in the destination format**. It is passed through unformatted, and `com.figma.name` is emitted so reversal restores it verbatim rather than re-deriving it. The Decision states the predicate exactly.
 
 ```yaml
 # figmaKeys: SENTENCE, keys: CAMEL

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -1,10 +1,10 @@
-# ADR: Lossless key formatting — safe key grammar and original-name preservation
+# ADR: Lossless key formatting — safe key grammar and Figma name preservation
 
 **Branch**: `066-lossless-key-formatting`
 **Created**: 2026-08-10
 **Status**: DRAFT
 **Deciders**: Nathan Curtis (author)
-**Supersedes**: *(none)*
+**Supersedes**: *(none — extends ADR-058)*
 
 ---
 
@@ -12,21 +12,22 @@
 
 `config.format.keys` selects a naming convention (`SAFE`, `CAMEL`, `SNAKE`, `KEBAB`, `PASCAL`, `TRAIN`) that is applied to every authored key in a spec: `anatomy` keys, `props` keys, and every reference to them — `elements`, `propConfigurations`, `children`, `slotContent`, `instanceExamples`, `compositions`.
 
-Every format other than `SAFE` is a lossy projection. The formatted key is derived by splitting the original name into `[A-Za-z0-9]` words and re-joining them, which discards:
+Every format other than `SAFE` is a lossy projection. The formatted key is derived by splitting the source name into `[A-Za-z0-9]` words and re-joining them, which discards:
 
-- **Separator identity** — `Icon leading`, `Icon-leading`, and `Icon_leading` all become `iconLeading` / `icon-leading` / `icon_leading`. The original separator is unrecoverable.
+- **Separator identity** — `Icon leading`, `Icon-leading`, and `Icon_leading` all become `iconLeading` / `icon-leading` / `icon_leading`. The source separator is unrecoverable.
 - **Casing** — `URL field` and `Url field` both become `urlField`; `Icon Leading` and `Icon leading` are indistinguishable after formatting.
-- **Non-alphanumeric characters** — `+`, `/`, `.`, `()`, `&`, and every non-ASCII letter are deleted outright.
+- **Non-alphanumeric characters** — `&`, `+`, `/`, `.`, `()`, and every non-ASCII letter are deleted outright, taking their word boundary with them: `Cut & paste` becomes `cutPaste`, and nothing in the spec records that a `&` was ever there.
 - **Word boundaries adjacent to digits** — `Icon 2 leading` collapses to `icon2Leading`, and no rule recovers the boundary.
 
 Because the schema has no record of the name a key was derived from, a spec produced with any format other than `SAFE` cannot be rendered back into Figma faithfully. Figma layer names and component property names are the identity used to match existing nodes; a formatted key that no longer reconstructs the Figma name causes the render direction to create duplicates or fail to bind.
 
-Two things are missing from the contract:
+Three things are missing from the contract:
 
 1. A stated **source name shape** on the Figma side, so producers and consumers agree on what an unformatted key looks like and what a formatted key reverses to.
-2. A stated **safe key grammar** — the set of names that survive every `format.keys` value unchanged in meaning — plus a place to record the original name whenever a key falls outside it.
+2. A stated **safe key grammar** — the set of names that survive every `format.keys` value unchanged in meaning.
+3. A place to record the **Figma name** whenever a key falls outside that grammar.
 
-The precedent for the second already exists: `AnatomyElement.$extensions['com.figma'].originalName` records the pre-collapse layer name for wrapper-collapsed elements (ADR-058). This ADR generalizes that field to all lossy key derivations and adds the equivalent to props.
+The precedent for the third already exists: `AnatomyElement.$extensions['com.figma'].originalName` records the pre-collapse layer name for wrapper-collapsed elements (ADR-058, shipped in `0.28.0`). This ADR generalizes that field to all lossy key derivations, adds the equivalent to props, and renames it to match its widened meaning.
 
 ---
 
@@ -35,36 +36,36 @@ The precedent for the second already exists: `AnatomyElement.$extensions['com.fi
 - **Round-trip fidelity**: a spec must carry enough information to reconstruct the Figma name of every anatomy element and prop, under any `format.keys` value.
 - **Mechanically verifiable contract** (Constitution IV): "which keys are safe" must be expressible in JSON Schema, not only in prose.
 - **Quiet by default**: the preservation field must not appear on well-formed specs. A catalog that follows the safe grammar emits no extensions at all.
-- **No logic in this package** (Constitution II): the schema declares the grammar and the field; deriving and emitting them is producer behavior.
+- **Formats must stay fit for purpose**: `CAMEL` and `PASCAL` exist to produce code identifiers. No widening of the safe character set may compromise that.
+- **No logic in this package** (Constitution II): the schema declares the grammar and the fields; deriving and emitting them is producer behavior.
 - **Types and schema symmetry** (Constitution I): every added field lands in both `types/` and `schema/`.
-- **Naming without abbreviation** and reverse-domain extension keys, consistent with the existing `$extensions` surface.
-- **References must stay resolvable**: `elements`, `propConfigurations`, and other key references continue to point at formatted keys — no reference-site duplication of original names.
+- **Minimal, intentional public API** (Constitution III): prefer one field with one meaning over parallel fields or a deprecated alias carried forward.
+- **References must stay resolvable**: `elements`, `propConfigurations`, and other key references continue to point at formatted keys — no reference-site duplication of source names.
 
 ---
 
 ## Options Considered
 
-### Decision 1 — Where the original Figma name is preserved
+### Decision 1 — Where the Figma name is preserved
 
-#### Option A: `$extensions['com.figma'].originalName` on the definition *(Selected)*
+#### Option A: `$extensions['com.figma']` on the definition *(Selected)*
 
-Record the original name once, on the `anatomy` element definition and on the prop definition. Reference sites (`elements`, `propConfigurations`, …) continue to use the formatted key and resolve the original through the definition.
+Record the Figma name once, on the `anatomy` element definition and on the prop definition. Reference sites (`elements`, `propConfigurations`, …) continue to use the formatted key and resolve the Figma name through the definition.
 
 **Pros**:
 - Reuses the field ADR-058 already established for exactly this purpose on `AnatomyElement`.
-- Single source of truth — no chance of divergent originals at reference sites.
+- Single source of truth — no chance of divergent values at reference sites.
 - Absent on well-formed specs, satisfying "quiet by default".
-- Additive optional field on both types — no reference-site schema churn.
+- Optional field on both types — no reference-site schema churn.
 
 **Cons / Trade-offs**:
-- Consumers must dereference the definition to recover the original name for a reference.
-- One field now carries two provenance meanings on `AnatomyElement` (wrapper-collapse origin and format-divergence origin). Both are "the Figma name this key came from", so the meaning stays coherent.
+- Consumers must dereference the definition to recover the Figma name for a reference.
 
 ---
 
 #### Option B: A parallel key-map block on `Component` *(Rejected)*
 
-A top-level `keyMap: Record<string, string>` mapping formatted key → original Figma name.
+A top-level `keyMap: Record<string, string>` mapping formatted key → Figma name.
 
 **Rejected because**: it introduces a second naming surface outside `$extensions`, with no namespace, and its entries are ambiguous across the anatomy and prop key spaces (a component may have an anatomy element and a prop that format to the same key). It also grows a block on every component rather than staying quiet by default.
 
@@ -78,31 +79,46 @@ Invert the relationship — keys stay as Figma names, and the `format.keys` resu
 
 ---
 
-### Decision 2 — How the safe key grammar is expressed
+### Decision 2 — What that field is called
 
-#### Option A: `propertyNames` pattern on `Anatomy` and `Props`, applied only under `format.keys: SAFE` semantics *(Rejected)*
+#### Option A: Rename `originalName` → `name` *(Selected)*
 
-**Rejected because**: JSON Schema has no access to the config that produced the document, so a conditional constraint cannot be expressed. A single pattern would have to accept the union of all six formats, which admits nothing and rejects nothing useful.
+Within `$extensions['com.figma']`, the field becomes `name`. `AnatomyElement` is renamed; `FigmaPropExtension` gains the field under the new spelling.
 
----
+```yaml
+# Before (ADR-058)
+$extensions:
+  com.figma:
+    originalName: Leading icon
 
-#### Option B: A named, documented grammar plus a reusable `SafeKey` definition *(Selected)*
-
-Define the safe grammar once as a schema definition (`#/definitions/SafeKey`) with its `pattern`, and reference it from the description of `Anatomy` and `Props` rather than as a hard constraint on their property names. Producers validate against it to decide whether `originalName` must be emitted; consumers can validate a spec's keys against it deliberately.
+# After
+$extensions:
+  com.figma:
+    name: Leading icon
+```
 
 **Pros**:
-- The grammar becomes mechanically checkable (Constitution IV) without rejecting legitimate formatted output.
-- One definition governs both anatomy and prop keys — no duplicated regex.
-- Non-breaking: no existing document becomes invalid.
+- The namespace already carries the qualifier — `com.figma.name` reads as "this element's name in Figma", which is precisely the contract.
+- `original` becomes inaccurate once the field generalizes. Under ADR-058 it meant *pre-collapse*; here it also means *pre-format*. "Original relative to what?" has two answers, and the shared answer is simply "in Figma".
+- One field, one meaning, two reasons it may be present — rather than a qualifier that describes only one of them.
+- Satisfies Constitution III: the smallest accurate public name.
 
 **Cons / Trade-offs**:
-- Conformance is opt-in rather than enforced by ordinary validation.
+- Breaking rename of a field shipped in `0.28.0`. See Migration — the real footprint is three call sites in one repo.
 
 ---
 
-#### Option C: Prose-only definition in the `format.keys` documentation *(Rejected)*
+#### Option B: Add `name`, deprecate `originalName` *(Rejected)*
 
-**Rejected because**: the grammar is the thing producers must agree on exactly. Prose leaves the boundary cases (digit-leading words, casing of the second word, non-ASCII letters) unresolved, which is how the current divergence arose.
+Ship both spellings, remove `originalName` at the next MAJOR.
+
+**Rejected because**: it buys a compatibility window no consumer needs (see Migration) at the cost of a period where either spelling may appear, forcing every reader to check both and every producer to choose. The ADR would ship ambiguity to avoid four line edits.
+
+---
+
+#### Option C: Keep `originalName` *(Rejected)*
+
+**Rejected because**: the field's meaning is being redefined by this ADR regardless. Retaining a qualifier that is accurate for only one of its two triggers embeds the confusion permanently to avoid a one-time rename.
 
 ---
 
@@ -120,15 +136,17 @@ format:
   keys: KEBAB           # what the spec emits         — existing
 ```
 
+The accepted values are `SENTENCE` and `TITLE` only — the two conventions observed in practice for Figma layer and component-property names. This is deliberately narrower than `format.keys`; values are added when a real file requires them, not in anticipation.
+
 **Pros**:
 - Reversal becomes a declared, symmetric pair rather than a hardcoded assumption.
-- Files that follow a non-sentence convention (`Title Case` layer names, `camelCase` property names) become losslessly reversible without emitting `originalName` on every key.
+- Files authored in `Title Case` become losslessly reversible without emitting `name` on every key.
 - Defaulting to `SENTENCE` keeps current behavior for every existing config — the field is optional and additive.
-- Reuses the existing `format.keys` vocabulary, extended with the two casings that occur in Figma but not in code output.
+- Both accepted values use single-space separators, so the safe grammar's character rules stay uniform and only its casing clause varies.
 
 **Cons / Trade-offs**:
-- A file with mixed conventions still diverges from whatever single value is declared, so `originalName` remains necessary as the escape hatch.
-- `format.figmaKeys` accepts two values `format.keys` does not (`SENTENCE`, `TITLE`), so the two unions are near-siblings rather than identical.
+- A file with mixed conventions still diverges from whatever single value is declared, so `name` remains necessary as the escape hatch.
+- A future file using an unlisted convention needs a schema change to declare it, rather than picking an already-present enum value.
 
 ---
 
@@ -136,13 +154,43 @@ format:
 
 Declare in prose that Figma names are always assumed sentence case, with no config surface.
 
-**Rejected because**: it is wrong for real files. A library whose layer names are `Title Case` or whose component properties are `camelCase` would emit `originalName` on every anatomy element and every prop, making the "quiet by default" driver unachievable for that catalog and burying genuine problems in noise.
+**Rejected because**: it is wrong for real files. A library whose layer names are `Title Case` would emit `name` on every anatomy element and every prop, making the "quiet by default" driver unachievable for that catalog and burying genuine problems in noise.
 
 ---
 
 #### Option C: Infer the source convention per component from the observed names *(Rejected)*
 
 **Rejected because**: inference is producer logic with no stable contract — the same catalog could infer differently as components are added, and the schema would have no way to state what a spec's keys reverse to. It also violates Constitution II if expressed here.
+
+---
+
+### Decision 4 — How wide the safe character set is
+
+#### Option A: ASCII letters and digits only *(Selected)*
+
+The safe set is `[A-Za-z0-9]` plus the single-space word separator. Every other character — `&`, `+`, `/`, `.`, `()`, punctuation, non-ASCII letters — is unsafe and routes to `com.figma.name`.
+
+**Pros**:
+- Keeps `CAMEL` and `PASCAL` fit for purpose. A preserved `&` would emit `cut&Paste` as an anatomy key — valid JSON, unusable as the code identifier those formats exist to produce.
+- Avoids ambiguous reversal. Transliterating `&` → `and` cannot be undone: `cutAndPaste` may have come from `Cut & paste` or from a literal `Cut and paste`.
+- One rule covers all six output formats, rather than a per-format safe set consumers must track.
+
+**Cons / Trade-offs**:
+- Common authoring characters (`&`, `+`, `/`) always trigger the extension, so catalogs using them are not extension-free.
+
+---
+
+#### Option B: Widen the safe set to retain `&` and `+` *(Rejected)*
+
+Preserve selected symbols through formatting rather than deleting them.
+
+**Rejected because**: it violates the "formats must stay fit for purpose" driver. These characters can only survive `SAFE`; under `CAMEL`, `PASCAL`, `SNAKE`, `KEBAB`, and `TRAIN` they either produce illegal identifiers or must be dropped anyway — meaning the safe set would have to be defined per format, and no single grammar could describe it.
+
+---
+
+#### Option C: Transliterate symbols to words (`&` → `and`, `+` → `plus`) *(Rejected)*
+
+**Rejected because**: it is lossy in the direction this ADR exists to fix. The transliteration is not injective, so the render direction cannot tell a transliterated key from a literal one, and it silently rewrites author intent into English-specific words.
 
 ---
 
@@ -156,33 +204,27 @@ Declare in prose that Figma names are always assumed sentence case, with no conf
 |-------|-------|---------|
 | `SENTENCE` *(default)* | First word capitalized, rest lowercase, single spaces | `Icon leading` |
 | `TITLE` | Every word capitalized, single spaces | `Icon Leading` |
-| `CAMEL` | First word lowercase, rest capitalized, no separators | `iconLeading` |
-| `PASCAL` | Every word capitalized, no separators | `IconLeading` |
-| `KEBAB` | All lowercase, hyphen-separated | `icon-leading` |
-| `SNAKE` | All lowercase, underscore-separated | `icon_leading` |
-| `TRAIN` | Every word capitalized, hyphen-separated | `Icon-Leading` |
 
-`SENTENCE` and `TITLE` are accepted here but not by `format.keys` — they describe how names are authored in Figma, not an output convention the spec emits.
+Both are source conventions only; neither is accepted by `format.keys`, which describes what the spec emits.
 
 ### The safe key grammar
 
-A name is **round-trip safe** when it is composed only of safe characters *and* its casing and separators match the declared `format.figmaKeys`.
+A name is **round-trip safe** when it satisfies both the character rules and the casing rule for the declared `format.figmaKeys`.
 
-Character and word rules, common to every `format.figmaKeys` value:
+Character and word rules, identical for both `figmaKeys` values:
 
-- ASCII letters and digits only — no `.`, `/`, `+`, `&`, parentheses, punctuation, or non-ASCII letters.
-- Exactly one separator between words, and it is the separator the declared convention uses. No leading, trailing, or repeated separators.
+- ASCII letters and digits only — no `&`, `+`, `/`, `.`, parentheses, punctuation, or non-ASCII letters.
+- Exactly one space between words. No leading, trailing, or repeated spaces.
 - No word begins with a digit — a digit-leading word loses its boundary under `CAMEL` and `PASCAL`.
 
-Casing rule, per declared convention: the name's word casing matches the convention's shape in the table above.
+Casing rule, per declared convention:
 
-Under the default `figmaKeys: SENTENCE`, the grammar is:
+| `figmaKeys` | Pattern |
+|-------------|---------|
+| `SENTENCE` | `^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$` |
+| `TITLE` | `^[A-Z][a-z0-9]*( [A-Z][a-z0-9]*)*$` |
 
-```
-^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$
-```
-
-Names satisfying the grammar reconstruct identically from the output of any `format.keys` value. Names that do not satisfy it require `originalName` to be recoverable.
+Names satisfying the grammar reconstruct identically from the output of any `format.keys` value. Names that do not satisfy it require `com.figma.name` to be recoverable.
 
 ```yaml
 # figmaKeys: SENTENCE
@@ -192,11 +234,12 @@ Icon leading        # → iconLeading | icon_leading | icon-leading | IconLeadin
 Label
 Badge count 2
 
-# Unsafe — requires $extensions.com.figma.originalName
-Icon-leading        # separator is not the declared convention's
+# Unsafe — requires $extensions.com.figma.name
+Icon-leading        # separator is not a space
 Icon Leading        # casing diverges from SENTENCE (safe under figmaKeys: TITLE)
 URL field           # inner capitals lost
 Icon 2 leading      # digit-leading word — boundary lost under CAMEL/PASCAL
+Cut & paste         # symbol deleted, word boundary lost
 Size (large)        # parentheses deleted
 Étiquette           # non-ASCII letter deleted
 ```
@@ -205,24 +248,21 @@ Size (large)        # parentheses deleted
 
 | File | Change | Bump |
 |------|--------|------|
-| `Anatomy.ts` | Widened documented meaning of `FigmaAnatomyElementExtension.originalName` — now also records the original Figma layer name when the anatomy key diverges from it under `format.keys` | PATCH |
-| `Props.ts` | Added optional field `originalName` to `FigmaPropExtension` | MINOR |
+| `Anatomy.ts` | Renamed `FigmaAnatomyElementExtension.originalName` → `name`, widened to record the Figma name whenever the anatomy key diverges from it (format projection or wrapper collapse) | MAJOR |
+| `Props.ts` | Added optional field `name` to `FigmaPropExtension` | MINOR |
 | `Config.ts` | Added optional field `format.figmaKeys` to `Config`, required field `format.figmaKeys` to `ResolvedConfig`, and `figmaKeys: 'SENTENCE'` to `DEFAULT_CONFIG` | MINOR |
 | `Config.ts` | Expanded `format.keys` documentation to reference `format.figmaKeys` and the safe key grammar | PATCH |
 
-**Example — config** (`types/Config.ts`):
+**Example — anatomy extension** (`types/Anatomy.ts`):
 
 ```yaml
 # Before
-Config.format:
-  output?: 'JSON' | 'YAML'
-  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+FigmaAnatomyElementExtension:
+  originalName?: string   # pre-collapse layer name only (ADR-058)
 
 # After
-Config.format:
-  output?: 'JSON' | 'YAML'
-  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
-  figmaKeys?: 'SENTENCE' | 'TITLE' | 'CAMEL' | 'PASCAL' | 'KEBAB' | 'SNAKE' | 'TRAIN'   # optional — defaults to SENTENCE
+FigmaAnatomyElementExtension:
+  name?: string           # the element's name in Figma — present when the key diverges from it
 ```
 
 **Example — prop extension** (`types/Props.ts`):
@@ -237,10 +277,25 @@ FigmaPropExtension:
 FigmaPropExtension:
   type?: string
   source?: FigmaCodeOnlySource
-  originalName?: string   # optional — present only when the prop key diverges from the Figma property name
+  name?: string   # optional — present only when the prop key diverges from the Figma property name
 ```
 
-**Example — emitted spec under `format.keys: KEBAB`**:
+**Example — config** (`types/Config.ts`):
+
+```yaml
+# Before
+Config.format:
+  output?: 'JSON' | 'YAML'
+  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+
+# After
+Config.format:
+  output?: 'JSON' | 'YAML'
+  keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN'
+  figmaKeys?: 'SENTENCE' | 'TITLE'   # optional — defaults to SENTENCE
+```
+
+**Example — emitted spec under `format.keys: KEBAB`, `format.figmaKeys: SENTENCE`**:
 
 ```yaml
 anatomy:
@@ -250,18 +305,17 @@ anatomy:
     type: text
     $extensions:
       com.figma:
-        originalName: URL field
+        name: URL field
 props:
   is-disabled:             # safe — derived from "Is disabled"
     type: boolean
     default: false
-  size-large:
-    type: string
-    enum: [small, large]
-    default: small
+  cut-paste:
+    type: boolean
+    default: false
     $extensions:
       com.figma:
-        originalName: Size (large)
+        name: Cut & paste
 elements:
   url-field:               # references remain in formatted key space
     text: Email address
@@ -271,54 +325,72 @@ elements:
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Added definition `SafeKey` with the round-trip-safe `pattern` and description | MINOR |
-| `workspace.schema.json` | Added property `figmaKeys` under `format`, enum of the seven source conventions, default `SENTENCE` | MINOR |
-| `component.schema.json` | Added property `originalName` to `FigmaPropExtension` | MINOR |
-| `component.schema.json` | Expanded descriptions of `AnatomyElement.$extensions['com.figma'].originalName`, `Anatomy`, and `Props` to reference `SafeKey` | PATCH |
+| `component.schema.json` | Renamed `AnatomyElement.$extensions['com.figma'].originalName` → `name`, with widened description | MAJOR |
+| `component.schema.json` | Added property `name` to `FigmaPropExtension` | MINOR |
+| `component.schema.json` | Added definitions `SafeKeySentence` and `SafeKeyTitle` with their `pattern`s and descriptions | MINOR |
+| `component.schema.json` | Expanded descriptions of `Anatomy` and `Props` to reference the safe key definitions | PATCH |
+| `workspace.schema.json` | Added property `figmaKeys` under `format`, enum `[SENTENCE, TITLE]`, default `SENTENCE` | MINOR |
 
-**Example — new definition** (`schema/component.schema.json`):
+**Example — new definitions** (`schema/component.schema.json`):
 
 ```yaml
-SafeKey:
+SafeKeySentence:
   type: string
   pattern: "^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$"
   description: >-
-    A round-trip-safe Figma name under the default format.figmaKeys of
-    SENTENCE: ASCII letters and digits, single-space word separators, sentence
-    case, no digit-leading words. Names matching this pattern reconstruct
-    identically from the output of any format.keys value; names that do not
-    require $extensions.com.figma.originalName. Other format.figmaKeys values
-    substitute that convention's separator and casing.
+    A round-trip-safe Figma name under format.figmaKeys SENTENCE: ASCII letters
+    and digits, single-space word separators, sentence case, no digit-leading
+    words. Names matching this pattern reconstruct identically from the output
+    of any format.keys value; names that do not require
+    $extensions.com.figma.name.
+
+SafeKeyTitle:
+  type: string
+  pattern: "^[A-Z][a-z0-9]*( [A-Z][a-z0-9]*)*$"
+  description: >-
+    As SafeKeySentence, but for format.figmaKeys TITLE — every word capitalized.
+```
+
+```yaml
+# New property under #/definitions/FigmaPropExtension/properties
+name:
+  type: string
+  description: >-
+    The Figma component-property name, recorded when the prop key diverges from
+    it under format.keys. Absent when the name matches the safe key grammar.
 ```
 
 ```yaml
 # New property under #/definitions/.../format/properties (workspace.schema.json)
 figmaKeys:
   type: string
-  enum: [SENTENCE, TITLE, CAMEL, PASCAL, KEBAB, SNAKE, TRAIN]
+  enum: [SENTENCE, TITLE]
   default: SENTENCE
   description: >-
     Naming convention the Figma file uses for layer names and component
     property names. Reversal target for format.keys.
 ```
 
-```yaml
-# New property under #/definitions/FigmaPropExtension/properties
-originalName:
-  type: string
-  description: >-
-    Original Figma component-property name, recorded when the prop key
-    diverges from it under format.keys. Absent when the name matches
-    #/definitions/SafeKey.
-```
-
 ### Notes
 
 - `format.figmaKeys` describes the source, `format.keys` describes the output. They are independent; `figmaKeys: SENTENCE` with `keys: SAFE` is the identity case where keys are emitted as authored.
-- `SafeKey` is a definition, not an applied constraint on `Anatomy`/`Props` property names. It describes the *Figma-side* name shape, while the keys in a document are in `format.keys` space.
-- `originalName` remains optional on both surfaces so that conforming catalogs emit no extensions at all.
-- Reference sites are deliberately unchanged. A consumer resolving `elements.url-field` looks up `anatomy['url-field']` and reads `originalName` there.
-- On `AnatomyElement`, `originalName` already exists (ADR-058) and its two triggers — wrapper-collapse promotion and format divergence — are not distinguished. When both apply, the pre-collapse Figma name is the correct value for both purposes.
+- `SafeKeySentence` and `SafeKeyTitle` are definitions, not applied constraints on `Anatomy`/`Props` property names. They describe the *Figma-side* name shape, while the keys in a document are in `format.keys` space.
+- `name` remains optional on both surfaces so that conforming catalogs emit no extensions at all.
+- Reference sites are deliberately unchanged. A consumer resolving `elements.url-field` looks up `anatomy['url-field']` and reads `name` there.
+- On `AnatomyElement`, `name` has two triggers — wrapper-collapse promotion and format divergence — that are not distinguished. When both apply, the pre-collapse Figma name is the correct value for both purposes.
+
+### Migration
+
+`originalName` shipped in `0.28.0`. Its consumers are:
+
+| Location | Role | Risk |
+|----------|------|------|
+| `specs-from-figma` — anatomy element construction | Writes the field | Compile error on rename — caught |
+| `figma-from-specs` — collapsed-root name recovery | Reads the field | **Reads via an inline structural type, not the published type — will not fail compilation. Silently yields `undefined` if missed.** |
+| `specs-plugin-2` | — | No references |
+| `specs-testing` workspace specs | Generated `api.yaml` output | Regenerated, not authored |
+
+The read site in `figma-from-specs` is the one hazard: because it declares the extension shape inline rather than importing `FigmaAnatomyElementExtension`, the rename is invisible to `tsc` there. Implementation MUST update it explicitly rather than relying on the compiler.
 
 ---
 
@@ -326,10 +398,10 @@ originalName:
 
 - **Symmetric**: Yes.
 - **Parity check**:
-  - `FigmaPropExtension.originalName` (`types/Props.ts`) ↔ `#/definitions/FigmaPropExtension/properties/originalName`
+  - `FigmaAnatomyElementExtension.name` (`types/Anatomy.ts`) ↔ `#/definitions/AnatomyElement/properties/$extensions/properties/com.figma/properties/name`
+  - `FigmaPropExtension.name` (`types/Props.ts`) ↔ `#/definitions/FigmaPropExtension/properties/name`
   - `Config['format']['figmaKeys']` and `ResolvedConfig['format']['figmaKeys']` (`types/Config.ts`) ↔ `format.figmaKeys` in `schema/workspace.schema.json`
-  - `SafeKey` (`schema/component.schema.json` `#/definitions/SafeKey`) has no TypeScript counterpart — a `pattern` constraint on a string is not expressible as a distinct TypeScript type, and introducing a branded type would be logic, not a declaration (Constitution II). This asymmetry is justified and intentional; the type-side contract remains `string`.
-  - `FigmaAnatomyElementExtension.originalName` (`types/Anatomy.ts`) ↔ existing `#/definitions/AnatomyElement/.../originalName` — description-only change on both sides.
+  - `SafeKeySentence` and `SafeKeyTitle` (`#/definitions`) have no TypeScript counterpart — a `pattern` constraint on a string is not expressible as a distinct TypeScript type, and introducing a branded type would be logic, not a declaration (Constitution II). This asymmetry is justified and intentional; the type-side contract remains `string`.
 
 ---
 
@@ -337,17 +409,17 @@ originalName:
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | Must evaluate each anatomy element name and prop name against the safe key grammar for the declared `format.figmaKeys` and emit `originalName` when it diverges | Update key formatting to read `format.figmaKeys` and record divergence; recompile |
+| `specs-from-figma` | Must evaluate each anatomy element name and prop name against the safe key grammar for the declared `format.figmaKeys` and emit `name` when it diverges; existing `originalName` write site breaks | Update key formatting to read `format.figmaKeys` and record divergence; rename the emitted extension key; recompile |
 | `specs-cli` | Emits and validates specs carrying the new optional field; the new config key is accepted in workspace config | Recompile against the new schema version; surface `format.figmaKeys` in config resolution and documentation |
-| `specs-plugin-2` | Same emission path as the CLI in the plugin runtime; the render direction reconstructs Figma names by formatting into `format.figmaKeys`, preferring `originalName` where present | Recompile; use `originalName` in preference to the formatted key when matching Figma nodes |
+| `specs-plugin-2` | Same emission path as the CLI in the plugin runtime; the render direction reconstructs Figma names by formatting into `format.figmaKeys`, preferring `name` where present | Recompile; use `name` in preference to the formatted key when matching Figma nodes |
 
 ---
 
 ## Semver Decision
 
-**Version bump**: `0.30.0 → 0.31.0` (`MINOR`)
+**Version bump**: `0.30.0 → 0.31.0` (`MAJOR`-class, released as a pre-1.0 minor)
 
-**Justification**: All schema and type changes are additive optional fields plus documentation — `FigmaPropExtension.originalName` and `Config.format.figmaKeys` are optional, `SafeKey` is a new definition referenced only from descriptions, and no existing document becomes invalid. `ResolvedConfig.format.figmaKeys` is required, but `ResolvedConfig` is the post-defaulting shape and `DEFAULT_CONFIG` supplies `SENTENCE`, so no caller loses a valid construction. Per the constitution's versioning rule, additive types and new optional fields are `MINOR`.
+**Justification**: Renaming `originalName` → `name` removes a published field name, which the constitution classes as `MAJOR`. The package is pre-1.0 and already releases breaking narrowing changes as minors — `0.29.0` narrowed `Styles.textAlignHorizontal` from `Style` to a string enum — so this ships as `0.31.0` under that established convention. All other changes are additive: `FigmaPropExtension.name` and `Config.format.figmaKeys` are optional, and the safe-key definitions are referenced only from descriptions. `ResolvedConfig.format.figmaKeys` is required, but `ResolvedConfig` is the post-defaulting shape and `DEFAULT_CONFIG` supplies `SENTENCE`, so no caller loses a valid construction.
 
 ---
 
@@ -355,9 +427,10 @@ originalName:
 
 - The schema states, for the first time, what an unformatted Figma-side name looks like — declared per workspace via `format.figmaKeys`, defaulting to sentence case.
 - Key formatting becomes a declared pair — `figmaKeys` in, `keys` out — so reversal is defined by config rather than inferred.
-- Libraries that author layer or property names in `Title Case`, `camelCase`, or another convention can declare it and stay extension-free.
-- The set of names that survive every `format.keys` value is defined by a single mechanically checkable pattern rather than by the behavior of one producer.
+- The set of names that survive every `format.keys` value is defined by two mechanically checkable patterns rather than by the behavior of one producer.
 - Specs produced with a lossy `format.keys` value carry enough information to reconstruct Figma names, making the spec → Figma direction lossless for anatomy and prop identity.
 - Well-formed catalogs are unchanged — no `$extensions` appear unless a name falls outside the safe grammar, so the field doubles as a signal that a Figma name needs attention.
-- Consumers that match Figma nodes by name MUST prefer `originalName` over the formatted key when it is present; ignoring it reintroduces the divergence this ADR removes.
+- Consumers that match Figma nodes by name MUST prefer `com.figma.name` over the formatted key when it is present; ignoring it reintroduces the divergence this ADR removes.
 - Names outside the safe grammar remain fully supported — they are recorded, not rejected. Narrowing them is an authoring recommendation, not a validation gate.
+- `&`, `+`, and `/` will always trigger the extension. Catalogs wanting extension-free output must avoid them in layer and property names.
+- `format.figmaKeys` starts deliberately narrow at `SENTENCE | TITLE`; encountering a file with another convention is a schema change, not a config choice.

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -209,9 +209,9 @@ A real Figma file is rarely uniform. A library that is largely `Sentence case` m
 
 The forward direction is not the problem — `CAMEL` is idempotent over an already-camel name. The problem is **reversal**: a renderer told to reconstruct the Figma name by formatting `isDisabled` into `SENTENCE` produces `Is disabled` and renames a property the author deliberately spelled `isDisabled`.
 
-#### Option A: Detect destination-format names, pass through, and record `name` *(Selected)*
+#### Option A: Detect names already authored as keys, retain them, and record `name` *(Selected)*
 
-A source name that fails the declared `figmaKeys` grammar but that `format.keys` leaves unchanged — formatting it is a no-op — is **already in the destination format**. It is passed through unformatted, and `com.figma.name` is emitted so reversal restores it verbatim rather than re-deriving it. The Decision states the predicate exactly.
+A source name that fails the declared `figmaKeys` grammar but is itself a well-formed key in the declared `format.keys` convention is **already in the destination format**. It is retained verbatim, and `com.figma.name` is emitted so reversal restores it rather than re-deriving it. Names in some *other* key convention are not retained — they are formatted and recorded like any divergent name. The Decision states the tests exactly.
 
 ```yaml
 # figmaKeys: SENTENCE, keys: CAMEL
@@ -231,7 +231,7 @@ props:
 - The detection is a pure predicate over two declared grammars, not inference about the file.
 
 **Cons / Trade-offs**:
-- **Detection alone cannot make it quiet.** `iconLeading` (formatted from `Icon leading`) and `isDisabled` (authored as-is) are both valid `CAMEL` and both invalid `SENTENCE`. Nothing in the emitted key distinguishes them, so the pass-through case *must* record `name`. Under a lossy `format.keys`, a catalog with many destination-format names will not be extension-free.
+- **Detection alone cannot make it quiet.** `iconLeading` (formatted from `Icon leading`) and `isDisabled` (authored as-is) are both valid `CAMEL` and both invalid `SENTENCE`. Nothing in the emitted key distinguishes them, so the retained case *must* record `name`. Under a lossy `format.keys`, a catalog with many authored-key names will not be extension-free.
 - Only meaningful when a convention is declared. Under `figmaKeys: NONE` there is no grammar to fail, so there is nothing to detect and no reversal to protect.
 
 ---
@@ -268,7 +268,7 @@ This is not the same ambiguity as `figmaKeys: NONE`. Under `NONE` no convention 
 
 - The safe key grammar is not evaluated.
 - `com.figma.name` is not emitted for format divergence. The ADR-058 wrapper-collapse trigger is independent of `figmaKeys` and continues to emit it.
-- Destination-format pass-through (below) does not apply — there is no grammar for a name to fail.
+- Authored-key retention (below) does not apply — there is no grammar for a name to fail.
 - Reversal is undefined. A renderer reading a spec produced under `NONE` has no declared target and MUST fall back to `com.figma.name` where present and the formatted key otherwise — today's behavior.
 
 Declaring `SENTENCE` or `TITLE` opts the catalog into all of it.
@@ -305,30 +305,36 @@ The letter↔digit clause is what makes `Badge count 2` safe: it formats to `bad
 
 Names satisfying the grammar reconstruct identically from the output of any `format.keys` value. Names that do not satisfy it require `com.figma.name` to be recoverable.
 
-### Destination-format pass-through
+### Names already authored as keys
 
 *Applies only when `format.figmaKeys` is `SENTENCE` or `TITLE`.*
 
-A source name is **already in the destination format** when it satisfies all three:
+Every Figma name is decided by two tests, in order:
 
-1. `format.keys` is not `SAFE`.
-2. The name fails the safe key grammar for the declared `figmaKeys`.
-3. Formatting is a no-op — `formatKey(name, format.keys) === name`.
+1. **Does it match the origin convention** — the safe key grammar for the declared `figmaKeys`? If so, format it and emit nothing. The key reverses back to the name unaided.
+2. **Does it match the destination convention** — a well-formed key in the declared `format.keys`? If so, **retain it verbatim** and record `com.figma.name`.
+3. **Otherwise** — it matches neither. Format it, and record `com.figma.name`.
 
-Such a name is **passed through unformatted** and records `com.figma.name` with its verbatim value. Reversal for it is identity, not re-derivation.
+Only the *destination* format retains. A `PascalCase` name with a `KEBAB` destination is not a match: it is reformatted and recorded, exactly like any other divergent name. Retention exists because formatting cannot *convert* between key conventions — it splits on spaces, hyphens, and underscores, not case transitions — so a name already in the destination convention can only be damaged by re-running it through the formatter, never improved.
 
-Clause 3 is deliberately an idempotence test rather than a per-format grammar. Defining "a well-formed `CAMEL` key" would mean writing and maintaining six grammars the schema does not otherwise need, and the producer already owns the one function that decides it. The test is mechanically checkable by any consumer holding the same formatter, which is what the driver requires.
+Test 1 runs first so that a name satisfying both tests stays quiet. `Label` is `SENTENCE`-safe *and* a well-formed `PASCAL` key; formatting and retention produce the same key, so the origin test wins and no extension is emitted for a name that reverses correctly on its own.
 
-Clause 1 exists because `SAFE` is the identity format: `formatKey(name, SAFE) === name` for every name, so clause 3 alone would classify every grammar-failing name as pass-through and emit `name` on all of them. Under `SAFE` the key *is* the Figma name, reversal is already identity, and no extension is warranted.
+`SAFE` has no destination pattern — it emits names as authored, so no consumer reverses a `SAFE` key and test 2 does not apply. `SAFE` is still lossy for the characters it strips (`.`, `[`, `]`, `\`, quotes), so a name it changes is recorded on that basis alone.
 
 ```yaml
+# figmaKeys: SENTENCE, keys: KEBAB
+Icon leading   → icon-leading   # matches origin: formatted, no extension
+is-disabled    → is-disabled    # matches destination KEBAB: retained, name: is-disabled
+isDisabled     → isdisabled     # matches neither: formatted, name: isDisabled
+IsDisabled     → isdisabled     # PASCAL is not the destination: formatted, name: IsDisabled
+URL field      → url-field      # matches neither: formatted, name: URL field
+
 # figmaKeys: SENTENCE, keys: CAMEL
-Icon leading   → iconLeading   # grammar-safe: formatted, no extension, reverses to "Icon leading"
-isDisabled     → isDisabled    # formatting is a no-op: passed through, name: isDisabled, reverses to itself
-URL field      → urlField      # fails the grammar, formatting changes it: formatted, name: URL field
+isDisabled     → isDisabled     # now matches the destination: retained, name: isDisabled
+is-disabled    → isDisabled     # KEBAB is not the destination: formatted, name: is-disabled
 ```
 
-The pass-through case always emits `name`. `iconLeading` and `isDisabled` are both valid `CAMEL` and both invalid `SENTENCE`, so the emitted key carries no signal a consumer could use to tell a formatted key from a natively-formatted one — the extension is the only thing that distinguishes them.
+The retained case always emits `name`. `iconLeading` and `isDisabled` are both valid `CAMEL` and both invalid `SENTENCE`, so the emitted key carries no signal a consumer could use to tell a formatted key from a natively-authored one — the extension is the only thing that distinguishes them.
 
 ```yaml
 # figmaKeys: SENTENCE
@@ -586,7 +592,7 @@ So titles already do what `com.figma.name` does for keys — they record the ori
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `specs-from-figma` | When `format.figmaKeys` is not `NONE`, must evaluate each anatomy element name and prop name against the safe key grammar, apply the pass-through test, and emit `name` on divergence or pass-through; existing `originalName` write site breaks under every value including `NONE` | Rename the emitted extension key unconditionally; add the grammar and pass-through evaluation gated on `format.figmaKeys`; align the word splitter with the stated letter↔digit rule; recompile |
+| `specs-from-figma` | When `format.figmaKeys` is not `NONE`, must evaluate each anatomy element name and prop name against the safe key grammar, apply the authored-key retention test, and emit `name` on divergence or retention; existing `originalName` write site breaks under every value including `NONE` | Rename the emitted extension key unconditionally; add the grammar and retention evaluation gated on `format.figmaKeys`; align the word splitter with the stated letter↔digit rule; recompile |
 | `specs-cli` | Emits and validates specs carrying the new optional field; the new config key is accepted in workspace config | Recompile against the new schema version; surface `format.figmaKeys` in config resolution and documentation |
 | `specs-plugin-2` | Same emission path as the CLI in the plugin runtime; the render direction reconstructs Figma names by formatting into `format.figmaKeys`, preferring `name` where present | Recompile; use `name` in preference to the formatted key when matching Figma nodes |
 
@@ -610,7 +616,7 @@ So titles already do what `com.figma.name` does for keys — they record the ori
 - The set of names that survive every `format.keys` value is defined by two mechanically checkable patterns rather than by the behavior of one producer.
 - **When `figmaKeys` is declared**, specs produced with a lossy `format.keys` value carry enough information to reconstruct Figma names, making the spec → Figma direction lossless for anatomy and prop identity. Under the `NONE` default they do not, and reversal stays undefined.
 - Well-formed catalogs stay quiet — no format-divergence `$extensions` appear unless a name falls outside the safe grammar, so the field doubles as a signal that a Figma name needs attention. Wrapper collapse emits `name` on its own trigger, so a grammar-conforming catalog is not necessarily extension-free.
-- Two distinct Figma names can still format to the same key — `Cut & paste` and `Cut paste` both reach `cutPaste`, and a pass-through name can collide with a formatted one. This is pre-existing behavior and is not changed here: a keyed record holds one entry per key, so one name wins and the other's `name` is not recorded. The loss belongs to the author who named two things the same in key space, not to the system. The safe grammar is collision-free among safe names, and `analyze keys` is the place to surface the rest.
+- Two distinct Figma names can still format to the same key — `Cut & paste` and `Cut paste` both reach `cutPaste`, and a retained name can collide with a formatted one. This is pre-existing behavior and is not changed here: a keyed record holds one entry per key, so one name wins and the other's `name` is not recorded. The loss belongs to the author who named two things the same in key space, not to the system. The safe grammar is collision-free among safe names, and `analyze keys` is the place to surface the rest.
 - Consumers that match Figma nodes by name MUST prefer `com.figma.name` over the formatted key when it is present; ignoring it reintroduces the divergence this ADR removes.
 - Names outside the safe grammar remain fully supported — they are recorded, not rejected. Narrowing them is an authoring recommendation, not a validation gate.
 - `&`, `+`, and `/` will always trigger the extension. Catalogs wanting extension-free output must avoid them in layer and property names.
@@ -619,7 +625,7 @@ So titles already do what `com.figma.name` does for keys — they record the ori
   - **Design-system teams** get a list of layer and property names to fix in Figma, ranked by how many components each affects.
   - **Adopters of `figmaKeys`** get the evidence for which value to declare — a catalog that is 94% `SENTENCE`-safe and 3% `TITLE`-safe has an obvious answer, and the residue is the exact list of names that will emit `com.figma.name`.
   The report is also the honest way to run under `figmaKeys: NONE`: no extension is emitted, but the divergence is still measurable and can be shown.
-- Deriving the pass-through and divergence signals is producer behavior (Constitution II). The schema declares the grammar; `analyze keys` is CLI work, out of scope for this ADR.
+- Deriving the retention and divergence signals is producer behavior (Constitution II). The schema declares the grammar; `analyze keys` is CLI work, out of scope for this ADR.
 - Two fields cover every Figma-derived name in a spec, at every nesting depth, because reference sites resolve through definitions — see the Coverage inventory for the full enumeration and the recursion requirement it places on producers.
 - The contract covers anatomy and prop *identity* only, and three surfaces stay as they are:
   - **Variant option values** pass through `format.keys` with no preservation field and remain lossy. Closing this needs a per-option surface on the prop extension — a separate decision.

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 066 | Lossless Key Formatting — Safe Key Grammar and Original-Name Preservation | |
 | 065 | Document the `nullable` Default and Add `NumberProp.nullable` | Absent `nullable` means true for `StringProp`/`NumberProp`/`SlotProp`/`ImageProp`, false for `EnumProp`; adds `NumberProp.nullable` |
 | 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | |
 | 062 | Text Overflow & Max Lines — `textOverflow` and `maxLines` on `Styles` | |
@@ -40,6 +39,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 066 | Lossless Key Formatting — Safe Key Grammar and Figma Name Preservation | Adds opt-in `format.figmaKeys` (`NONE` default), a safe key grammar, and `com.figma.name` on anatomy and props; renames `originalName` |
 | 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | Narrow from `Style` to `TextAlignHorizontal \| null` (`'START' \| 'CENTER' \| 'END' \| 'JUSTIFY'`); Figma `LEFT`/`RIGHT`/`JUSTIFIED` remapped |
 | 063 | Image Content — `backgroundImage` fill, an `images` registry, `ImageProp`, and `ImageBinding` | Add `backgroundImage` fills, a `Component.images` registry (Figma identity + optional `src`), `ImageProp`/`ImageBinding`, and presence-switched `processing.images` |
 | 060 | Subcomponent Figma Source Identity — `Subcomponent.source` | Add optional `SubcomponentSource` (`pageId`, `nodeId`, `nodeType`) to `Subcomponent`; enables reverse-direction tools to resolve `SubcomponentRef` to Figma nodes |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 066 | Lossless Key Formatting — Safe Key Grammar and Original-Name Preservation | |
 | 065 | Document the `nullable` Default and Add `NumberProp.nullable` | Absent `nullable` means true for `StringProp`/`NumberProp`/`SlotProp`/`ImageProp`, false for `EnumProp`; adds `NumberProp.nullable` |
 | 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | |
 | 062 | Text Overflow & Max Lines — `textOverflow` and `maxLines` on `Styles` | |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `format.figmaKeys` in the generated `specs.config.yaml` template — commented out at its `NONE` default, documenting the opt-in that enables the safe key grammar and Figma name preservation (ADR-066)
-- `specs analyze keys` — reports Figma layer and property names a formatted key cannot reconstruct, written to `_analysis/keys.yaml`. Organized `byComponent` as a designer's checklist, then `byCause` for systemic problems and `byName` for a name repeated across the library. Requires `format.figmaKeys` to declare a convention; empty under the `NONE` default (ADR-066)
+- `specs analyze keys` — reports Figma layer and property names a formatted key cannot reconstruct, written to `_analysis/keys.yaml`. Organized `byComponent` as a designer's checklist — each component splitting into `props` and `anatomy`, with an empty surface omitted — then `byCause` for systemic problems and `byName` for a name repeated across the library. Requires `format.figmaKeys` to declare a convention; empty under the `NONE` default (ADR-066)
 
 ### Changed
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `format.figmaKeys` in the generated `specs.config.yaml` template — commented out at its `NONE` default, documenting the opt-in that enables the safe key grammar and Figma name preservation (ADR-066)
+- `specs analyze keys` — reports Figma layer and property names a formatted key cannot reconstruct, written to `_analysis/keys.yaml`. Organized `byComponent` as a designer's checklist, then `byCause` for systemic problems and `byName` for a name repeated across the library. Requires `format.figmaKeys` to declare a convention; empty under the `NONE` default (ADR-066)
 
 ### Changed
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `format.figmaKeys` in the generated `specs.config.yaml` template — commented out at its `NONE` default, documenting the opt-in that enables the safe key grammar and Figma name preservation (ADR-066)
+
 ### Changed
 
 ### Removed

--- a/packages/cli/src/Config/ConfigTemplates.ts
+++ b/packages/cli/src/Config/ConfigTemplates.ts
@@ -62,6 +62,13 @@ config:
     # See: https://www.specsplugin.com/guides/key-formatting/
     keys: SAFE
 
+    # Naming convention your Figma file uses for layer and property names, and the
+    # target a spec reverses into when rendered back to Figma: NONE, SENTENCE, or TITLE.
+    # NONE declares no convention — names are not checked and none are preserved.
+    # Declaring one records the Figma name wherever a key cannot reconstruct it.
+    # See: https://www.specsplugin.com/settings/figma-keys/
+    # figmaKeys: NONE
+
     # Layout representation: LAYOUT, PARENT_CHILDREN, or BOTH
     # See: https://www.specsplugin.com/guides/data-layout/
     layout: LAYOUT

--- a/packages/cli/src/analyzers/Keys.ts
+++ b/packages/cli/src/analyzers/Keys.ts
@@ -1,0 +1,216 @@
+import fs from 'fs-extra';
+import path from 'path';
+import yaml from 'yaml';
+import type { Transformer, TransformerContext } from '../Types/Transformer.js';
+
+/**
+ * Reports Figma layer and property names that a formatted key cannot reconstruct
+ * (ADR-066), so they can be tidied at the source.
+ *
+ * Reads generated specs, and therefore sees a name only where the producer recorded it
+ * in `$extensions['com.figma'].name`. That happens when `format.figmaKeys` declares a
+ * source convention — under the `NONE` default nothing is recorded and this report is
+ * empty, which is correct: no convention was declared, so no name diverged from one.
+ */
+
+type Surface = 'anatomy' | 'prop';
+
+/** Why a Figma name falls outside the safe key grammar. First match wins. */
+type Cause =
+  | 'separator'
+  | 'symbol'
+  | 'non-ascii'
+  | 'mixed-letter-digit'
+  | 'digit-initial'
+  | 'casing'
+  | 'already-a-key';
+
+interface NameEntry {
+  key: string;
+  figmaName: string;
+  surface: Surface;
+  cause: Cause;
+}
+
+interface ComponentEntry {
+  divergent: number;
+  names: NameEntry[];
+}
+
+interface CauseEntry {
+  cause: Cause;
+  occurrences: number;
+  names: string[];
+}
+
+interface NameFrequencyEntry {
+  figmaName: string;
+  occurrences: number;
+  components: string[];
+  cause: Cause;
+}
+
+interface KeysAggregate {
+  summary: {
+    totalComponents: number;
+    componentsWithDivergence: number;
+    totalNames: number;
+    divergentNames: number;
+    causeDistribution: Record<string, number>;
+  };
+  byComponent: Record<string, ComponentEntry>;
+  byCause: CauseEntry[];
+  byName: NameFrequencyEntry[];
+}
+
+interface Collected extends NameEntry {
+  component: string;
+}
+
+export class KeysAnalyzer implements Transformer {
+  readonly name = 'keys';
+
+  private readonly _divergent: Collected[] = [];
+  private readonly _components = new Set<string>();
+  private _totalNames = 0;
+  private _outputFormat: 'JSON' | 'YAML' = 'JSON';
+
+  async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
+    const { componentKey, outputFormat } = context;
+    this._outputFormat = outputFormat;
+    this._components.add(componentKey);
+
+    this.collect(componentKey, apiYaml);
+
+    const subcomponents = (apiYaml.subcomponents ?? {}) as Record<string, unknown>;
+    for (const [subName, subRaw] of Object.entries(subcomponents)) {
+      this.collect(`${componentKey}.${subName}`, subRaw as Record<string, unknown>);
+    }
+  }
+
+  /**
+   * Walks a component's anatomy and props. Compositions and slot content carry their own
+   * nested anatomy, so those are walked too — the producer records names at every depth.
+   */
+  private collect(component: string, comp: Record<string, unknown>): void {
+    this.collectAnatomy(component, comp.anatomy);
+    this.collectProps(component, comp.props);
+
+    const slotContent = (comp.slotContentExamples ?? {}) as Record<string, unknown>;
+    for (const entry of Object.values(slotContent)) {
+      this.collectAnatomy(component, (entry as Record<string, unknown>)?.anatomy);
+    }
+
+    const compositions = (comp.compositions ?? {}) as Record<string, unknown>;
+    for (const entry of Object.values(compositions)) {
+      this.collectAnatomy(component, (entry as Record<string, unknown>)?.anatomy);
+    }
+  }
+
+  private collectAnatomy(component: string, anatomy: unknown): void {
+    for (const [key, raw] of Object.entries((anatomy ?? {}) as Record<string, unknown>)) {
+      this._totalNames++;
+      const figmaName = figmaNameOf(raw);
+      if (figmaName) this._divergent.push({ component, key, figmaName, surface: 'anatomy', cause: causeOf(figmaName) });
+    }
+  }
+
+  private collectProps(component: string, props: unknown): void {
+    for (const [key, raw] of Object.entries((props ?? {}) as Record<string, unknown>)) {
+      this._totalNames++;
+      const figmaName = figmaNameOf(raw);
+      if (figmaName) this._divergent.push({ component, key, figmaName, surface: 'prop', cause: causeOf(figmaName) });
+    }
+  }
+
+  async finalize(outputDir: string, analysisDir?: string): Promise<void> {
+    if (this._totalNames === 0) return;
+
+    const outDir = analysisDir ?? path.join(outputDir, '_analysis');
+    await fs.ensureDir(outDir);
+
+    const aggregate = this.buildAggregate();
+    const ext = this._outputFormat === 'JSON' ? 'json' : 'yaml';
+    const content = this._outputFormat === 'JSON'
+      ? JSON.stringify(aggregate, null, 2) + '\n'
+      : yaml.stringify(aggregate, { lineWidth: 120 });
+    await fs.writeFile(path.join(outDir, `keys.${ext}`), content, 'utf-8');
+  }
+
+  private buildAggregate(): KeysAggregate {
+    const byComponent: Record<string, ComponentEntry> = {};
+    for (const entry of this._divergent) {
+      const bucket = (byComponent[entry.component] ??= { divergent: 0, names: [] });
+      bucket.names.push({ key: entry.key, figmaName: entry.figmaName, surface: entry.surface, cause: entry.cause });
+      bucket.divergent++;
+    }
+    for (const bucket of Object.values(byComponent)) {
+      bucket.names.sort((a, b) => a.figmaName.localeCompare(b.figmaName));
+    }
+
+    const causeDistribution: Record<string, number> = {};
+    const causeNames = new Map<Cause, Set<string>>();
+    for (const entry of this._divergent) {
+      causeDistribution[entry.cause] = (causeDistribution[entry.cause] ?? 0) + 1;
+      (causeNames.get(entry.cause) ?? causeNames.set(entry.cause, new Set()).get(entry.cause)!).add(entry.figmaName);
+    }
+    const byCause: CauseEntry[] = [...causeNames.entries()]
+      .map(([cause, names]) => ({ cause, occurrences: causeDistribution[cause], names: [...names].sort() }))
+      .sort((a, b) => b.occurrences - a.occurrences);
+
+    // A name wrong in twelve components is one decision, not twelve — which is what a
+    // per-component checklist cannot show on its own.
+    const frequency = new Map<string, { components: Set<string>; occurrences: number; cause: Cause }>();
+    for (const entry of this._divergent) {
+      const record = frequency.get(entry.figmaName)
+        ?? { components: new Set<string>(), occurrences: 0, cause: entry.cause };
+      record.components.add(entry.component);
+      record.occurrences++;
+      frequency.set(entry.figmaName, record);
+    }
+    const byName: NameFrequencyEntry[] = [...frequency.entries()]
+      .map(([figmaName, r]) => ({
+        figmaName,
+        occurrences: r.occurrences,
+        components: [...r.components].sort(),
+        cause: r.cause,
+      }))
+      .sort((a, b) => b.occurrences - a.occurrences || a.figmaName.localeCompare(b.figmaName));
+
+    return {
+      summary: {
+        totalComponents: this._components.size,
+        componentsWithDivergence: Object.keys(byComponent).length,
+        totalNames: this._totalNames,
+        divergentNames: this._divergent.length,
+        causeDistribution,
+      },
+      byComponent: Object.fromEntries(Object.entries(byComponent).sort(([a], [b]) => a.localeCompare(b))),
+      byCause,
+      byName,
+    };
+  }
+}
+
+function figmaNameOf(raw: unknown): string | undefined {
+  const extensions = (raw as Record<string, unknown>)?.$extensions as Record<string, unknown> | undefined;
+  const figma = extensions?.['com.figma'] as Record<string, unknown> | undefined;
+  const name = figma?.name;
+  return typeof name === 'string' ? name : undefined;
+}
+
+/**
+ * Classifies why a name diverged. Ordered most-specific first: a name with both a
+ * symbol and odd casing is reported as a symbol problem, because that is the edit to
+ * make. `already-a-key` is last — it is not a defect, just a name authored in the
+ * spec's own convention rather than as a Figma display name.
+ */
+function causeOf(name: string): Cause {
+  if (/[\-_]/.test(name) && !/\s/.test(name)) return 'already-a-key';
+  if (/[^\x20-\x7E]/.test(name)) return 'non-ascii';
+  if (/[^A-Za-z0-9 ]/.test(name)) return 'symbol';
+  if (/\s\s|^\s|\s$|[\t\n]/.test(name)) return 'separator';
+  if (/[A-Za-z][0-9]|[0-9][A-Za-z]/.test(name)) return 'mixed-letter-digit';
+  if (/^[0-9]/.test(name)) return 'digit-initial';
+  return 'casing';
+}

--- a/packages/cli/src/analyzers/Keys.ts
+++ b/packages/cli/src/analyzers/Keys.ts
@@ -9,11 +9,32 @@ import type { Transformer, TransformerContext } from '../Types/Transformer.js';
  *
  * Reads generated specs, and therefore sees a name only where the producer recorded it
  * in `$extensions['com.figma'].name`. That happens when `format.figmaKeys` declares a
- * source convention — under the `NONE` default nothing is recorded and this report is
- * empty, which is correct: no convention was declared, so no name diverged from one.
+ * source convention — under the `NONE` default nothing diverges and this report is
+ * empty, which is correct: no convention was declared, so no name departed from one.
+ *
+ * A recorded name is NOT by itself a naming problem. The field has two independent
+ * triggers: format divergence (ADR-066) and wrapper-collapse provenance (ADR-058), and
+ * the latter fires on the `root` key regardless of `figmaKeys` or of how well-formed
+ * the name is. `Text` on a collapsed root is perfectly safe under SENTENCE and
+ * round-trips unaided. So each recorded name is re-tested against the safe key grammar
+ * here, and only genuine failures are reported.
  */
 
 type Surface = 'anatomy' | 'prop';
+
+type DeclaredConvention = 'SENTENCE' | 'TITLE';
+
+/**
+ * The safe key grammar. These mirror the `SafeKeySentence` and `SafeKeyTitle`
+ * definitions in `component.schema.json`, which remain the contract — kept as literals
+ * here because the CLI bundles to a single file and reading the schema JSON at runtime
+ * would make the report depend on a resolvable package path. If the schema patterns
+ * change, change these.
+ */
+const SAFE_KEY_PATTERNS: Record<DeclaredConvention, RegExp> = {
+  SENTENCE: /^[A-Z][a-z]*( ([a-z]+|[0-9]+))*$/,
+  TITLE: /^[A-Z][a-z]*( ([A-Z][a-z]*|[0-9]+))*$/,
+};
 
 /** Why a Figma name falls outside the safe key grammar. First match wins. */
 type Cause =
@@ -76,11 +97,14 @@ export class KeysAnalyzer implements Transformer {
   private readonly _components = new Set<string>();
   private _totalNames = 0;
   private _outputFormat: 'JSON' | 'YAML' = 'JSON';
+  /** Read from each spec's own `metadata.config`; undefined means no convention declared. */
+  private _convention: DeclaredConvention | undefined;
 
   async run(apiYaml: Record<string, unknown>, context: TransformerContext): Promise<void> {
     const { componentKey, outputFormat } = context;
     this._outputFormat = outputFormat;
     this._components.add(componentKey);
+    this._convention = declaredConvention(apiYaml) ?? this._convention;
 
     this.collect(componentKey, apiYaml);
 
@@ -112,17 +136,26 @@ export class KeysAnalyzer implements Transformer {
   private collectAnatomy(component: string, anatomy: unknown): void {
     for (const [key, raw] of Object.entries((anatomy ?? {}) as Record<string, unknown>)) {
       this._totalNames++;
-      const figmaName = figmaNameOf(raw);
-      if (figmaName) this._divergent.push({ component, key, figmaName, surface: 'anatomy', cause: causeOf(figmaName) });
+      this.record(component, key, 'anatomy', figmaNameOf(raw));
     }
   }
 
   private collectProps(component: string, props: unknown): void {
     for (const [key, raw] of Object.entries((props ?? {}) as Record<string, unknown>)) {
       this._totalNames++;
-      const figmaName = figmaNameOf(raw);
-      if (figmaName) this._divergent.push({ component, key, figmaName, surface: 'prop', cause: causeOf(figmaName) });
+      this.record(component, key, 'prop', figmaNameOf(raw));
     }
+  }
+
+  /**
+   * Records a name only if it actually fails the declared grammar. A recorded name that
+   * passes was written for the other reason the field exists — wrapper-collapse
+   * provenance — and is not a naming problem: it reconstructs from its key unaided.
+   */
+  private record(component: string, key: string, surface: Surface, figmaName: string | undefined): void {
+    if (!figmaName || !this._convention) return;
+    if (SAFE_KEY_PATTERNS[this._convention].test(figmaName)) return;
+    this._divergent.push({ component, key, figmaName, surface, cause: causeOf(figmaName) });
   }
 
   async finalize(outputDir: string, analysisDir?: string): Promise<void> {
@@ -222,5 +255,17 @@ function causeOf(name: string): Cause {
   if (/\s\s|^\s|\s$|[\t\n]/.test(name)) return 'separator';
   if (/[A-Za-z][0-9]|[0-9][A-Za-z]/.test(name)) return 'mixed-letter-digit';
   if (/^[0-9]/.test(name)) return 'digit-initial';
+  // Characters and word shape are all fine, so the only rule left to fail is casing.
+  // Reached only for names that already failed the grammar, so this is a verdict rather
+  // than a catch-all — a well-formed name never gets here.
   return 'casing';
+}
+
+/** The convention the spec was generated under, from its own `metadata.config`. */
+function declaredConvention(apiYaml: Record<string, unknown>): DeclaredConvention | undefined {
+  const metadata = apiYaml.metadata as Record<string, unknown> | undefined;
+  const config = metadata?.config as Record<string, unknown> | undefined;
+  const format = config?.format as Record<string, unknown> | undefined;
+  const value = format?.figmaKeys;
+  return value === 'SENTENCE' || value === 'TITLE' ? value : undefined;
 }

--- a/packages/cli/src/analyzers/Keys.ts
+++ b/packages/cli/src/analyzers/Keys.ts
@@ -28,13 +28,14 @@ type Cause =
 interface NameEntry {
   key: string;
   figmaName: string;
-  surface: Surface;
   cause: Cause;
 }
 
+/** Empty surfaces are omitted rather than emitted as `[]`, to keep the checklist quiet. */
 interface ComponentEntry {
   divergent: number;
-  names: NameEntry[];
+  props?: NameEntry[];
+  anatomy?: NameEntry[];
 }
 
 interface CauseEntry {
@@ -65,6 +66,7 @@ interface KeysAggregate {
 
 interface Collected extends NameEntry {
   component: string;
+  surface: Surface;
 }
 
 export class KeysAnalyzer implements Transformer {
@@ -138,14 +140,22 @@ export class KeysAnalyzer implements Transformer {
   }
 
   private buildAggregate(): KeysAggregate {
-    const byComponent: Record<string, ComponentEntry> = {};
+    const surfaces = new Map<string, { props: NameEntry[]; anatomy: NameEntry[] }>();
     for (const entry of this._divergent) {
-      const bucket = (byComponent[entry.component] ??= { divergent: 0, names: [] });
-      bucket.names.push({ key: entry.key, figmaName: entry.figmaName, surface: entry.surface, cause: entry.cause });
-      bucket.divergent++;
+      const bucket = surfaces.get(entry.component)
+        ?? surfaces.set(entry.component, { props: [], anatomy: [] }).get(entry.component)!;
+      const list = entry.surface === 'prop' ? bucket.props : bucket.anatomy;
+      list.push({ key: entry.key, figmaName: entry.figmaName, cause: entry.cause });
     }
-    for (const bucket of Object.values(byComponent)) {
-      bucket.names.sort((a, b) => a.figmaName.localeCompare(b.figmaName));
+    const byComponent: Record<string, ComponentEntry> = {};
+    for (const [component, { props, anatomy }] of surfaces) {
+      props.sort((a, b) => a.figmaName.localeCompare(b.figmaName));
+      anatomy.sort((a, b) => a.figmaName.localeCompare(b.figmaName));
+      byComponent[component] = {
+        divergent: props.length + anatomy.length,
+        ...(props.length ? { props } : {}),
+        ...(anatomy.length ? { anatomy } : {}),
+      };
     }
 
     const causeDistribution: Record<string, number> = {};

--- a/packages/cli/src/analyzers/index.ts
+++ b/packages/cli/src/analyzers/index.ts
@@ -1,5 +1,6 @@
 import type { Transformer } from '../Types/Transformer.js';
 import { DependenciesAnalyzer } from './Dependencies.js';
+import { KeysAnalyzer } from './Keys.js';
 import { PropsAnalyzer } from './Props.js';
 import { StylingAnalyzer } from './Styling.js';
 
@@ -7,6 +8,7 @@ const ALL_ANALYZERS: Transformer[] = [
   new PropsAnalyzer(),
   new StylingAnalyzer(),
   new DependenciesAnalyzer(),
+  new KeysAnalyzer(),
 ];
 
 const BY_NAME = new Map(ALL_ANALYZERS.map(a => [a.name, a]));

--- a/packages/cli/src/commands/AnalyzeCommand.ts
+++ b/packages/cli/src/commands/AnalyzeCommand.ts
@@ -19,7 +19,7 @@ interface AnalyzeOptions {
 
 export const Analyze = new Command('analyze')
   .description('Run analysis passes over component specs and write aggregate reports to _analysis/')
-  .argument('[analyzers...]', 'Analyzer names to run (props, styling, dependencies)')
+  .argument('[analyzers...]', 'Analyzer names to run (props, styling, dependencies, keys)')
   .option('-o, --output <path>', 'Path to the specs directory (input)')
   .option('--analysis <path>', 'Path to write analysis output (default: <specs-dir>/_analysis)')
   .option('--config <path>', 'Path to config file (specs.config.yaml)')

--- a/packages/cli/tests/unit/analyzers/Keys.test.ts
+++ b/packages/cli/tests/unit/analyzers/Keys.test.ts
@@ -41,12 +41,22 @@ describe('KeysAnalyzer', () => {
     await fs.remove(outputDir);
   });
 
-  async function runAnalyzer(components: Record<string, Record<string, unknown>>) {
+  /**
+   * @param figmaKeys The convention the specs declare in `metadata.config`. Defaults to
+   *   SENTENCE; pass undefined to model a catalog generated under the NONE default.
+   */
+  async function runAnalyzer(
+    components: Record<string, Record<string, unknown>>,
+    figmaKeys: 'SENTENCE' | 'TITLE' | undefined = 'SENTENCE',
+  ) {
     const a = new KeysAnalyzer();
     for (const [componentKey, apiYaml] of Object.entries(components)) {
       const compDir = path.join(outputDir, componentKey);
       await fs.ensureDir(compDir);
-      await a.run(apiYaml, { outputDir: compDir, componentKey, outputFormat: 'YAML', tokensFormat: 'TOKEN' });
+      const spec = figmaKeys
+        ? { ...apiYaml, metadata: { config: { format: { keys: 'CAMEL', figmaKeys } } } }
+        : apiYaml;
+      await a.run(spec, { outputDir: compDir, componentKey, outputFormat: 'YAML', tokensFormat: 'TOKEN' });
     }
     await a.finalize!(outputDir, analysisDir);
     const file = path.join(analysisDir, 'keys.yaml');
@@ -54,7 +64,31 @@ describe('KeysAnalyzer', () => {
     return yaml.parse(await fs.readFile(file, 'utf-8')) as KeysYaml;
   }
 
-  it('reports nothing when no name was recorded — the NONE default', async () => {
+  it('reports nothing for a catalog generated under the NONE default', async () => {
+    const result = await runAnalyzer({
+      dsBody: { anatomy: { root: withName('text', 'Text') } },
+    }, undefined);
+    expect(result!.summary.divergentNames).toBe(0);
+    expect(result!.byComponent).toEqual({});
+  });
+
+  it('ignores a recorded name that satisfies the grammar — wrapper-collapse provenance', async () => {
+    // $extensions['com.figma'].name has two triggers. ADR-058 wrapper collapse records
+    // the pre-collapse layer name on `root` whether or not it diverges, so a safe name
+    // like 'Text' or 'Icon glyph' must not be reported as a naming problem.
+    const result = await runAnalyzer({
+      dsBody: { anatomy: { root: withName('text', 'Text') } },
+      dsIcon: { anatomy: { root: withName('glyph', 'Icon glyph') } },
+      dsText: { anatomy: { root: withName('text', 'Text'), urlField: withName('text', 'URL field') } },
+    });
+    expect(result!.summary.divergentNames).toBe(1);
+    expect(Object.keys(result!.byComponent)).toEqual(['dsText']);
+    expect(result!.byComponent.dsText.anatomy).toEqual([
+      { key: 'urlField', figmaName: 'URL field', cause: 'casing' },
+    ]);
+  });
+
+  it('reports nothing when no name was recorded', async () => {
     const result = await runAnalyzer({
       dsButton: { anatomy: { label: { type: 'text' } }, props: { size: { type: 'string' } } },
     });

--- a/packages/cli/tests/unit/analyzers/Keys.test.ts
+++ b/packages/cli/tests/unit/analyzers/Keys.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import yaml from 'yaml';
+import { KeysAnalyzer } from '../../../src/analyzers/Keys.js';
+
+type KeysYaml = {
+  summary: {
+    totalComponents: number;
+    componentsWithDivergence: number;
+    totalNames: number;
+    divergentNames: number;
+    causeDistribution: Record<string, number>;
+  };
+  byComponent: Record<string, { divergent: number; names: Array<{ key: string; figmaName: string; surface: string; cause: string }> }>;
+  byCause: Array<{ cause: string; occurrences: number; names: string[] }>;
+  byName: Array<{ figmaName: string; occurrences: number; components: string[]; cause: string }>;
+};
+
+/** An anatomy or prop entry carrying a recorded Figma name. */
+const withName = (type: string, figmaName: string) => ({
+  type,
+  $extensions: { 'com.figma': { name: figmaName } },
+});
+
+describe('KeysAnalyzer', () => {
+  let outputDir: string;
+  let analysisDir: string;
+
+  beforeEach(async () => {
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'keys-test-'));
+    analysisDir = path.join(outputDir, '_analysis');
+  });
+
+  afterEach(async () => {
+    await fs.remove(outputDir);
+  });
+
+  async function runAnalyzer(components: Record<string, Record<string, unknown>>) {
+    const a = new KeysAnalyzer();
+    for (const [componentKey, apiYaml] of Object.entries(components)) {
+      const compDir = path.join(outputDir, componentKey);
+      await fs.ensureDir(compDir);
+      await a.run(apiYaml, { outputDir: compDir, componentKey, outputFormat: 'YAML', tokensFormat: 'TOKEN' });
+    }
+    await a.finalize!(outputDir, analysisDir);
+    const file = path.join(analysisDir, 'keys.yaml');
+    if (!await fs.pathExists(file)) return null;
+    return yaml.parse(await fs.readFile(file, 'utf-8')) as KeysYaml;
+  }
+
+  it('reports nothing when no name was recorded — the NONE default', async () => {
+    const result = await runAnalyzer({
+      dsButton: { anatomy: { label: { type: 'text' } }, props: { size: { type: 'string' } } },
+    });
+    expect(result!.summary.divergentNames).toBe(0);
+    expect(result!.byComponent).toEqual({});
+  });
+
+  it('groups divergent names under their component', async () => {
+    const result = await runAnalyzer({
+      dsAlert: {
+        anatomy: { root: { type: 'container' }, iconLeading: withName('glyph', 'Icon Leading') },
+        props: { fullBleed: { type: 'boolean', $extensions: { 'com.figma': { name: 'Full Bleed' } } } },
+      },
+    });
+
+    expect(result!.byComponent.dsAlert.divergent).toBe(2);
+    expect(result!.byComponent.dsAlert.names).toEqual([
+      { key: 'fullBleed', figmaName: 'Full Bleed', surface: 'prop', cause: 'casing' },
+      { key: 'iconLeading', figmaName: 'Icon Leading', surface: 'anatomy', cause: 'casing' },
+    ]);
+  });
+
+  it('counts every name, not only divergent ones', async () => {
+    const result = await runAnalyzer({
+      dsButton: {
+        anatomy: { root: { type: 'container' }, label: { type: 'text' }, urlField: withName('text', 'URL field') },
+        props: { size: { type: 'string' } },
+      },
+    });
+    expect(result!.summary.totalNames).toBe(4);
+    expect(result!.summary.divergentNames).toBe(1);
+    expect(result!.summary.componentsWithDivergence).toBe(1);
+    expect(result!.summary.totalComponents).toBe(1);
+  });
+
+  it('aggregates a repeated name across components — one decision, not many', async () => {
+    const props = { a11yLabel: withName('string', 'A11y label') };
+    const result = await runAnalyzer({
+      dsAvatar: { props }, dsBadge: { props }, dsButton: { props },
+    });
+
+    const entry = result!.byName.find(n => n.figmaName === 'A11y label')!;
+    expect(entry.occurrences).toBe(3);
+    expect(entry.components).toEqual(['dsAvatar', 'dsBadge', 'dsButton']);
+  });
+
+  it('walks anatomy nested in slot content and compositions', async () => {
+    const result = await runAnalyzer({
+      dsCard: {
+        anatomy: { root: { type: 'container' } },
+        slotContentExamples: { basic: { anatomy: { urlField: withName('text', 'URL field') } } },
+        compositions: { hero: { anatomy: { cutPaste: withName('container', 'Cut & paste') } } },
+      },
+    });
+    expect(result!.byComponent.dsCard.divergent).toBe(2);
+  });
+
+  it('collects subcomponents under a dot-path key', async () => {
+    const result = await runAnalyzer({
+      dsList: {
+        anatomy: { root: { type: 'container' } },
+        subcomponents: { item: { anatomy: { startIcon: withName('glyph', 'Start Icon') } } },
+      },
+    });
+    expect(result!.byComponent['dsList.item'].divergent).toBe(1);
+  });
+
+  describe('cause classification', () => {
+    it.each([
+      ['Label   ', 'separator'],
+      ['Cut & paste', 'symbol'],
+      ['Étiquette', 'non-ascii'],
+      ['A11y label', 'mixed-letter-digit'],
+      ['0000 0000', 'digit-initial'],
+      ['Start Icon', 'casing'],
+      ['x-figmacollapse', 'already-a-key'],
+    ])('classifies %s as %s', async (figmaName, expected) => {
+      const result = await runAnalyzer({
+        dsX: { anatomy: { k: withName('text', figmaName as string) } },
+      });
+      expect(result!.byComponent.dsX.names[0].cause).toBe(expected);
+    });
+
+    it('ranks causes by frequency', async () => {
+      const result = await runAnalyzer({
+        dsA: { anatomy: { a: withName('text', 'Start Icon'), b: withName('text', 'End Icon') } },
+        dsB: { anatomy: { c: withName('text', 'Cut & paste') } },
+      });
+      expect(result!.byCause[0]).toEqual({ cause: 'casing', occurrences: 2, names: ['End Icon', 'Start Icon'] });
+      expect(result!.byCause[1].cause).toBe('symbol');
+    });
+  });
+});

--- a/packages/cli/tests/unit/analyzers/Keys.test.ts
+++ b/packages/cli/tests/unit/analyzers/Keys.test.ts
@@ -13,7 +13,11 @@ type KeysYaml = {
     divergentNames: number;
     causeDistribution: Record<string, number>;
   };
-  byComponent: Record<string, { divergent: number; names: Array<{ key: string; figmaName: string; surface: string; cause: string }> }>;
+  byComponent: Record<string, {
+    divergent: number;
+    props?: Array<{ key: string; figmaName: string; cause: string }>;
+    anatomy?: Array<{ key: string; figmaName: string; cause: string }>;
+  }>;
   byCause: Array<{ cause: string; occurrences: number; names: string[] }>;
   byName: Array<{ figmaName: string; occurrences: number; components: string[]; cause: string }>;
 };
@@ -67,10 +71,20 @@ describe('KeysAnalyzer', () => {
     });
 
     expect(result!.byComponent.dsAlert.divergent).toBe(2);
-    expect(result!.byComponent.dsAlert.names).toEqual([
-      { key: 'fullBleed', figmaName: 'Full Bleed', surface: 'prop', cause: 'casing' },
-      { key: 'iconLeading', figmaName: 'Icon Leading', surface: 'anatomy', cause: 'casing' },
+    expect(result!.byComponent.dsAlert.props).toEqual([
+      { key: 'fullBleed', figmaName: 'Full Bleed', cause: 'casing' },
     ]);
+    expect(result!.byComponent.dsAlert.anatomy).toEqual([
+      { key: 'iconLeading', figmaName: 'Icon Leading', cause: 'casing' },
+    ]);
+  });
+
+  it('omits a surface array entirely when it is empty', async () => {
+    const result = await runAnalyzer({
+      dsBadge: { props: { fullBleed: withName('boolean', 'Full Bleed') } },
+    });
+    expect(result!.byComponent.dsBadge).not.toHaveProperty('anatomy');
+    expect(result!.byComponent.dsBadge.props).toHaveLength(1);
   });
 
   it('counts every name, not only divergent ones', async () => {
@@ -131,7 +145,7 @@ describe('KeysAnalyzer', () => {
       const result = await runAnalyzer({
         dsX: { anatomy: { k: withName('text', figmaName as string) } },
       });
-      expect(result!.byComponent.dsX.names[0].cause).toBe(expected);
+      expect(result!.byComponent.dsX.anatomy![0].cause).toBe(expected);
     });
 
     it('ranks causes by frequency', async () => {

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,9 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Config.format.figmaKeys` — naming convention the Figma file uses (`SENTENCE` | `TITLE`, default `SENTENCE`); the reversal target for `format.keys` (ADR-066)
+- `FigmaPropExtension.name` — Figma property name, emitted when the prop key cannot reconstruct it (ADR-066)
+- `SafeKeySentence` and `SafeKeyTitle` schema definitions — the key grammar that survives every `format.keys` value (ADR-066)
+
 ### Changed
 
+- `FigmaAnatomyElementExtension.name` — renamed from `originalName`; now records the Figma layer name for key divergence as well as wrapper collapse (ADR-066)
+
 ### Removed
+
+### Migration
+
+`FigmaAnatomyElementExtension.originalName` → `FigmaAnatomyElementExtension.name`: read `$extensions['com.figma'].name` instead; the value and its collapse-provenance meaning are unchanged. Consumers that read the extension through an inline structural type will not see a compile error — update those call sites explicitly.
 
 
 ## [0.29.0] - 2026-08-07

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Config.format.figmaKeys` — naming convention the Figma file uses (`NONE` | `SENTENCE` | `TITLE`, default `NONE`); the reversal target for `format.keys` (ADR-066). `NONE` declares no convention, so the safe key grammar, the `com.figma.name` divergence extension, and reversal are all opt-in
 - `FigmaPropExtension.name` — Figma property name, emitted when the prop key cannot reconstruct it (ADR-066)
 - `SafeKeySentence` and `SafeKeyTitle` schema definitions — the key grammar that survives every `format.keys` value (ADR-066)
+- `NumberProp.$extensions` — the only prop type that could not carry platform extensions, so a number prop had nowhere to record its Figma name under ADR-066. The JSON schema already permitted `$`-prefixed keys; the TypeScript type did not.
 
 ### Changed
 

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Config.format.figmaKeys` — naming convention the Figma file uses (`SENTENCE` | `TITLE`, default `SENTENCE`); the reversal target for `format.keys` (ADR-066)
+- `Config.format.figmaKeys` — naming convention the Figma file uses (`NONE` | `SENTENCE` | `TITLE`, default `NONE`); the reversal target for `format.keys` (ADR-066). `NONE` declares no convention, so the safe key grammar, the `com.figma.name` divergence extension, and reversal are all opt-in
 - `FigmaPropExtension.name` — Figma property name, emitted when the prop key cannot reconstruct it (ADR-066)
 - `SafeKeySentence` and `SafeKeyTitle` schema definitions — the key grammar that survives every `format.keys` value (ADR-066)
 

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -1063,6 +1063,9 @@
             "type": "number"
           },
           "description": "Sample numeric values demonstrating typical content for this prop"
+        },
+        "$extensions": {
+          "$ref": "#/definitions/PropExtensions"
         }
       },
       "required": [

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -124,11 +124,21 @@
     },
     "Anatomy": {
       "type": "object",
-      "description": "The structural elements that make up the component. Element names format depends on user settings.",
+      "description": "The structural elements that make up the component. Keys are formatted per format.keys. A key whose Figma name did not satisfy the safe key grammar (see SafeKeySentence / SafeKeyTitle) carries that name in $extensions['com.figma'].name.",
       "examples": [],
       "additionalProperties": {
         "$ref": "#/definitions/AnatomyElement"
       }
+    },
+    "SafeKeySentence": {
+      "type": "string",
+      "pattern": "^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$",
+      "description": "A round-trip-safe Figma name under format.figmaKeys SENTENCE: ASCII letters and digits, single-space word separators, sentence case, no digit-leading words. Names matching this pattern reconstruct identically from the output of any format.keys value; names that do not require $extensions['com.figma'].name."
+    },
+    "SafeKeyTitle": {
+      "type": "string",
+      "pattern": "^[A-Z][a-z0-9]*( [A-Z][a-z0-9]*)*$",
+      "description": "As SafeKeySentence, but for format.figmaKeys TITLE — every word capitalized."
     },
     "ElementType": {
       "type": "string",
@@ -213,9 +223,9 @@
             "com.figma": {
               "type": "object",
               "properties": {
-                "originalName": {
+                "name": {
                   "type": "string",
-                  "description": "Original Figma layer name before primitive-wrapper collapse promoted this element to root (ADR-058)."
+                  "description": "The element's name in Figma, recorded when the anatomy key diverges from it — either because primitive-wrapper collapse promoted this element to root (ADR-058) or because format.keys could not represent the name losslessly (ADR-066). Absent when the key reconstructs the Figma name under format.figmaKeys."
                 }
               },
               "additionalProperties": false
@@ -231,7 +241,7 @@
     },
     "Props": {
       "type": "object",
-      "description": "",
+      "description": "Component properties. Keys are formatted per format.keys. A key whose Figma property name did not satisfy the safe key grammar (see SafeKeySentence / SafeKeyTitle) carries that name in $extensions['com.figma'].name.",
       "examples": [],
       "additionalProperties": {
         "$ref": "#/definitions/AnyProp"
@@ -302,6 +312,10 @@
         "source": {
           "$ref": "#/definitions/FigmaCodeOnlySource",
           "description": "Provenance metadata \u2014 present only for props extracted from a code-only container layer"
+        },
+        "name": {
+          "type": "string",
+          "description": "The Figma component-property name, recorded when the prop key diverges from it under format.keys (ADR-066). Absent when the key reconstructs the Figma name under format.figmaKeys."
         }
       },
       "additionalProperties": true

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -132,13 +132,13 @@
     },
     "SafeKeySentence": {
       "type": "string",
-      "pattern": "^[A-Z][a-z0-9]*( [a-z][a-z0-9]*)*$",
-      "description": "A round-trip-safe Figma name under format.figmaKeys SENTENCE: ASCII letters and digits, single-space word separators, sentence case, no digit-leading words. Names matching this pattern reconstruct identically from the output of any format.keys value; names that do not require $extensions['com.figma'].name."
+      "pattern": "^[A-Z][a-z]*( ([a-z]+|[0-9]+))*$",
+      "description": "A round-trip-safe Figma name under format.figmaKeys SENTENCE: ASCII letters and digits, single-space word separators, sentence case, each word either all letters or all digits, never beginning with a digit. Names matching this pattern reconstruct identically from the output of any format.keys value; names that do not require $extensions['com.figma'].name."
     },
     "SafeKeyTitle": {
       "type": "string",
-      "pattern": "^[A-Z][a-z0-9]*( [A-Z][a-z0-9]*)*$",
-      "description": "As SafeKeySentence, but for format.figmaKeys TITLE — every word capitalized."
+      "pattern": "^[A-Z][a-z]*( ([A-Z][a-z]*|[0-9]+))*$",
+      "description": "As SafeKeySentence, but for format.figmaKeys TITLE — every letter word capitalized."
     },
     "ElementType": {
       "type": "string",
@@ -225,7 +225,7 @@
               "properties": {
                 "name": {
                   "type": "string",
-                  "description": "The element's name in Figma, recorded when the anatomy key diverges from it — either because primitive-wrapper collapse promoted this element to root (ADR-058) or because format.keys could not represent the name losslessly (ADR-066). Absent when the key reconstructs the Figma name under format.figmaKeys."
+                  "description": "The element's name in Figma. Recorded on any of three triggers: primitive-wrapper collapse promoted this element to root (ADR-058), always and independent of format.figmaKeys; the name fell outside the safe key grammar so format.keys could not represent it losslessly (ADR-066); or the name was already written in the destination format and passed through unformatted, making reversal identity rather than re-derivation (ADR-066). The latter two apply only when format.figmaKeys is not NONE — under NONE, format divergence is not evaluated and this field is absent however the key was derived."
                 }
               },
               "additionalProperties": false
@@ -315,7 +315,7 @@
         },
         "name": {
           "type": "string",
-          "description": "The Figma component-property name, recorded when the prop key diverges from it under format.keys (ADR-066). Absent when the key reconstructs the Figma name under format.figmaKeys."
+          "description": "The Figma component-property name (ADR-066). Recorded when the name fell outside the safe key grammar, or when it was already written in the destination format and passed through unformatted — in which case reversal is identity, not re-derivation. Both triggers require format.figmaKeys to be other than NONE; under NONE this field is absent however the key was derived."
         }
       },
       "additionalProperties": true

--- a/packages/schema/schema/workspace.schema.json
+++ b/packages/schema/schema/workspace.schema.json
@@ -217,7 +217,16 @@
                 "TRAIN"
               ],
               "default": "SAFE",
-              "description": "Key naming convention. Defaults to SAFE."
+              "description": "Key naming convention applied to anatomy keys, prop keys, and every reference to them. Every value other than SAFE is a lossy projection of the Figma name; names outside the safe key grammar are preserved in $extensions['com.figma'].name (ADR-066). Defaults to SAFE."
+            },
+            "figmaKeys": {
+              "type": "string",
+              "enum": [
+                "SENTENCE",
+                "TITLE"
+              ],
+              "default": "SENTENCE",
+              "description": "Naming convention the Figma file uses for layer names and component property names. The reversal target for keys — a renderer reconstructs a Figma name by re-formatting the spec key into this convention. Defaults to SENTENCE."
             },
             "layout": {
               "type": "string",

--- a/packages/schema/schema/workspace.schema.json
+++ b/packages/schema/schema/workspace.schema.json
@@ -222,11 +222,12 @@
             "figmaKeys": {
               "type": "string",
               "enum": [
+                "NONE",
                 "SENTENCE",
                 "TITLE"
               ],
-              "default": "SENTENCE",
-              "description": "Naming convention the Figma file uses for layer names and component property names. The reversal target for keys — a renderer reconstructs a Figma name by re-formatting the spec key into this convention. Defaults to SENTENCE."
+              "default": "NONE",
+              "description": "Naming convention the Figma file uses for layer names and component property names. The reversal target for keys — a renderer reconstructs a Figma name by re-formatting the spec key into this convention. NONE declares no convention: the safe key grammar is not evaluated, no $extensions['com.figma'].name is emitted for format divergence, and reversal is undefined. Declaring SENTENCE or TITLE opts in to all three. Defaults to NONE."
             },
             "layout": {
               "type": "string",

--- a/packages/schema/tests/Anatomy.test-d.ts
+++ b/packages/schema/tests/Anatomy.test-d.ts
@@ -90,14 +90,29 @@ if (typeof element.type === 'string') {
   const _ref: string = element.type.$ref;
 }
 
-// AnatomyElement.$extensions carries collapse provenance (ADR-058)
+// AnatomyElement.$extensions carries the Figma name (ADR-058 collapse, ADR-066 key divergence)
 const collapsedRoot: AnatomyElement = {
   type: 'text',
-  $extensions: { 'com.figma': { originalName: 'Text' } },
+  $extensions: { 'com.figma': { name: 'Text' } },
 };
+
+// ADR-066 — a key that could not represent its Figma name losslessly
+const divergentKey: AnatomyElement = {
+  type: 'glyph',
+  $extensions: { 'com.figma': { name: 'Cut & paste' } },
+};
+
+// name is optional — safe keys emit no extension at all
+const safeKey: AnatomyElement = { type: 'text' };
 
 const badExtension: AnatomyElement = {
   type: 'text',
   // @ts-expect-error — unknown extension members are rejected
   $extensions: { 'com.figma': { layerName: 'Text' } },
+};
+
+const renamedExtension: AnatomyElement = {
+  type: 'text',
+  // @ts-expect-error — originalName was renamed to name in 0.30.0 (ADR-066)
+  $extensions: { 'com.figma': { originalName: 'Text' } },
 };

--- a/packages/schema/tests/Config.test-d.ts
+++ b/packages/schema/tests/Config.test-d.ts
@@ -38,6 +38,7 @@ const fullConfig: Config = {
   format: {
     output: 'JSON',
     keys: 'SAFE',
+    figmaKeys: 'SENTENCE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
     color: 'HEX',
@@ -178,11 +179,24 @@ const defaultIsValidConfig: Config = DEFAULT_CONFIG;
 
 const defaultTokensValue: typeof DEFAULT_CONFIG.format.tokens = 'TOKEN';
 
+// ─── format.figmaKeys (ADR-066) ──────────────────────────────────────────────
+
+// Optional on Config — absence means SENTENCE
+const noFigmaKeys: Config = { processing: {}, format: {}, include: {} };
+
+const sentenceKeys: Config = { processing: {}, format: { figmaKeys: 'SENTENCE' }, include: {} };
+const titleKeys: Config = { processing: {}, format: { figmaKeys: 'TITLE' }, include: {} };
+
+// @ts-expect-error — figmaKeys is deliberately narrower than format.keys
+const kebabFigmaKeys: Config = { processing: {}, format: { figmaKeys: 'KEBAB' }, include: {} };
+
+const defaultFigmaKeysValue: typeof DEFAULT_CONFIG.format.figmaKeys = 'SENTENCE';
+
 // ─── ResolvedConfig requires all defaultable fields ──────────────────────────
 
 const resolved: ResolvedConfig = {
   processing: { slotConstraints: false, collapsePrimitiveWrapper: false, variantDepth: 9999, details: 'LAYERED', inferNumberProps: false },
-  format: { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT', tokens: 'TOKEN', color: 'HEX' },
+  format: { output: 'JSON', keys: 'SAFE', figmaKeys: 'SENTENCE', layout: 'LAYOUT', tokens: 'TOKEN', color: 'HEX' },
   include: { invalidVariants: false, invalidCombinations: true, emptyVariants: false, defaultSlotContent: false },
   transformers: [],
 };

--- a/packages/schema/tests/Props.test-d.ts
+++ b/packages/schema/tests/Props.test-d.ts
@@ -97,6 +97,21 @@ const slotWithExt: SlotProp = { type: 'slot', $extensions: { 'com.figma': { type
 // $extensions with empty com.figma
 const boolEmptyFigma: BooleanProp = { type: 'boolean', default: true, $extensions: { 'com.figma': {} } };
 
+// com.figma.name preserves a Figma property name the key could not represent (ADR-066)
+const boolDivergentKey: BooleanProp = {
+  type: 'boolean',
+  default: false,
+  $extensions: { 'com.figma': { type: 'BOOLEAN', name: 'Cut & paste' } },
+};
+
+// name is optional — safe keys emit no name at all
+const enumSafeKey: EnumProp = {
+  type: 'string',
+  default: 'sm',
+  enum: ['sm', 'md'],
+  $extensions: { 'com.figma': { type: 'VARIANT' } },
+};
+
 // $extensions with empty object
 const boolEmptyExt: BooleanProp = { type: 'boolean', default: true, $extensions: {} };
 

--- a/packages/schema/types/Anatomy.ts
+++ b/packages/schema/types/Anatomy.ts
@@ -30,8 +30,14 @@ export type SubcomponentRef = {
  * @since 0.28.0
  */
 export interface FigmaAnatomyElementExtension {
-  /** Original Figma layer name before primitive-wrapper collapse promoted this element to root (ADR-058). */
-  originalName?: string;
+  /**
+   * The element's name in Figma, recorded when the anatomy key diverges from it —
+   * either because primitive-wrapper collapse promoted this element to root (ADR-058)
+   * or because `format.keys` could not represent the name losslessly (ADR-066).
+   * Absent when the key reconstructs the Figma name under `format.figmaKeys`.
+   * @since 0.30.0 — renamed from `originalName`
+   */
+  name?: string;
 }
 
 /**

--- a/packages/schema/types/Anatomy.ts
+++ b/packages/schema/types/Anatomy.ts
@@ -31,10 +31,17 @@ export type SubcomponentRef = {
  */
 export interface FigmaAnatomyElementExtension {
   /**
-   * The element's name in Figma, recorded when the anatomy key diverges from it —
-   * either because primitive-wrapper collapse promoted this element to root (ADR-058)
-   * or because `format.keys` could not represent the name losslessly (ADR-066).
-   * Absent when the key reconstructs the Figma name under `format.figmaKeys`.
+   * The element's name in Figma. Recorded on any of three triggers:
+   * - primitive-wrapper collapse promoted this element to root (ADR-058) — always,
+   *   independent of `format.figmaKeys`;
+   * - the name fell outside the safe key grammar, so `format.keys` could not
+   *   represent it losslessly (ADR-066);
+   * - the name was already written in the destination format and passed through
+   *   unformatted, making reversal identity rather than re-derivation (ADR-066).
+   *
+   * The latter two apply only when `format.figmaKeys` is not NONE. Under NONE no
+   * source convention is declared, so format divergence is not evaluated and this
+   * field is absent however the key was derived.
    * @since 0.30.0 — renamed from `originalName`
    */
   name?: string;

--- a/packages/schema/types/Config.ts
+++ b/packages/schema/types/Config.ts
@@ -121,8 +121,20 @@ export interface Config {
   format: {
     /** Output format. Optional; defaults to JSON. */
     output?: 'JSON' | 'YAML';
-    /** Key naming convention. Optional; defaults to SAFE. */
+    /**
+     * Key naming convention applied to anatomy keys, prop keys, and every reference
+     * to them. Every value other than SAFE is a lossy projection of the Figma name;
+     * names outside the safe key grammar are preserved in `$extensions['com.figma'].name`
+     * (ADR-066). Optional; defaults to SAFE.
+     */
     keys?: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
+    /**
+     * Naming convention the Figma file uses for layer names and component property
+     * names. The reversal target for `keys` — a renderer reconstructs a Figma name by
+     * re-formatting the spec key into this convention. Optional; defaults to SENTENCE.
+     * @since 0.30.0
+     */
+    figmaKeys?: 'SENTENCE' | 'TITLE';
     /** Layout representation format. Optional; defaults to LAYOUT. */
     layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /**
@@ -209,6 +221,8 @@ export interface ResolvedConfig {
     output: 'JSON' | 'YAML';
     /** Key naming convention. */
     keys: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
+    /** Naming convention the Figma file uses — the reversal target for `keys`. @since 0.30.0 */
+    figmaKeys: 'SENTENCE' | 'TITLE';
     /** Layout representation format. */
     layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /** Token reference serialization profile. */
@@ -241,6 +255,7 @@ export interface ResolvedConfig {
  * - processing.details: LAYERED reduces output size by only showing differences from default
  * - processing.inferNumberProps: false — opt-in feature, off by default
  * - format.keys: SAFE prevents corruption of special characters while maintaining readability
+ * - format.figmaKeys: SENTENCE matches the prevailing convention for Figma layer and property names (ADR-066)
  * - format.layout: LAYOUT provides tree structure with layout properties
  * - format.tokens: TOKEN provides platform-neutral token references with $token path and $type
  * - format.color: HEX matches historical v1 behaviour and maximises human readability
@@ -262,6 +277,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
   format: {
     output: 'JSON',
     keys: 'SAFE',
+    figmaKeys: 'SENTENCE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
     color: 'HEX',

--- a/packages/schema/types/Config.ts
+++ b/packages/schema/types/Config.ts
@@ -131,10 +131,17 @@ export interface Config {
     /**
      * Naming convention the Figma file uses for layer names and component property
      * names. The reversal target for `keys` — a renderer reconstructs a Figma name by
-     * re-formatting the spec key into this convention. Optional; defaults to SENTENCE.
+     * re-formatting the spec key into this convention.
+     *
+     * NONE declares no convention: the safe key grammar is not evaluated, no
+     * `$extensions['com.figma'].name` is emitted for format divergence, and reversal
+     * is undefined. Declaring SENTENCE or TITLE opts the catalog into all three, at
+     * the cost of an extension on every name outside the grammar.
+     *
+     * Optional; defaults to NONE.
      * @since 0.30.0
      */
-    figmaKeys?: 'SENTENCE' | 'TITLE';
+    figmaKeys?: 'NONE' | 'SENTENCE' | 'TITLE';
     /** Layout representation format. Optional; defaults to LAYOUT. */
     layout?: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /**
@@ -221,8 +228,8 @@ export interface ResolvedConfig {
     output: 'JSON' | 'YAML';
     /** Key naming convention. */
     keys: 'SAFE' | 'CAMEL' | 'SNAKE' | 'KEBAB' | 'PASCAL' | 'TRAIN';
-    /** Naming convention the Figma file uses — the reversal target for `keys`. @since 0.30.0 */
-    figmaKeys: 'SENTENCE' | 'TITLE';
+    /** Naming convention the Figma file uses — the reversal target for `keys`. NONE declares none. @since 0.30.0 */
+    figmaKeys: 'NONE' | 'SENTENCE' | 'TITLE';
     /** Layout representation format. */
     layout: 'LAYOUT' | 'PARENT_CHILDREN' | 'BOTH';
     /** Token reference serialization profile. */
@@ -255,7 +262,7 @@ export interface ResolvedConfig {
  * - processing.details: LAYERED reduces output size by only showing differences from default
  * - processing.inferNumberProps: false — opt-in feature, off by default
  * - format.keys: SAFE prevents corruption of special characters while maintaining readability
- * - format.figmaKeys: SENTENCE matches the prevailing convention for Figma layer and property names (ADR-066)
+ * - format.figmaKeys: NONE declares no source convention — the safe key grammar, the name extension, and reversal are opt-in (ADR-066)
  * - format.layout: LAYOUT provides tree structure with layout properties
  * - format.tokens: TOKEN provides platform-neutral token references with $token path and $type
  * - format.color: HEX matches historical v1 behaviour and maximises human readability
@@ -277,7 +284,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
   format: {
     output: 'JSON',
     keys: 'SAFE',
-    figmaKeys: 'SENTENCE',
+    figmaKeys: 'NONE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
     color: 'HEX',

--- a/packages/schema/types/Props.ts
+++ b/packages/schema/types/Props.ts
@@ -35,6 +35,13 @@ export interface FigmaPropExtension {
   type?: string;
   /** Provenance metadata — present only for props extracted from a code-only container layer. @since 0.14.0 */
   source?: FigmaCodeOnlySource;
+  /**
+   * The Figma component-property name, recorded when the prop key diverges from it
+   * under `format.keys` (ADR-066). Absent when the key reconstructs the Figma name
+   * under `format.figmaKeys`.
+   * @since 0.30.0
+   */
+  name?: string;
   /** Additional Figma-specific metadata passes through without type enforcement. */
   [key: string]: unknown;
 }

--- a/packages/schema/types/Props.ts
+++ b/packages/schema/types/Props.ts
@@ -36,9 +36,13 @@ export interface FigmaPropExtension {
   /** Provenance metadata — present only for props extracted from a code-only container layer. @since 0.14.0 */
   source?: FigmaCodeOnlySource;
   /**
-   * The Figma component-property name, recorded when the prop key diverges from it
-   * under `format.keys` (ADR-066). Absent when the key reconstructs the Figma name
-   * under `format.figmaKeys`.
+   * The Figma component-property name (ADR-066). Recorded when the name fell outside
+   * the safe key grammar, or when it was already written in the destination format and
+   * passed through unformatted — in which case reversal is identity, not re-derivation.
+   *
+   * Both triggers require `format.figmaKeys` to be other than NONE. Under NONE no
+   * source convention is declared, so divergence is not evaluated and this field is
+   * absent however the key was derived.
    * @since 0.30.0
    */
   name?: string;

--- a/packages/schema/types/Props.ts
+++ b/packages/schema/types/Props.ts
@@ -122,6 +122,8 @@ export interface NumberProp {
   nullable?: boolean;
   /** Sample numeric values demonstrating typical content for this prop */
   examples?: number[];
+  /** DTCG §5.2.3 platform-specific extensions. @since 0.30.0 */
+  $extensions?: PropExtensions;
 }
 
 /**

--- a/scripts/check-prerequisites.sh
+++ b/scripts/check-prerequisites.sh
@@ -74,12 +74,59 @@ EOF
     esac
 done
 
-# Source common functions
+# Resolve repo root and branch. These were previously sourced from common.sh, which
+# was removed with the rest of the spec-kit scaffolding; the helpers this script
+# actually used are inlined here so it has no external dependency.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/common.sh"
 
-# Get feature paths and validate branch
-eval $(get_feature_paths)
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    HAS_GIT="true"
+else
+    # Fall back to the script's parent directory (scripts/ lives at the repo root)
+    REPO_ROOT="$(CDPATH="" cd "$SCRIPT_DIR/.." && pwd)"
+    HAS_GIT="false"
+fi
+
+if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+    CURRENT_BRANCH="$SPECIFY_FEATURE"
+elif [[ "$HAS_GIT" == "true" ]]; then
+    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+else
+    CURRENT_BRANCH=""
+fi
+
+check_feature_branch() {
+    local branch="$1"
+    local has_git_repo="$2"
+
+    if [[ "$has_git_repo" != "true" ]]; then
+        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
+        return 0
+    fi
+
+    # Accept feature branches (###-name) or ADR branches under a release (X.Y.Z/###-name)
+    if [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]+\.[0-9]+\.[0-9]+/[0-9]{3}- ]]; then
+        echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
+        echo "Feature branches should be named like: 001-feature-name or 0.12.0/001-feature-name" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
+check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
+
+FEATURE_DIR="$REPO_ROOT/specs/$CURRENT_BRANCH"
+FEATURE_SPEC="$FEATURE_DIR/spec.md"
+IMPL_PLAN="$FEATURE_DIR/plan.md"
+TASKS="$FEATURE_DIR/tasks.md"
+RESEARCH="$FEATURE_DIR/research.md"
+DATA_MODEL="$FEATURE_DIR/data-model.md"
+QUICKSTART="$FEATURE_DIR/quickstart.md"
+CONTRACTS_DIR="$FEATURE_DIR/contracts"
+
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)

--- a/scripts/validate-schema.sh
+++ b/scripts/validate-schema.sh
@@ -7,7 +7,7 @@
 #
 # Usage: ./validate-schema.sh [--json] [--schema-dir <path>]
 #   --json          Output results in JSON format
-#   --schema-dir    Override the schema directory (default: <repo-root>/schema)
+#   --schema-dir    Override the schema directory (default: <repo-root>/packages/schema/schema)
 
 set -e
 
@@ -23,10 +23,16 @@ for arg in "$@"; do
   esac
 done
 
-# Locate repo root and schema dir
+# Locate repo root and schema dir. This script lives at <repo-root>/scripts/, so the
+# repo root is one level up — it previously assumed the old spec-kit location three
+# levels down, which resolved outside the repo entirely.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(CDPATH="" cd "$SCRIPT_DIR/../../.." && pwd)"
-SCHEMA_DIR="${SCHEMA_DIR:-$REPO_ROOT/schema}"
+if git -C "$SCRIPT_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+else
+  REPO_ROOT="$(CDPATH="" cd "$SCRIPT_DIR/.." && pwd)"
+fi
+SCHEMA_DIR="${SCHEMA_DIR:-$REPO_ROOT/packages/schema/schema}"
 
 if [ ! -d "$SCHEMA_DIR" ]; then
   echo "ERROR: Schema directory not found: $SCHEMA_DIR" >&2

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -125,6 +125,7 @@ export default defineConfig({
                 { label: 'props', slug: 'cli/analyze/props' },
                 { label: 'styling', slug: 'cli/analyze/styling' },
                 { label: 'dependencies', slug: 'cli/analyze/dependencies' },
+                { label: 'keys', slug: 'cli/analyze/keys' },
               ],
             },
           ],

--- a/site/src/content/docs/cli/analyze/index.md
+++ b/site/src/content/docs/cli/analyze/index.md
@@ -21,6 +21,7 @@ Analyzer names are passed as positional arguments. There is no config key — an
 specs analyze props
 specs analyze styling
 specs analyze dependencies
+specs analyze keys
 specs analyze props styling dependencies
 specs analyze props --analysis ./reports
 ```
@@ -41,6 +42,7 @@ specs analyze props --analysis ./reports
 | [`props`](/cli/analyze/props/) | `_analysis/props.yaml` | Cross-library prop inventory — frequency, enum discordance, API surface, slots |
 | [`styling`](/cli/analyze/styling/) | `_analysis/styling.byComponent.json`, `_analysis/styling.byToken.json`, `_analysis/styling.unused.json` | Token usage indexed by component and by token name, plus tokens no spec references |
 | [`dependencies`](/cli/analyze/dependencies/) | `_analysis/dependencies.graph.json`, `_analysis/dependencies.byComponent.json` | Component dependency graph — blast radius of a change, and which props consumers configure |
+| [`keys`](/cli/analyze/keys/) | `_analysis/keys.yaml` | Figma names a formatted key cannot reconstruct, as a per-component checklist. Requires `format.figmaKeys` |
 
 ## Output Directory
 
@@ -53,6 +55,7 @@ specs/
     styling.unused.json           # from specs analyze styling
     dependencies.graph.json       # from specs analyze dependencies
     dependencies.byComponent.json # from specs analyze dependencies
+    keys.yaml                     # from specs analyze keys
   ds-button/
     api.yaml
     contract.ts

--- a/site/src/content/docs/cli/analyze/keys.md
+++ b/site/src/content/docs/cli/analyze/keys.md
@@ -75,25 +75,23 @@ The checklist. Names are grouped under the component they belong to, because tha
 byComponent:
   dsAlert:
     divergent: 1
-    names:
+    props:
       - key: fullBleed
         figmaName: Full Bleed
-        surface: prop
         cause: casing
   dsAvatar:
     divergent: 2
-    names:
+    props:
       - key: a11yLabel
         figmaName: A11y label
-        surface: prop
         cause: mixed-letter-digit
+    anatomy:
       - key: startIcon
         figmaName: Start Icon
-        surface: anatomy
         cause: casing
 ```
 
-`surface` is `anatomy` or `prop` — the layer name or the component property name.
+Names appear under `props` (component property names) or `anatomy` (layer names). A surface with nothing to fix is omitted.
 
 ### byCause
 

--- a/site/src/content/docs/cli/analyze/keys.md
+++ b/site/src/content/docs/cli/analyze/keys.md
@@ -1,0 +1,154 @@
+---
+title: "keys"
+description: "List the Figma layer and property names a formatted key cannot reconstruct, organized as a per-component checklist"
+---
+
+<script>document.querySelector('#_top').insertAdjacentHTML('beforeend',' <span class="sl-badge experimental-badge">Experimental</span>')</script>
+
+Reads every component's `api.yaml` and produces `_analysis/keys.yaml`: every Figma layer and property name that falls outside the [safe key grammar](/guides/key-formatting/), grouped by component so it reads as a checklist, then by cause and by frequency.
+
+## Requires a declared convention
+
+This analyzer reports names the producer recorded in `$extensions['com.figma'].name`, which only happens when [`format.figmaKeys`](/settings/figma-keys/) declares a source convention:
+
+```yaml
+config:
+  format:
+    figmaKeys: SENTENCE
+```
+
+Under the default `NONE`, no convention is declared, no names are recorded, and this report is empty. That is correct rather than a failure — nothing has diverged from a convention you never stated.
+
+## Use When
+
+- You want a per-component list of Figma names to tidy, in the order a designer would work through them.
+- You want to find a badly-formed name that repeats across the library, where one rename fixes dozens of specs.
+- You want to see which kinds of naming problem dominate before deciding what to fix first.
+- You want to confirm a naming cleanup actually landed, by diffing the aggregate between runs.
+
+## Invocation
+
+```bash
+specs analyze keys
+```
+
+## Output
+
+Writes a single file to `_analysis/` after all components are processed.
+
+```
+specs/
+  _analysis/
+    keys.yaml   # cross-library aggregate
+  ds-button/
+    api.yaml
+  ds-alert/
+    api.yaml
+```
+
+## Sections
+
+### summary
+
+Counts for the library as a whole, and the distribution of causes.
+
+```yaml
+summary:
+  totalComponents: 69
+  componentsWithDivergence: 52
+  totalNames: 948
+  divergentNames: 75
+  causeDistribution:
+    mixed-letter-digit: 42
+    casing: 28
+    symbol: 2
+    separator: 1
+    digit-initial: 1
+    already-a-key: 1
+```
+
+### byComponent
+
+The checklist. Names are grouped under the component they belong to, because that is the unit a designer opens and edits.
+
+```yaml
+byComponent:
+  dsAlert:
+    divergent: 1
+    names:
+      - key: fullBleed
+        figmaName: Full Bleed
+        surface: prop
+        cause: casing
+  dsAvatar:
+    divergent: 2
+    names:
+      - key: a11yLabel
+        figmaName: A11y label
+        surface: prop
+        cause: mixed-letter-digit
+      - key: startIcon
+        figmaName: Start Icon
+        surface: anatomy
+        cause: casing
+```
+
+`surface` is `anatomy` or `prop` — the layer name or the component property name.
+
+### byCause
+
+The same names grouped by what is wrong with them, most common first. Useful for deciding what to fix in bulk: a library with 28 casing problems and 2 symbol problems has one systemic issue and two one-offs.
+
+```yaml
+byCause:
+  - cause: casing
+    occurrences: 28
+    names:
+      - Alternate Half
+      - Children minItems
+      - EGDS Bottom Sheet
+```
+
+### byName
+
+Each distinct Figma name with the components it appears in, most frequent first. This is the counterweight to the per-component checklist — a name wrong in forty components is one decision, not forty.
+
+```yaml
+byName:
+  - figmaName: A11y label
+    occurrences: 42
+    components:
+      - dsAvatar
+      - dsBadge
+      - dsButton
+    cause: mixed-letter-digit
+```
+
+## Causes
+
+| Cause | Meaning | Example |
+|-------|---------|---------|
+| `separator` | Leading, trailing, or repeated spaces | `Label   ` |
+| `symbol` | A character outside letters, digits, and single spaces | `Cut & paste` |
+| `non-ascii` | A non-ASCII character | `Étiquette` |
+| `mixed-letter-digit` | Letters and digits share a word, so the boundary is lost | `A11y label` |
+| `digit-initial` | The name begins with a digit | `0000 0000 0000 0000` |
+| `casing` | Characters are fine, but casing diverges from the declared convention | `Start Icon` under `SENTENCE` |
+| `already-a-key` | Not a defect — a name authored in a key convention rather than as a display name | `x-figmacollapse` |
+
+A name is reported under the most specific cause that applies, since that is the edit to make. `already-a-key` is listed last because it is a deliberate authoring choice, not a problem: such names are [retained as authored](/guides/key-formatting/#names-already-written-as-keys).
+
+## Fixing What It Finds
+
+Nothing here is a validation failure. Every name it lists is fully supported — its Figma name is recorded, so the spec round-trips correctly either way. The report exists so naming can be tidied at the source, which makes the extensions disappear and the specs smaller.
+
+Two things worth knowing before a cleanup:
+
+- Renaming a layer or property in Figma changes the spec key too, which is a breaking change for anything consuming that key.
+- The report cannot see names in a catalog that has never declared `figmaKeys`. Declare a convention first, generate, then analyze.
+
+## See Also
+
+- [Key Formatting guide](/guides/key-formatting/) — the safe key grammar and what happens to unsafe names
+- [Figma Keys](/settings/figma-keys/) — declaring the source convention this analyzer depends on
+- [Analyze overview](/cli/analyze/) — options shared by every analyzer

--- a/site/src/content/docs/guides/key-formatting.md
+++ b/site/src/content/docs/guides/key-formatting.md
@@ -151,11 +151,11 @@ Cut & paste         # the symbol and its word boundary are deleted
 
 A digit run always counts as its own word, in both directions. That is what lets `Badge count 2` become `badgeCount2` and come back intact — and why `Badge count2` cannot, since it formats to the same key but is not the same name.
 
-### Names already in your output convention
+### Names already written as keys
 
-Figma files are rarely uniform. If yours is mostly sentence case but a few properties were named `isDisabled` for the engineers consuming them, those names fail the grammar — yet they are already exactly what you want on both sides.
+Figma files are rarely uniform. If yours is mostly sentence case but a few properties were named `isDisabled` or `is-disabled` for the engineers consuming them, those names fail the grammar — yet they are already exactly what you want on both sides.
 
-Such names are passed through unformatted and recorded, so rendering the spec back into Figma restores `isDisabled` rather than rewriting it to `Is disabled`:
+A name that is already a well-formed key **in the convention you emit** is kept exactly as authored, and recorded. With `keys: CAMEL`, a layer named `isDisabled` stays `isDisabled`, and rendering the spec back into Figma restores it rather than rewriting it to `Is disabled`:
 
 ```yaml
 props:
@@ -165,6 +165,8 @@ props:
       com.figma:
         name: isDisabled
 ```
+
+Only the convention you emit is retained. A name in some *other* key convention is formatted like any divergent name — with `keys: KEBAB`, a layer named `isDisabled` or `IsDisabled` becomes `isdisabled` and carries its Figma name in the extension. Formatting splits on spaces, hyphens, and underscores rather than case, so it flattens such names rather than converting them; the extension is what keeps them recoverable.
 
 ### What happens to unsafe names
 

--- a/site/src/content/docs/guides/key-formatting.md
+++ b/site/src/content/docs/guides/key-formatting.md
@@ -114,16 +114,22 @@ model:
 
 | Value | Shape | Example |
 |-------|-------|---------|
-| `SENTENCE` (default) | First word capitalized, rest lowercase | `Icon leading` |
+| `NONE` (default) | No convention declared | — |
+| `SENTENCE` | First word capitalized, rest lowercase | `Icon leading` |
 | `TITLE` | Every word capitalized | `Icon Leading` |
 
+Everything in the rest of this guide is **opt-in**. Under the `NONE` default, names are formatted per `keys` and nothing else happens: no grammar check, no preserved names, no defined reversal. Declaring `SENTENCE` or `TITLE` turns all of it on, and your specs grow an extension block for each name that needs one. Declare a convention when you intend to render specs back into Figma, or when you want divergent names surfaced.
+
 ### The safe key grammar
+
+*Applies when `figmaKeys` is `SENTENCE` or `TITLE`.*
 
 A Figma name survives every `keys` format when it satisfies all of the following:
 
 - ASCII letters and digits only — no `&`, `+`, `/`, `.`, parentheses, punctuation, or accented characters
 - Exactly one space between words, with no leading, trailing, or repeated spaces
-- No word begins with a digit
+- Each word is either all letters or all digits — `Badge count 2` is fine, `Badge count2` is not
+- The name does not begin with a digit
 - Casing matches your declared `figmaKeys`
 
 ```yaml
@@ -132,13 +138,32 @@ A Figma name survives every `keys` format when it satisfies all of the following
 # Safe — reconstructs under every keys format
 Icon leading
 Label
-Badge count 2
+Badge count 2       # the digit is its own word, so the boundary survives
+Icon 2 leading
 
 # Unsafe — the Figma name is preserved separately
 Icon-leading        # separator is not a space
 URL field           # inner capitals are lost
-Icon 2 leading      # digit-leading word loses its boundary
+Badge count2        # letters and digits share a word
+2 icons             # begins with a digit
 Cut & paste         # the symbol and its word boundary are deleted
+```
+
+A digit run always counts as its own word, in both directions. That is what lets `Badge count 2` become `badgeCount2` and come back intact — and why `Badge count2` cannot, since it formats to the same key but is not the same name.
+
+### Names already in your output convention
+
+Figma files are rarely uniform. If yours is mostly sentence case but a few properties were named `isDisabled` for the engineers consuming them, those names fail the grammar — yet they are already exactly what you want on both sides.
+
+Such names are passed through unformatted and recorded, so rendering the spec back into Figma restores `isDisabled` rather than rewriting it to `Is disabled`:
+
+```yaml
+props:
+  isDisabled:
+    type: boolean
+    $extensions:
+      com.figma:
+        name: isDisabled
 ```
 
 ### What happens to unsafe names
@@ -159,6 +184,13 @@ anatomy:
 References elsewhere in the spec (`elements`, `propConfigurations`) keep pointing at the formatted key; the Figma name is resolved through the definition.
 
 Because well-formed names emit nothing, the presence of `com.figma.name` doubles as a signal that a Figma layer or property name is worth tidying.
+
+### What is not covered
+
+The Figma names of anatomy elements and props are preserved, including those nested inside compositions and slot content. Two things are not:
+
+- **Variant option values.** The values inside a variant prop's `options` are formatted like keys, but no Figma name is recorded for them.
+- **Titles.** Component and subcomponent titles are never formatted — they carry the Figma name verbatim already, so there is nothing to preserve.
 
 ## See Also
 

--- a/site/src/content/docs/guides/key-formatting.md
+++ b/site/src/content/docs/guides/key-formatting.md
@@ -89,12 +89,79 @@ model:
 
 **Choose one format and use it consistently.** Mixing formats across different spec runs creates the same inconsistency problem you're trying to solve. Set the format once in your config file and leave it.
 
-**`SAFE` is lossless; everything else is lossy.** The `SAFE` format preserves the original name exactly. All other formats discard information (casing, separators, spaces). If you need the original Figma name alongside a transformed key, `SAFE` is the only format that preserves it.
+**`SAFE` is lossless; everything else is lossy.** The `SAFE` format preserves the original name exactly. All other formats discard information (casing, separators, spaces). Names that would lose information are preserved separately — see [Round-Trip Safety](#round-trip-safety) below.
 
 **Match your consuming platform.** If your specs feed a React component library, use `CAMEL`. If they feed a Python SDK, use `SNAKE`. The format should eliminate transformation work for the most common consumer, not add it.
 
 **Special characters are handled gracefully.** Keys containing special characters (slashes, dots, brackets) are cleaned during transformation. The `SAFE` format preserves them as-is; other formats normalize them into the target convention.
 
+## Round-Trip Safety
+
+Formatting a key is one-way: `Icon leading`, `Icon-leading`, and `Icon_leading` all become `icon-leading` under `KEBAB`, and the formatted key alone cannot say which one it came from. That matters when a spec is rendered back into Figma, where layer and property names are the identity used to match existing nodes.
+
+Two settings make the round trip reliable.
+
+### The source convention
+
+`figmaKeys` declares the convention your Figma file already uses, so a formatted key has a defined name to reverse into:
+
+```yaml
+model:
+  format:
+    figmaKeys: SENTENCE   # what your Figma file uses
+    keys: KEBAB           # what the spec emits
+```
+
+| Value | Shape | Example |
+|-------|-------|---------|
+| `SENTENCE` (default) | First word capitalized, rest lowercase | `Icon leading` |
+| `TITLE` | Every word capitalized | `Icon Leading` |
+
+### The safe key grammar
+
+A Figma name survives every `keys` format when it satisfies all of the following:
+
+- ASCII letters and digits only — no `&`, `+`, `/`, `.`, parentheses, punctuation, or accented characters
+- Exactly one space between words, with no leading, trailing, or repeated spaces
+- No word begins with a digit
+- Casing matches your declared `figmaKeys`
+
+```yaml
+# figmaKeys: SENTENCE
+
+# Safe — reconstructs under every keys format
+Icon leading
+Label
+Badge count 2
+
+# Unsafe — the Figma name is preserved separately
+Icon-leading        # separator is not a space
+URL field           # inner capitals are lost
+Icon 2 leading      # digit-leading word loses its boundary
+Cut & paste         # the symbol and its word boundary are deleted
+```
+
+### What happens to unsafe names
+
+Unsafe names are fully supported — nothing is rejected. When a key cannot reconstruct its Figma name, that name is recorded on the definition:
+
+```yaml
+anatomy:
+  icon-leading:          # safe — nothing extra emitted
+    type: glyph
+  url-field:
+    type: text
+    $extensions:
+      com.figma:
+        name: URL field
+```
+
+References elsewhere in the spec (`elements`, `propConfigurations`) keep pointing at the formatted key; the Figma name is resolved through the definition.
+
+Because well-formed names emit nothing, the presence of `com.figma.name` doubles as a signal that a Figma layer or property name is worth tidying.
+
 ## See Also
 
+- [Keys](/settings/keys/) — the output convention setting
+- [Figma Keys](/settings/figma-keys/) — the source convention setting
 - [CLI Configuration](/settings/) — full config reference

--- a/site/src/content/docs/schema/anatomy.md
+++ b/site/src/content/docs/schema/anatomy.md
@@ -16,6 +16,15 @@ type Anatomy = Record<string, AnatomyElement>;
 | `type` | `ElementType \| ElementTypeRef` | Yes | What kind of element this is |
 | `detectedIn` | `string` | No | Frame or node name where this element was found |
 | `instanceOf` | `string \| SubcomponentRef` | No | Component name this element is an instance of, or a `$ref` to a subcomponent |
+| `$extensions` | `AnatomyElementExtensions` | No | Vendor extensions; `com.figma` carries extraction provenance |
+
+### AnatomyElementExtensions
+
+Only the `com.figma` extension is defined.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | The element's Figma layer name, present only when the anatomy key cannot reconstruct it — either after [wrapper collapse](/settings/collapse-primitive-wrapper/) or when the name falls outside the safe key grammar (see [Key Formatting](/guides/key-formatting/)) |
 
 ### ElementType
 

--- a/site/src/content/docs/schema/config.md
+++ b/site/src/content/docs/schema/config.md
@@ -11,7 +11,7 @@ Controls how specs are generated. See the [settings reference](/settings/) for d
 |----------|------|---------|-------------|
 | [`output`](/settings/output-format/) | `'JSON' \| 'YAML'` | `'JSON'` | Output file format |
 | [`keys`](/guides/key-formatting/) | `'SAFE' \| 'CAMEL' \| 'SNAKE' \| 'KEBAB' \| 'PASCAL' \| 'TRAIN'` | `'SAFE'` | Key casing style |
-| [`figmaKeys`](/settings/figma-keys/) | `'SENTENCE' \| 'TITLE'` | `'SENTENCE'` | Naming convention the Figma file uses — the reversal target for `keys` |
+| [`figmaKeys`](/settings/figma-keys/) | `'NONE' \| 'SENTENCE' \| 'TITLE'` | `'NONE'` | Naming convention the Figma file uses — the reversal target for `keys`. `NONE` declares none, making key preservation opt-in |
 | [`layout`](/guides/data-layout/) | `'LAYOUT' \| 'PARENT_CHILDREN' \| 'BOTH'` | `'LAYOUT'` | Element hierarchy representation |
 | [`tokens`](/settings/tokens/) | `'TOKEN' \| 'TOKEN_NAME' \| 'TOKEN_FIGMA_EXTENSIONS' \| 'FIGMA_NAME' \| 'CUSTOM' \| 'FIGMA_SYNTAX_WEB' \| 'FIGMA_SYNTAX_IOS' \| 'FIGMA_SYNTAX_ANDROID'` | `'TOKEN'` | Token reference output format — `FIGMA_SYNTAX_*` emit per-platform Figma code syntax, falling back to `TOKEN` |
 | [`color`](/settings/color/) | `ColorFormat` | `'HEX'` | Color value output format — `HEX`, `HEXA`, `RGB`, `RGBA`, `HSLA`, `HSB`, `OKLCH`, `OKLAB`, or `OBJECT` |
@@ -100,7 +100,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
   format: {
     output: 'JSON',
     keys: 'SAFE',
-    figmaKeys: 'SENTENCE',
+    figmaKeys: 'NONE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
     color: 'HEX',

--- a/site/src/content/docs/schema/config.md
+++ b/site/src/content/docs/schema/config.md
@@ -11,6 +11,7 @@ Controls how specs are generated. See the [settings reference](/settings/) for d
 |----------|------|---------|-------------|
 | [`output`](/settings/output-format/) | `'JSON' \| 'YAML'` | `'JSON'` | Output file format |
 | [`keys`](/guides/key-formatting/) | `'SAFE' \| 'CAMEL' \| 'SNAKE' \| 'KEBAB' \| 'PASCAL' \| 'TRAIN'` | `'SAFE'` | Key casing style |
+| [`figmaKeys`](/settings/figma-keys/) | `'SENTENCE' \| 'TITLE'` | `'SENTENCE'` | Naming convention the Figma file uses — the reversal target for `keys` |
 | [`layout`](/guides/data-layout/) | `'LAYOUT' \| 'PARENT_CHILDREN' \| 'BOTH'` | `'LAYOUT'` | Element hierarchy representation |
 | [`tokens`](/settings/tokens/) | `'TOKEN' \| 'TOKEN_NAME' \| 'TOKEN_FIGMA_EXTENSIONS' \| 'FIGMA_NAME' \| 'CUSTOM' \| 'FIGMA_SYNTAX_WEB' \| 'FIGMA_SYNTAX_IOS' \| 'FIGMA_SYNTAX_ANDROID'` | `'TOKEN'` | Token reference output format — `FIGMA_SYNTAX_*` emit per-platform Figma code syntax, falling back to `TOKEN` |
 | [`color`](/settings/color/) | `ColorFormat` | `'HEX'` | Color value output format — `HEX`, `HEXA`, `RGB`, `RGBA`, `HSLA`, `HSB`, `OKLCH`, `OKLAB`, or `OBJECT` |
@@ -99,6 +100,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
   format: {
     output: 'JSON',
     keys: 'SAFE',
+    figmaKeys: 'SENTENCE',
     layout: 'LAYOUT',
     tokens: 'TOKEN',
     color: 'HEX',

--- a/site/src/content/docs/schema/props.md
+++ b/site/src/content/docs/schema/props.md
@@ -115,6 +115,7 @@ The `$extensions` object holds vendor-specific metadata. Currently only the `com
 |----------|------|-------------|
 | `type` | `string` | Figma property type (e.g. `BOOLEAN`, `TEXT`, `INSTANCE_SWAP`, `VARIANT`) |
 | `source` | `FigmaCodeOnlySource` | Present when the prop originates from a code-only prop layer |
+| `name` | `string` | The Figma property name, present only when the prop key cannot reconstruct it — see [Key Formatting](/guides/key-formatting/) |
 
 ### FigmaCodeOnlySource
 
@@ -131,3 +132,4 @@ The `$extensions` object holds vendor-specific metadata. Currently only the `com
 - [ADR 056 — Rename SlotProp.minItems/maxItems → minChildren/maxChildren](https://github.com/DirectedEdges/specs/blob/main/adr/056-slot-children-constraints.md) — aligns field names with Figma native `slotSettings`; adds native `preferredValues` resolution
 - [ADR 029 — NumberProp](https://github.com/DirectedEdges/specs/blob/main/adr/029-number-prop.md) — adds the `NumberProp` type with opt-in inference
 - [ADR 063 — Image Content](https://github.com/DirectedEdges/specs/blob/main/adr/063-image-content.md) — adds the `ImageProp` type and image fills/registry
+- [ADR 066 — Lossless Key Formatting](https://github.com/DirectedEdges/specs/blob/main/adr/066-lossless-key-formatting.md) — adds `name` to `FigmaPropExtension` so lossy key formats stay reversible

--- a/site/src/content/docs/settings/collapse-primitive-wrapper.md
+++ b/site/src/content/docs/settings/collapse-primitive-wrapper.md
@@ -33,10 +33,10 @@ anatomy:
   root:
     type: text
     $extensions:
-      com.figma.originalName: Label
+      com.figma.name: Label
 ```
 
-The `$extensions.com.figma.originalName` field on the anatomy root carries the original Figma layer name so the source layer remains traceable.
+The `$extensions.com.figma.name` field on the anatomy root carries the Figma layer name so the source layer remains traceable.
 
 ## Eligibility
 

--- a/site/src/content/docs/settings/figma-keys.md
+++ b/site/src/content/docs/settings/figma-keys.md
@@ -9,12 +9,13 @@ Where [`keys`](/settings/keys/) controls what the spec *emits*, `figmaKeys` desc
 
 ## Options
 
-- **Default**: `SENTENCE`
+- **Default**: `NONE`
 - **Values**:
+  - `NONE` - No convention declared. Names are not checked, and nothing is preserved
   - `SENTENCE` - First word capitalized, rest lowercase (`Icon leading`)
   - `TITLE` - Every word capitalized (`Icon Leading`)
 
-Only the two conventions observed in real Figma files are accepted. This is deliberately narrower than `keys`.
+Only the two conventions observed in real Figma files are accepted as declarations. This is deliberately narrower than `keys`.
 
 ## Path
 
@@ -29,11 +30,25 @@ config:
     keys: CAMEL        # spec emits camelCase
 ```
 
-## Why it matters
+## Opting in
+
+`NONE` is the default, and it means your specs behave exactly as they always have: names are formatted per [`keys`](/settings/keys/), nothing is checked, and no Figma names are preserved.
+
+Declaring `SENTENCE` or `TITLE` turns on three things at once:
+
+- Every layer and property name is checked against the safe key grammar.
+- Any name that cannot survive formatting has its Figma name recorded in `$extensions.com.figma.name`.
+- Rendering a spec back into Figma has a defined name to reverse into.
+
+This is a trade, not a free upgrade. You gain round-trip fidelity and pay for it in spec size — every name outside the grammar grows an extension block. On a file with inconsistent layer naming, that can be a lot of new output. Declare a convention when you intend to render specs back into Figma, or when you want the divergences surfaced.
+
+## Why the declaration matters
 
 Declaring the convention your file actually uses keeps specs quiet. A file authored in Title Case but read as sentence case treats every name as divergent, so each anatomy element and prop carries a preserved copy of its Figma name — noise that buries the names genuinely worth fixing.
 
 Names that fall outside the declared convention, or outside the safe character set, are still fully supported. Their Figma name is recorded in `$extensions.com.figma.name` on the definition.
+
+Names already written in your output convention are handled too. If your file is mostly sentence case but a few properties are named `isDisabled` for the engineers reading them, those are passed through untouched rather than rewritten to `Is disabled` when the spec is rendered back.
 
 ## See Also
 

--- a/site/src/content/docs/settings/figma-keys.md
+++ b/site/src/content/docs/settings/figma-keys.md
@@ -1,0 +1,41 @@
+---
+title: "Figma Keys"
+description: "Declare the naming convention your Figma file uses, so formatted keys stay reversible"
+---
+
+The naming convention your Figma file uses for layer names and component property names.
+
+Where [`keys`](/settings/keys/) controls what the spec *emits*, `figmaKeys` describes what the Figma file *contains*. Declaring it gives every formatted key a defined name to reverse back into when a spec is rendered into Figma.
+
+## Options
+
+- **Default**: `SENTENCE`
+- **Values**:
+  - `SENTENCE` - First word capitalized, rest lowercase (`Icon leading`)
+  - `TITLE` - Every word capitalized (`Icon Leading`)
+
+Only the two conventions observed in real Figma files are accepted. This is deliberately narrower than `keys`.
+
+## Path
+
+`config.format.figmaKeys`
+
+### Example
+
+```yaml
+config:
+  format:
+    figmaKeys: TITLE   # Figma layer names are Title Case
+    keys: CAMEL        # spec emits camelCase
+```
+
+## Why it matters
+
+Declaring the convention your file actually uses keeps specs quiet. A file authored in Title Case but read as sentence case treats every name as divergent, so each anatomy element and prop carries a preserved copy of its Figma name — noise that buries the names genuinely worth fixing.
+
+Names that fall outside the declared convention, or outside the safe character set, are still fully supported. Their Figma name is recorded in `$extensions.com.figma.name` on the definition.
+
+## See Also
+
+- [Keys](/settings/keys/) - the output naming convention
+- [Key Formatting guide](/guides/key-formatting/) - the safe key grammar and round-trip behavior

--- a/site/src/content/docs/settings/figma-keys.md
+++ b/site/src/content/docs/settings/figma-keys.md
@@ -48,7 +48,7 @@ Declaring the convention your file actually uses keeps specs quiet. A file autho
 
 Names that fall outside the declared convention, or outside the safe character set, are still fully supported. Their Figma name is recorded in `$extensions.com.figma.name` on the definition.
 
-Names already written in your output convention are handled too. If your file is mostly sentence case but a few properties are named `isDisabled` for the engineers reading them, those are passed through untouched rather than rewritten to `Is disabled` when the spec is rendered back.
+Names already written as keys are handled too. If your file is mostly sentence case but a few properties are named `isDisabled` for the engineers reading them, those are kept exactly as authored — provided they match the convention you emit — and never rewritten to `Is disabled` when the spec is rendered back.
 
 ## See Also
 

--- a/site/src/content/docs/settings/index.mdx
+++ b/site/src/content/docs/settings/index.mdx
@@ -25,6 +25,7 @@ The **Format** section controls how spec data is serialized once it's extracted:
 
 - [Output Format](/settings/output-format/) — Serializes specs as `YAML` or `JSON`
 - [Keys](/settings/keys/) — Renames keys, such as `camelCase` or `snake_case`
+- [Figma Keys](/settings/figma-keys/) — Declares the convention your Figma file uses, keeping renamed keys reversible
 - [Tokens](/settings/tokens/) — Serializes as forms such as a name string or `{ $token, $type }` object
 - [Color](/settings/color/) — Formats color, such as `#FF6600` or `{ colorSpace, components }`
 
@@ -153,6 +154,7 @@ config:
   format:
     output: YAML
     keys: SAFE
+    figmaKeys: SENTENCE
     layout: LAYOUT
     tokens: TOKEN
 

--- a/site/src/content/docs/settings/index.mdx
+++ b/site/src/content/docs/settings/index.mdx
@@ -154,7 +154,7 @@ config:
   format:
     output: YAML
     keys: SAFE
-    figmaKeys: SENTENCE
+    figmaKeys: SENTENCE   # opts in to key preservation; defaults to NONE
     layout: LAYOUT
     tokens: TOKEN
 

--- a/site/src/content/docs/settings/keys.md
+++ b/site/src/content/docs/settings/keys.md
@@ -41,6 +41,9 @@ config:
     keys: CAMEL  # Transform keys to camelCase
 ```
 
+Every value other than `SAFE` is a lossy projection of the Figma name. Names that cannot be reconstructed from the formatted key are preserved in `$extensions.com.figma.name` on the definition, so the spec stays reversible into Figma.
+
 ## See Also
 
+- [Figma Keys](/settings/figma-keys/) - The convention your Figma file uses, and the target keys reverse into
 - [Key Formatting guide](/guides/key-formatting/) - Detailed formatting behavior and edge cases


### PR DESCRIPTION
Implements ADR-066. Makes `format.keys` reversible, so a spec produced with a lossy key format can still be rendered back into Figma.

## Problem

Every `format.keys` value other than `SAFE` is a one-way projection. `Icon leading`, `Icon-leading`, and `Icon_leading` all become `icon-leading` under `KEBAB`, and the formatted key alone cannot say which one it came from. Symbols fare worse — `Cut & paste` becomes `cutPaste`, with nothing recording that a `&` was ever there. Since Figma layer and property names are the identity used to match existing nodes, the render direction had no reliable way back.

## What changed

**A declared source convention.** `format.figmaKeys` (`SENTENCE` | `TITLE`, default `SENTENCE`) states what the Figma file's names look like. `keys` describes output, `figmaKeys` describes source, and reversal is defined as re-formatting the key into `figmaKeys`. The enum is deliberately narrow — only the two conventions observed in real files.

**A stated safe key grammar.** `SafeKeySentence` and `SafeKeyTitle` schema definitions carry the patterns for names that survive every `keys` value:

- ASCII letters and digits only
- exactly one space between words
- no digit-leading words
- casing matching the declared `figmaKeys`

`&`, `+`, and `/` are deliberately excluded — preserving them would emit `cut&Paste` as a key, defeating the purpose of `CAMEL`/`PASCAL` as identifier producers, and transliterating them (`&` → `and`) is not reversible.

**A home for divergent names.** Names outside the grammar are recorded on the definition, never rejected:

```yaml
anatomy:
  icon-leading:          # safe — nothing extra emitted
    type: glyph
  url-field:
    type: text
    $extensions:
      com.figma:
        name: URL field
```

Reference sites (`elements`, `propConfigurations`) are unchanged — they keep pointing at formatted keys and resolve the Figma name through the definition. Well-formed catalogs emit no extensions at all, so the field doubles as a signal that a name is worth tidying.

## Breaking change

`FigmaAnatomyElementExtension.originalName` → `name` (shipped in 0.28.0 by ADR-058). Once the field generalizes beyond wrapper collapse, `original` is accurate for only one of its two triggers — and `$extensions['com.figma']` already carries the qualifier, so `name` says exactly what it is.

**The one hazard:** `figma-from-specs/src/Elements/Elements.ts:131` reads this extension through an inline structural type rather than the published type, so the rename will *not* fail compilation there — it will silently read `undefined` and fall back to `'Icon'`/`'Text'` for collapsed roots. That call site needs an explicit update.

## Version

No `package.json` bump — this lands in the in-flight `0.30.0`, which is what the release branch targets. MAJOR-class per the constitution, absorbed into a pre-1.0 minor as `0.29.0` did for `textAlignHorizontal`.

## Verification

- `tsc -p tsconfig.build.json --noEmit` — clean
- all 14 `tests/*.test-d.ts` compile under `--strict`, including a `@ts-expect-error` asserting `originalName` is gone
- `validate-schema.sh` — 5/5 schemas valid

## Docs

New `settings/figma-keys.md`; a "Round-Trip Safety" section in the key-formatting guide; `schema/anatomy.md` gained the `$extensions` row and extension table it previously lacked; `Props` in `component.schema.json` had an empty `description`, now filled. Historical `originalName` mentions in `overview/releases.mdx` are left alone — they describe what 0.28.0 actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfAEBwDThqo1KpCL8GaruH
