### PR TITLE
feat(site): publish accepted ADRs as a generated docs section

### DIFF
--- a/.github/agents/Specs.adr.implement.agent.md
+++ b/.github/agents/Specs.adr.implement.agent.md
@@ -62,9 +62,20 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Create or update `tests/[type-name].test-d.ts` for each changed type using `tsd`-style assertions or `@ts-expect-error` patterns
    - Run: `tsc --noEmit --strict tests/*.test-d.ts` to confirm test files compile
    - If tests fail: halt and report
-   - **All gates have now passed. Steps 10–12 are REQUIRED before reporting completion. Do not skip to step 13.**
+   - **All gates have now passed. Steps 10–13 are REQUIRED before reporting completion. Do not skip to step 14.**
 
-10. **Update docs**:
+10. **Write the ADR summary**: Add or update the `**Summary**:` line in the ADR's metadata block, directly beneath `**Status**`. Write it now rather than at draft time — it must describe what was actually implemented, which often differs from the original draft.
+    - **One sentence, present tense, roughly 15–18 words.** The new property, type, or config option is the grammatical subject.
+    - Anchor the addition to the neighbouring fields it joins, not to the gap it filled.
+    - Never open with "The schema", and never include a past-tense problem clause ("could not", "was dropped", "had nowhere to land").
+    - Keep identifiers in backticks.
+    - Examples of the target voice:
+      - A `strokeDashPattern` property adds dashes to strokes already supported with color, weight and alignment.
+      - A `glyph` element type, `IconProp` and `glyphNamePattern` emit icons as first-class by applying Figma conventions.
+      - Images are supported by `backgroundImage` style, `ImageProp` and binding in components and examples.
+    - **Gate**: read the ADR back and confirm the `**Summary**:` line is present and no longer a placeholder. The docs site publishes this line verbatim with no fallback — a missing summary leaves a blank row in the published index.
+
+11. **Update docs**:
     - Docs live in `site/src/content/docs/`. Schema type pages are under `site/src/content/docs/schema/` (e.g., `schema/styles.md` for `Styles`, `schema/config.md` for `Config`). Individual config option pages are under `site/src/content/docs/config/` (e.g., `config/tokens.md`, `config/keys.md`).
     - For each property added, removed, or renamed in the ADR: update the relevant doc page's Properties table, Values table, and "Relating properties to values" section to reflect the new state.
     - For new dedicated types (e.g., `LayoutMode`, `WrapAlignment`, `ItemSpacing`): add a row to the Values table describing the type and its valid values.
@@ -72,7 +83,7 @@ You **MUST** consider the user input before proceeding (if not empty).
     - Do not create new doc pages for types that are only used as field values on an existing documented type — document them inline in the parent type's page.
     - If no doc file exists for the changed type, skip this step.
 
-11. **Update CHANGELOG.md**:
+12. **Update CHANGELOG.md**:
     - The release branch scaffolds an `## [X.Y.Z] - Unreleased` heading with empty sections. Add entries into the existing scaffold — do **not** replace `Unreleased` with a date (the date is set at release time). If no scaffold heading exists, prepend one using `Unreleased` as the date.
     - **Format**: one top-level bullet per user-visible change; no sub-bullets; no bold; no code blocks; no wrapping prose paragraphs
     - **Entry line**: `` `Parent.field` `` — one-phrase description; aim for ≤ 12 words; omit implementation detail (class names, file paths, method names)
@@ -80,12 +91,12 @@ You **MUST** consider the user input before proceeding (if not empty).
     - **Consolidation**: When a new type exists only to serve a property, merge into one property-first bullet — e.g. `` `Styles.mainAxisAlignment` — typed as `MainAxisAlignment` (`'START' | 'END' | 'CENTER' | 'SPACE_BETWEEN'`) or `null`; description ``. Do not list the type as a separate bullet.
     - **Sections**: use `### Added`, `### Changed`, `### Removed` as needed; add `### Migration` (MAJOR or rename only)
     - **Migration line**: `` `Parent.old` → `Parent.new` ``: one sentence; imperative; describe what to read instead and how to handle the new type
-    - **Gate**: After writing, verify the new entry is present in the file. If CHANGELOG.md does not contain the new version heading, halt and report — do not proceed to step 12.
+    - **Gate**: After writing, verify the new entry is present in the file. If CHANGELOG.md does not contain the new version heading, halt and report — do not proceed to step 13.
 
-12. **Bump version in `package.json`**: Apply the `NEW` version from the ADR's Semver Decision.
-    - **Gate**: After writing, read `package.json` back and confirm the `"version"` field matches the ADR's `NEW` version. If it does not match, halt and report — do not proceed to step 13.
+13. **Bump version in `package.json`**: Apply the `NEW` version from the ADR's Semver Decision.
+    - **Gate**: After writing, read `package.json` back and confirm the `"version"` field matches the ADR's `NEW` version. If it does not match, halt and report — do not proceed to step 14.
 
-13. **Report**: List every file modified (with one-line description each). The list **must** include `CHANGELOG.md` and `package.json` — if either is absent from the list, halt: steps 11–12 were not completed. State that the author should review the diff and accept the ADR once satisfied. Remind the author that this ADR branch (`$BRANCH`) targets the release branch (`$RELEASE_BRANCH`), not `main`.
+14. **Report**: List every file modified (with one-line description each). The list **must** include the ADR file, `CHANGELOG.md`, and `package.json` — if any is absent from the list, halt: steps 10, 12, or 13 were not completed. State that the author should review the diff and accept the ADR once satisfied. Remind the author that this ADR branch (`$BRANCH`) targets the release branch (`$RELEASE_BRANCH`), not `main`.
 
 ## Key rules
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/tmp/
 
 # Generated at build time from package CHANGELOGs
 site/src/content/docs/overview/releases.mdx
+site/src/content/docs/adr/

--- a/adr/001-metadata.license.md
+++ b/adr/001-metadata.license.md
@@ -3,6 +3,7 @@
 **Branch**: `001-license-check`
 **Created**: 2026-02-24
 **Status**: ACCEPTED
+**Summary**: A `license` field inside `metadata.generator` records the license state that produced a component's output.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/002-effects-shadows-blurs.md
+++ b/adr/002-effects-shadows-blurs.md
@@ -3,6 +3,7 @@
 **Branch**: `v0.11.0`
 **Created**: 2026-02-24
 **Status**: ACCEPTED
+**Summary**: An `effects` property with `Shadow`, `Blur` and `Effects` types replaces `effectStyleId` to describe shadows and blurs.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/003-gradients.md
+++ b/adr/003-gradients.md
@@ -3,6 +3,7 @@
 **Branch**: `003-gradients`
 **Created**: 2026-02-25
 **Status**: ACCEPTED
+**Summary**: Gradient types and a `ColorStyle` alias let `backgroundColor`, `textColor` and `strokes` carry linear, radial and angular gradients.
 **Deciders**: Nathan Curtis
 **Supersedes**: *(none)*
 

--- a/adr/004-aspect-ratio.md
+++ b/adr/004-aspect-ratio.md
@@ -3,6 +3,7 @@
 **Branch**: `004-aspect-ratio`
 **Created**: 2026-02-25
 **Status**: ACCEPTED
+**Summary**: An `aspectRatio` property carries an `x`/`y` ratio object on styles alongside width and height.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/005-typography-composite.md
+++ b/adr/005-typography-composite.md
@@ -3,6 +3,7 @@
 **Branch**: `005-typography-composite`
 **Created**: 2026-02-26
 **Status**: ACCEPTED
+**Summary**: A composite `typography` property replaces fourteen flat text keys including `fontSize`, `lineHeight`, `letterSpacing` and `textStyleId`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/006-token-references.md
+++ b/adr/006-token-references.md
@@ -3,6 +3,7 @@
 **Branch**: `v0.11.0/006-token-references`
 **Created**: 2026-02-28
 **Status**: ACCEPTED
+**Summary**: A single `TokenReference` type replaces `VariableStyle` and `FigmaStyle` for variables, named styles and composite references.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/007-token-reference-config.md
+++ b/adr/007-token-reference-config.md
@@ -3,6 +3,7 @@
 **Branch**: `007-token-reference-config`
 **Created**: 2026-03-01
 **Status**: ACCEPTED
+**Summary**: A `format.tokens` option replaces `variables`, `simplifyVariables` and `simplifyStyles` with one token output format.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — extends ADR 006: Unified Token Reference Type)*
 

--- a/adr/008-prop-bindings.md
+++ b/adr/008-prop-bindings.md
@@ -3,6 +3,7 @@
 **Branch**: `v0.11.0`
 **Created**: 2026-03-02
 **Status**: ACCEPTED
+**Summary**: A `PropBinding` type keyed `$binding` replaces `ReferenceValue` unions wherever a value is bound to a prop.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/009-color-values.md
+++ b/adr/009-color-values.md
@@ -2,6 +2,7 @@
 
 **Created**: 2026-03-02
 **Status**: ACCEPTED
+**Summary**: A DTCG `ColorValue` object replaces the hex string in `ColorStyle`, aligning color values with token standards.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/010-sides-and-corners.md
+++ b/adr/010-sides-and-corners.md
@@ -3,6 +3,7 @@
 **Branch**: `010-sides-and-corners`
 **Created**: 2026-03-05
 **Status**: ACCEPTED
+**Summary**: Composite `Sides` and `Corners` types replace flat padding, stroke weight and corner radius properties.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/011-icon-glyph-as-content.md
+++ b/adr/011-icon-glyph-as-content.md
@@ -3,6 +3,7 @@
 **Branch**: `011-icon-glyph-as-content`
 **Created**: 2026-03-05
 **Status**: ACCEPTED
+**Summary**: An `ElementType` union and `iconNamePattern` option constrain element types and detect icons by Figma naming.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/012-element-type-references.md
+++ b/adr/012-element-type-references.md
@@ -3,6 +3,7 @@
 **Branch**: `012-element-type-references`
 **Created**: 2026-03-05
 **Status**: ACCEPTED
+**Summary**: An `ElementTypeRef` widens `AnatomyElement.type`, letting an element type point at a shared definition.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/013-icon-fillColor.md
+++ b/adr/013-icon-fillColor.md
@@ -3,6 +3,7 @@
 **Branch**: `013-icon-fillColor`
 **Created**: 2026-03-09
 **Status**: ACCEPTED
+**Summary**: A `fillColor` property colors icon elements alongside `backgroundColor`, `textColor` and `strokes`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/014-prop-examples.md
+++ b/adr/014-prop-examples.md
@@ -3,6 +3,7 @@
 **Branch**: `014-prop-examples`
 **Created**: 2026-03-09
 **Status**: ACCEPTED
+**Summary**: An `examples` array on `TextProp` and `IconProp` carries sample values, and `default` becomes optional.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/015-anyprop-oneOf-discrimination.md
+++ b/adr/015-anyprop-oneOf-discrimination.md
@@ -3,6 +3,7 @@
 **Branch**: `015-anyprop-oneOf-discrimination`
 **Created**: 2026-03-09
 **Status**: ACCEPTED
+**Summary**: A single `StringProp` merges `TextProp` and `IconProp`, restoring valid `oneOf` discrimination in `AnyProp`.
 **Deciders**: Nathan Curtis (author), *(collaborators TBD)*
 **Supersedes**: ADR 017 (`017-icon-or-glyph-element-name`) — prop rename portion only. ADR 017 renamed `IconProp` → `GlyphProp`; this ADR merges both `TextProp` and `IconProp` into `StringProp`, making the intermediate `GlyphProp` rename moot. The element type rename (`icon` → `glyph`) and other non-prop changes from ADR 017 remain in effect.
 

--- a/adr/016-element-content.md
+++ b/adr/016-element-content.md
@@ -3,6 +3,7 @@
 **Branch**: `016-element-content`
 **Created**: 2026-03-10
 **Status**: ACCEPTED
+**Summary**: A `content` property replaces `text`, identifying literal or bound content on any element type.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/017-icon-or-glyph-element-name.md
+++ b/adr/017-icon-or-glyph-element-name.md
@@ -3,6 +3,7 @@
 **Branch**: `017-icon-or-glyph-element-name`
 **Created**: 2026-03-10
 **Status**: ACCEPTED
+**Summary**: A `glyph` element type, `GlyphProp` and `glyphNamePattern` emit icons as first-class by applying Figma conventions.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/018-conditional-visible-binding.md
+++ b/adr/018-conditional-visible-binding.md
@@ -3,6 +3,7 @@
 **Branch**: `018-conditional-visible-binding`
 **Created**: 2026-03-10
 **Status**: ACCEPTED
+**Summary**: A `Conditional` type with condition expressions lets `visible` test a prop value rather than mirror it.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/019-nullable-prop-defaults.md
+++ b/adr/019-nullable-prop-defaults.md
@@ -3,6 +3,7 @@
 **Branch**: `019-nullable-prop-defaults`
 **Created**: 2026-03-11
 **Status**: ACCEPTED
+**Summary**: `StringProp.default` accepts `null`, expressing props whose absent value is meaningful.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/022-nullable-slot-props.md
+++ b/adr/022-nullable-slot-props.md
@@ -3,6 +3,7 @@
 **Branch**: `022-nullable-slot-props`
 **Created**: 2026-03-12
 **Status**: ACCEPTED
+**Summary**: `SlotProp` gains `nullable` and a nullable `default`, matching the other prop types.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — extends ADR 019 to cover `SlotProp`)*
 

--- a/adr/023-schema-compliance-fixes.md
+++ b/adr/023-schema-compliance-fixes.md
@@ -3,6 +3,7 @@
 **Branch**: `023-schema-compliance-fixes`
 **Created**: 2026-03-13
 **Status**: ACCEPTED
+**Summary**: `SlotProp.default` becomes optional and pattern properties admit `$`-prefixed keys, bringing types and schema back into compliance.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — extends ADR 022 for `SlotProp.default` optionality)*
 

--- a/adr/026-platform-extensions.md
+++ b/adr/026-platform-extensions.md
@@ -3,6 +3,7 @@
 **Branch**: `026-platform-extensions`
 **Created**: 2026-03-16
 **Status**: ACCEPTED
+**Summary**: An `$extensions` object on every prop type unifies platform-specific metadata, replacing the Figma-only `x-platform` field.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/027-code-only-props.md
+++ b/adr/027-code-only-props.md
@@ -3,6 +3,7 @@
 **Branch**: `027-code-only-props`
 **Created**: 2026-03-16
 **Status**: ACCEPTED
+**Summary**: A `codeOnlyPropsPattern` option and `FigmaCodeOnlySource` extension emit props that exist in code but not Figma.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 **Depends on**: [026-platform-extensions](./026-platform-extensions.md) (`$extensions` pattern)

--- a/adr/028-slot-constraints.md
+++ b/adr/028-slot-constraints.md
@@ -3,6 +3,7 @@
 **Branch**: `028-slot-constraints`
 **Created**: 2026-03-16
 **Status**: ACCEPTED
+**Summary**: `minItems`, `maxItems` and `anyOf` on `SlotProp`, with a `slotConstraints` option, describe what a slot accepts.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/029-number-prop.md
+++ b/adr/029-number-prop.md
@@ -3,6 +3,7 @@
 **Branch**: `029-number-prop`
 **Created**: 2026-03-17
 **Status**: ACCEPTED
+**Summary**: A `NumberProp` type and `inferNumberProps` option carry numeric properties alongside boolean, string, enum and slot props.
 **Deciders**: (author)
 **Supersedes**: *(none)*
 

--- a/adr/030-subcomponent-refs.md
+++ b/adr/030-subcomponent-refs.md
@@ -3,6 +3,7 @@
 **Branch**: `030-subcomponent-refs`
 **Created**: 2026-03-23
 **Status**: ACCEPTED
+**Summary**: A `SubcomponentRef` lets `instanceOf` point at a subcomponent definition rather than repeat its name.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/031-subcomponent-search-scope.md
+++ b/adr/031-subcomponent-search-scope.md
@@ -3,6 +3,7 @@
 **Branch**: `031-subcomponent-search-scope`
 **Created**: 2026-03-24
 **Status**: ACCEPTED
+**Summary**: A `processing.subcomponents` object with `scope`, `match` and `exclude` replaces `subcomponentNamePattern` for finding subcomponents.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/032-typography-leading-trim-enum.md
+++ b/adr/032-typography-leading-trim-enum.md
@@ -3,6 +3,7 @@
 **Branch**: `032-leading-trim-enum`
 **Created**: 2026-03-25
 **Status**: ACCEPTED
+**Summary**: `Typography.leadingTrim` is a string enum, matching the values Figma actually reports.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/033-typography-font-token-reference.md
+++ b/adr/033-typography-font-token-reference.md
@@ -3,6 +3,7 @@
 **Branch**: `033-font-token-reference`
 **Created**: 2026-03-25
 **Status**: ACCEPTED
+**Summary**: `Typography.fontFamily` and `fontStyle` accept a `TokenReference` and drop `number`, matching how fonts are tokenized.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/034-empty-variants.md
+++ b/adr/034-empty-variants.md
@@ -3,6 +3,7 @@
 **Branch**: `034-empty-variants`
 **Created**: 2026-03-30
 **Status**: ACCEPTED
+**Summary**: An `emptyVariants` include option replaces `variantNames`, and the remaining `Config.include` fields become optional.
 **Deciders**: nathanacurtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/035-optional-config-defaults.md
+++ b/adr/035-optional-config-defaults.md
@@ -3,6 +3,7 @@
 **Branch**: `035-optional-config-defaults`
 **Created**: 2026-04-10
 **Status**: ACCEPTED
+**Summary**: Every `Config` property carrying a default becomes optional, so a config states only what it changes.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/036-remove-variant-name-baseline.md
+++ b/adr/036-remove-variant-name-baseline.md
@@ -3,6 +3,7 @@
 **Branch**: `036-remove-variant-name-baseline`
 **Created**: 2026-04-13
 **Status**: ACCEPTED
+**Summary**: `Variant.name` and `Variant.baseline` are removed, leaving a variant identified by its prop configuration alone.
 **Deciders**: nathanacurtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/037-item-spacing.md
+++ b/adr/037-item-spacing.md
@@ -3,6 +3,7 @@
 **Branch**: `037-item-spacing`
 **Created**: 2026-04-20
 **Status**: ACCEPTED
+**Summary**: An `ItemSpacing` type gives `itemSpacing` a bi-axial shape, replacing the separate `counterAxisSpacing` property.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/038-layout-mode-enum.md
+++ b/adr/038-layout-mode-enum.md
@@ -3,6 +3,7 @@
 **Branch**: `038-layout-mode-enum`
 **Created**: 2026-04-20
 **Status**: ACCEPTED
+**Summary**: A `LayoutMode` enum types `layoutMode` as `NONE`, `HORIZONTAL` or `VERTICAL` rather than an open string.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/039-wrap-alignment.md
+++ b/adr/039-wrap-alignment.md
@@ -3,6 +3,7 @@
 **Branch**: `039-wrap-alignment`
 **Created**: 2026-04-20
 **Status**: ACCEPTED
+**Summary**: `wrap` and `wrapAlignment` with a `WrapAlignment` enum replace `layoutWrap` and `counterAxisAlignContent`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/040-layout-alignment.md
+++ b/adr/040-layout-alignment.md
@@ -3,6 +3,7 @@
 **Branch**: `040-layout-alignment`
 **Created**: 2026-04-23
 **Status**: ACCEPTED
+**Summary**: `mainAxisAlignment` and `crossAxisAlignment` with named enums replace `primaryAxisAlignItems` and `counterAxisAlignItems`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/041-layout-positioning.md
+++ b/adr/041-layout-positioning.md
@@ -3,6 +3,7 @@
 **Branch**: `041-layout-positioning`
 **Created**: 2026-04-27
 **Status**: ACCEPTED
+**Summary**: `Position` and `PositionOffset` types describe constraint-based placement, replacing `x`, `y` and `layoutPositioning`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/042-composition-type.md
+++ b/adr/042-composition-type.md
@@ -3,6 +3,7 @@
 **Branch**: `042-composition-type`
 **Created**: 2026-04-29
 **Status**: ACCEPTED
+**Summary**: A `Composition` type names composed content, carrying `anatomy`, `elements` and `layout` with optional title and description.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: [ADR 025 — Flowing Content into a Nested Instance's Slot](025-nested-slot-api) *(partially — retains its `Composition` shape; defers its `PropConfigurations` widening to ADR-049)*
 **Extended by**: ADR-046 (Slots and Slot References), ADR-047 (Component Slot Examples), ADR-048 (Component Instance Examples), ADR-049 (Prop Configurations and Bindings)

--- a/adr/043-custom-color-format-config.md
+++ b/adr/043-custom-color-format-config.md
@@ -3,6 +3,7 @@
 **Branch**: `043-custom-color-format-config`
 **Created**: 2026-05-01
 **Status**: ACCEPTED
+**Summary**: A `format.color` option with a `ColorFormat` type emits color as hex, RGB, HSL, OKLCH or object.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/046-slots-and-slot-references.md
+++ b/adr/046-slots-and-slot-references.md
@@ -3,6 +3,7 @@
 **Branch**: `046-slots-and-slot-references`
 **Created**: 2026-05-18
 **Status**: ACCEPTED
+**Summary**: A `SlotContent` triplet and `SlotContentRef` pointer let compositions fill slots by reference.
 **Deciders**: Nathan Curtis (author)
 **Depends on**: [ADR-042 — Composition Structural Type](042-composition-type)
 **Extended by**: ADR-047 (Component Slot Examples), ADR-049 (Prop Configurations and Bindings)

--- a/adr/047-component-slot-examples.md
+++ b/adr/047-component-slot-examples.md
@@ -3,6 +3,7 @@
 **Branch**: `047-component-slot-examples`
 **Created**: 2026-04-29
 **Status**: ACCEPTED
+**Summary**: A `slotContentExamples` registry and `SlotBinding` carry example slot fills, referenced rather than duplicated across variants.
 **Deciders**: Nathan Curtis (author)
 **Depends on**: [ADR-042 — Composition Structural Type](042-composition-type), [ADR-046 — Slots and Slot References](046-slots-and-slot-references)
 **Extended by**: ADR-048 (Component Instance Examples), ADR-049 (Prop Configurations and Bindings)

--- a/adr/048-component-instance-examples.md
+++ b/adr/048-component-instance-examples.md
@@ -3,6 +3,7 @@
 **Branch**: `048-component-instance-examples`
 **Created**: 2026-04-29
 **Status**: ACCEPTED
+**Summary**: An `instanceExamples` registry carries real instances of a component, stored once and referenced by variants.
 **Deciders**: Nathan Curtis (author)
 **Depends on**: [ADR-042 — Composition Structural Type](042-composition-type), [ADR-046 — Slots and Slot References](046-slots-and-slot-references), [ADR-047 — Component Slot Examples](047-component-slot-examples)
 **Extended by**: ADR-049 (Prop Configurations and Bindings)

--- a/adr/049-prop-configurations-bindings.md
+++ b/adr/049-prop-configurations-bindings.md
@@ -3,6 +3,7 @@
 **Branch**: `049-prop-configurations-bindings`
 **Created**: 2026-04-29
 **Status**: ACCEPTED
+**Summary**: `PropConfigurations` values accept `PropBinding` and `SlotContentRef`, so a configuration can forward a prop or fill a slot.
 **Deciders**: Nathan Curtis (author)
 **Depends on**: [ADR-008 — Introduce PropBinding](008-prop-binding), [ADR-042 — Composition Structural Type](042-composition-type), [ADR-046 — Slots and Slot References](046-slots-and-slot-references), [ADR-047 — Component Slot Examples](047-component-slot-examples), [ADR-048 — Component Instance Examples](048-component-instance-examples)
 

--- a/adr/050-examples-config.md
+++ b/adr/050-examples-config.md
@@ -3,6 +3,7 @@
 **Branch**: `042-composition-type`
 **Created**: 2026-05-19
 **Status**: ACCEPTED
+**Summary**: A `processing.instanceExamples` block and `include.defaultSlotContent` govern which examples a spec carries.
 **Deciders**: Nathan Curtis (author)
 **Depends on**: [ADR-047 — Component Slot Examples](047-component-slot-examples), [ADR-048 — Component Instance Examples](048-component-instance-examples)
 

--- a/adr/051-platform-token-syntax.md
+++ b/adr/051-platform-token-syntax.md
@@ -3,6 +3,7 @@
 **Branch**: `051-platform-token-syntax`
 **Created**: 2026-05-20
 **Status**: ACCEPTED
+**Summary**: Three `FIGMA_SYNTAX_WEB`, `FIGMA_SYNTAX_IOS` and `FIGMA_SYNTAX_ANDROID` token profiles emit platform code syntax alongside the default `TOKEN`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/052-slotting-nested-instances.md
+++ b/adr/052-slotting-nested-instances.md
@@ -3,6 +3,7 @@
 **Branch**: `examples-slots-instances`
 **Created**: 2026-05-22
 **Status**: ACCEPTED — supersedes the deferred `Element.overrides` design (retained below as Option C, *rejected*)
+**Summary**: A reserved `$nested` key in `PropConfigurations` carries path-addressed configurations that reach into nested instances.
 **Deciders**: Nathan Curtis (author)
 **Depends on**: [ADR-046 — Slots & Slot References](046-slots-and-slot-references), [ADR-047 — Component Slot Examples](047-component-slot-examples), [ADR-048 — Component Instance Examples](048-component-instance-examples), [ADR-049 — PropConfigurations Bindings](049-prop-configurations-bindings), [ADR-050 — Examples Config](050-examples-config)
 

--- a/adr/053-transform-emit-config.md
+++ b/adr/053-transform-emit-config.md
@@ -3,6 +3,7 @@
 **Branch**: `053-transform-emit-config`
 **Created**: 2026-06-05
 **Status**: ACCEPTED
+**Summary**: A `transform` config block with `TransformEntry` drives the `specs transform` command's code artifact output.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 **RFC**: [RFC 001: Component Dictionary](../rfc/001-component-dictionary/README.md)

--- a/adr/054-workspace-schema.md
+++ b/adr/054-workspace-schema.md
@@ -3,6 +3,7 @@
 **Branch**: `053-transform-emit-config`
 **Created**: 2026-06-05
 **Status**: ACCEPTED
+**Summary**: A `workspace.schema.json` file describes `specs.config.yaml`, covering sources, output and the `config` block.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 **Follows**: [ADR 053](053-transform-emit-config.md)

--- a/adr/055-processing-states.md
+++ b/adr/055-processing-states.md
@@ -3,6 +3,7 @@
 **Branch**: `055-processing-states`
 **Created**: 2026-06-05
 **Status**: ACCEPTED
+**Summary**: A `processing.states` list of `VariantStateEntry` classifies variant props as browser-driven or consumer-controlled.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/056-slot-children-constraints.md
+++ b/adr/056-slot-children-constraints.md
@@ -3,6 +3,7 @@
 **Branch**: `adr/056-slot-children-constraints`
 **Created**: 2026-06-12
 **Status**: ACCEPTED
+**Summary**: `SlotProp.minChildren` and `maxChildren` replace `minItems` and `maxItems`, aligning with Figma's slot settings.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/057-generator-version-string.md
+++ b/adr/057-generator-version-string.md
@@ -3,6 +3,7 @@
 **Branch**: `057-generator-version-string`
 **Created**: 2026-06-15
 **Status**: ACCEPTED
+**Summary**: `Metadata.generator.version` is typed `string`, matching the semver values every producer already emits.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/058-wrapper-collapse.md
+++ b/adr/058-wrapper-collapse.md
@@ -3,6 +3,7 @@
 **Branch**: `058-wrapper-collapse`
 **Created**: 2026-06-16
 **Status**: ACCEPTED
+**Summary**: A `collapsePrimitiveWrapper` processing option strips plain wrappers, promoting a single text or glyph child to the spec root.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/059-border-style.md
+++ b/adr/059-border-style.md
@@ -3,6 +3,7 @@
 **Branch**: `059-border-style`
 **Created**: 2026-06-26
 **Status**: ACCEPTED
+**Summary**: A `strokeDashPattern` property adds dashes to strokes already supported with color, weight and alignment.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/060-subcomponent-source-metadata.md
+++ b/adr/060-subcomponent-source-metadata.md
@@ -3,6 +3,7 @@
 **Branch**: `060-subcomponent-source-metadata`
 **Created**: 2026-06-27
 **Status**: ACCEPTED
+**Summary**: A `Subcomponent.source` carrying `pageId`, `nodeId` and `nodeType` resolves a subcomponent back to its Figma node.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/062-text-truncation.md
+++ b/adr/062-text-truncation.md
@@ -3,6 +3,7 @@
 **Branch**: `062-text-truncation`
 **Created**: 2026-07-09
 **Status**: ACCEPTED
+**Summary**: `textOverflow` and `maxLines` properties add truncation to styles already covering typography and layout.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/063-image-content.md
+++ b/adr/063-image-content.md
@@ -3,6 +3,7 @@
 **Branch**: `063-image-content`
 **Created**: 2026-07-14
 **Status**: ACCEPTED
+**Summary**: Images are supported by `backgroundImage` style, `ImageProp` and binding in components and examples.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/064-text-align-horizontal.md
+++ b/adr/064-text-align-horizontal.md
@@ -3,6 +3,7 @@
 **Branch**: `064-text-align-horizontal`
 **Created**: 2026-08-03
 **Status**: ACCEPTED
+**Summary**: A `TextAlignHorizontal` enum types `textAlignHorizontal` as `START`, `CENTER`, `END` or `JUSTIFY`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/065-code-only-text-prop-nullable.md
+++ b/adr/065-code-only-text-prop-nullable.md
@@ -3,6 +3,7 @@
 **Branch**: `065-code-only-text-prop-nullable`
 **Created**: 2026-08-05
 **Status**: ACCEPTED
+**Summary**: `NumberProp` gains `nullable`, and JSDoc documents the default each prop type applies when `nullable` is absent.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — extends ADR-019 and ADR-022)*
 

--- a/adr/066-lossless-key-formatting.md
+++ b/adr/066-lossless-key-formatting.md
@@ -3,6 +3,7 @@
 **Branch**: `066-lossless-key-formatting`
 **Created**: 2026-08-10
 **Status**: ACCEPTED
+**Summary**: A `format.figmaKeys` option and safe key grammar preserve Figma layer names losslessly through `com.figma.name`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — extends ADR-058)*
 

--- a/adr/adr-template.md
+++ b/adr/adr-template.md
@@ -3,6 +3,7 @@
 **Branch**: `[###-short-name]`
 **Created**: [DATE]
 **Status**: DRAFT
+**Summary**: *(written at implementation — see `/specs.adr.implement`)*
 **Deciders**: [Author] (author), [name], [name]
 **Supersedes**: *(none, or link to prior ADR)*
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -239,6 +239,11 @@ export default defineConfig({
             { label: 'Variant Layering', slug: 'guides/variant-layering' },
           ],
         },
+        {
+          label: 'Decision Records',
+          collapsed: true,
+          autogenerate: { directory: 'adr' },
+        },
         { label: 'License (Legal)', slug: 'overview/license' },
         { label: 'Terms of Service', slug: 'overview/terms-of-service' },
       ],

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
         Sidebar: './src/components/Sidebar.astro',
         Hero: './src/components/Hero.astro',
         Header: './src/components/Header.astro',
+        PageTitle: './src/components/PageTitle.astro',
         Footer: './src/components/Footer.astro',
       },
       customCss: ['./src/custom.css'],

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
         { label: 'About Specs', slug: 'overview/aboutspecs' },
         { label: 'Getting Started', slug: 'cli/getting-started' },
         { label: 'Releases', slug: 'overview/releases' },
+        { label: 'Decision Records (ADRs)', slug: 'adr' },
         { label: 'Licensing', slug: 'overview/licensing', badge: pro },
         {
           label: 'Specs 2 Figma Plugin',
@@ -238,11 +239,6 @@ export default defineConfig({
             { label: 'Variant Depth', slug: 'guides/variant-depth' },
             { label: 'Variant Layering', slug: 'guides/variant-layering' },
           ],
-        },
-        {
-          label: 'Decision Records',
-          collapsed: true,
-          autogenerate: { directory: 'adr' },
         },
         { label: 'License (Legal)', slug: 'overview/license' },
         { label: 'Terms of Service', slug: 'overview/terms-of-service' },

--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "prebuild": "node scripts/build-releases.mjs",
-    "predev": "node scripts/build-releases.mjs",
+    "prebuild": "node scripts/build-releases.mjs && node scripts/build-adrs.mjs",
+    "predev": "node scripts/build-releases.mjs && node scripts/build-adrs.mjs",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/site/scripts/build-adrs.mjs
+++ b/site/scripts/build-adrs.mjs
@@ -34,8 +34,29 @@ function extractStatus(md) {
   return m ? m[1].replace(/[^A-Z]/gi, '').toUpperCase() : null;
 }
 
-function truncate(text) {
-  return text.length > 300 ? `${text.slice(0, 297)}…` : text;
+/** Clip to a word boundary so summaries stay scannable in the index. */
+function truncate(text, limit = 160) {
+  if (text.length <= limit) return text;
+  const clipped = text.slice(0, limit);
+  const lastSpace = clipped.lastIndexOf(' ');
+  return `${clipped.slice(0, lastSpace > 0 ? lastSpace : limit).replace(/[.,;:—-]$/, '')}…`;
+}
+
+/** Escape text destined for raw HTML in the generated index. */
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Markdown inside a raw HTML block is passed through untouched, so titles
+ * carrying `code spans` need them rendered here.
+ */
+function escapeTitle(title) {
+  return escapeHtml(title).replace(/`([^`]+)`/g, '<code>$1</code>');
 }
 
 /**
@@ -114,9 +135,6 @@ for (const adr of adrs) {
     '---',
     `title: ${yaml(adr.title)}`,
     adr.summary ? `description: ${yaml(adr.summary)}` : null,
-    'sidebar:',
-    `  label: ${yaml(`${adr.number} — ${adr.title}`)}`,
-    `  order: ${Number(adr.number)}`,
     '---',
   ]
     .filter(Boolean)
@@ -127,23 +145,32 @@ for (const adr of adrs) {
 
 const rows = [...adrs]
   .reverse()
-  .map(a => `| [${a.number}](/adr/${a.slug}/) | [${a.title}](/adr/${a.slug}/) | ${(a.summary ?? '').replace(/\|/g, '\\|')} |`)
+  .map(a => {
+    const summary = a.summary
+      ? `\n<p class="adr-summary">${escapeHtml(a.summary)}</p>`
+      : '';
+    return `<tr>
+<td class="adr-number">${a.number}</td>
+<td class="adr-entry"><a href="/adr/${a.slug}/">${escapeTitle(a.title)}</a>${summary}</td>
+</tr>`;
+  })
   .join('\n');
 
 const index = `---
-title: "Architecture Decision Records"
-description: "Accepted decisions shaping the Specs schema, CLI, and plugin."
+title: "Decision Records (ADRs)"
+description: "Accepted architecture decisions shaping the Specs schema, CLI, and plugin."
 tableOfContents: false
-sidebar:
-  label: "Overview"
-  order: 0
 ---
 
-Each record captures one decision about the Specs schema and tooling — the context that forced it, the options weighed, and what was chosen. Only accepted decisions are published here; the newest appear first.
+Specs is defined by its schema — the shape of the component data that the Figma plugin and the CLI both produce. Every field in that schema exists because of a decision: what a design system needs to express, how Figma exposes it, and which of several possible designs best survives contact with real component libraries. An **Architecture Decision Record** captures one such decision in full. It states the problem, lays out the options considered, records which one was chosen, and explains the reasoning — including the designs that were rejected and why.
 
-| # | Title | Summary |
-|---|-------|---------|
+These records are the reasoning behind the reference documentation. Where the [Schema](/schema/) and [Settings](/settings/) sections tell you what a field is and how to use it, an ADR tells you why it looks the way it does. Read them when you want the history behind a design, when a field's shape seems surprising, or when you are weighing a change and want to know what ground has already been covered. Only accepted decisions appear here, newest first; each one remains as written when it was accepted, so later records may supersede earlier ones.
+
+<table class="adr-index">
+<tbody>
 ${rows}
+</tbody>
+</table>
 `;
 
 writeFileSync(resolve(outDir, 'index.md'), index);

--- a/site/scripts/build-adrs.mjs
+++ b/site/scripts/build-adrs.mjs
@@ -48,7 +48,10 @@ function escapeHtml(text) {
  * carrying `code spans` needs them rendered here.
  */
 function renderInline(text) {
-  return escapeHtml(text).replace(/`([^`]+)`/g, '<code>$1</code>');
+  return escapeHtml(text)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>');
 }
 
 /**
@@ -66,6 +69,24 @@ function extractSummary(md) {
 /** Drop the H1 — Starlight renders the title from frontmatter. */
 function stripTitle(md) {
   return md.replace(/^#\s+.+$/m, '').replace(/^\n+/, '');
+}
+
+/**
+ * The `**Key**: value` lines opening every ADR are consecutive, so markdown
+ * joins them into one run-on paragraph. Render them as a label/value grid
+ * instead, and drop the horizontal rule that followed the block.
+ */
+function formatMetadata(md) {
+  return md.replace(
+    /^((?:\*\*[A-Za-z]+\*\*:.*\n)+)(\n---\n)?/,
+    (match, block) => {
+      const rows = [...block.matchAll(/^\*\*([A-Za-z]+)\*\*:\s*(.*)$/gm)].map(
+        ([, key, value]) =>
+          `<div class="adr-meta-row"><dt>${key}</dt><dd>${renderInline(value.trim())}</dd></div>`,
+      );
+      return rows.length ? `<dl class="adr-meta">\n${rows.join('\n')}\n</dl>\n` : match;
+    },
+  );
 }
 
 const files = readdirSync(srcDir)
@@ -87,7 +108,7 @@ for (const file of files) {
   }
   const summary = extractSummary(md);
   if (!summary) console.warn(`⚠ ${file}: no **Summary** in the metadata block`);
-  adrs.push({ number, slug, title, summary, body: stripTitle(md) });
+  adrs.push({ number, slug, title, summary, body: formatMetadata(stripTitle(md)) });
 }
 
 rmSync(outDir, { recursive: true, force: true });

--- a/site/scripts/build-adrs.mjs
+++ b/site/scripts/build-adrs.mjs
@@ -162,9 +162,9 @@ description: "Accepted architecture decisions shaping the Specs schema, CLI, and
 tableOfContents: false
 ---
 
-Specs is defined by its schema — the shape of the component data that the Figma plugin and the CLI both produce. Every field in that schema exists because of a decision: what a design system needs to express, how Figma exposes it, and which of several possible designs best survives contact with real component libraries. An **Architecture Decision Record** captures one such decision in full. It states the problem, lays out the options considered, records which one was chosen, and explains the reasoning — including the designs that were rejected and why.
+Every field in the Specs schema exists because of a decision about what a design system needs to express and how Figma exposes it. An **Architecture Decision Record** captures one such decision: the problem, the options weighed, the choice made, and the designs rejected along the way.
 
-These records are the reasoning behind the reference documentation. Where the [Schema](/schema/) and [Settings](/settings/) sections tell you what a field is and how to use it, an ADR tells you why it looks the way it does. Read them when you want the history behind a design, when a field's shape seems surprising, or when you are weighing a change and want to know what ground has already been covered. Only accepted decisions appear here, newest first; each one remains as written when it was accepted, so later records may supersede earlier ones.
+Where [Schema](/schema/) and [Settings](/settings/) tell you what a field is, an ADR tells you why it looks that way — read one when a field's shape surprises you, or when you're weighing a change. Only accepted decisions appear here, newest first, each left as written, so later records may supersede earlier ones.
 
 <table class="adr-index">
 <tbody>

--- a/site/scripts/build-adrs.mjs
+++ b/site/scripts/build-adrs.mjs
@@ -34,14 +34,6 @@ function extractStatus(md) {
   return m ? m[1].replace(/[^A-Z]/gi, '').toUpperCase() : null;
 }
 
-/** Clip to a word boundary so summaries stay scannable in the index. */
-function truncate(text, limit = 160) {
-  if (text.length <= limit) return text;
-  const clipped = text.slice(0, limit);
-  const lastSpace = clipped.lastIndexOf(' ');
-  return `${clipped.slice(0, lastSpace > 0 ? lastSpace : limit).replace(/[.,;:—-]$/, '')}…`;
-}
-
 /** Escape text destined for raw HTML in the generated index. */
 function escapeHtml(text) {
   return text
@@ -52,54 +44,23 @@ function escapeHtml(text) {
 }
 
 /**
- * Markdown inside a raw HTML block is passed through untouched, so titles
- * carrying `code spans` need them rendered here.
+ * Markdown inside a raw HTML block is passed through untouched, so text
+ * carrying `code spans` needs them rendered here.
  */
-function escapeTitle(title) {
-  return escapeHtml(title).replace(/`([^`]+)`/g, '<code>$1</code>');
+function renderInline(text) {
+  return escapeHtml(text).replace(/`([^`]+)`/g, '<code>$1</code>');
 }
 
 /**
- * First sentence of the Context section, flattened to plain text, for use as
- * the page description and the index summary.
+ * The `**Summary**:` line from the metadata block, authored at implementation
+ * time. There is deliberately no fallback — an unwritten summary shows up as a
+ * blank index row rather than as plausible-looking prose lifted from Context.
  */
 function extractSummary(md) {
-  const after = md.split(/^##\s+Context\s*$/m)[1];
-  if (!after) return null;
-  const section = after.split(/^##\s+/m)[0];
-
-  // Fenced blocks and tables read as prose once flattened — drop them first.
-  const prose = section
-    .replace(/^```[\s\S]*?^```/gm, '')
-    .replace(/^\|.*$/gm, '');
-
-  let leadIn = null;
-
-  for (const raw of prose.split('\n\n')) {
-    const para = raw.trim();
-    if (!para || para.startsWith('#') || para.startsWith('-') || para.startsWith('>')) continue;
-
-    const flat = para
-      .replace(/\s+/g, ' ')
-      .replace(/`([^`]*)`/g, '$1')
-      .replace(/\*\*([^*]*)\*\*/g, '$1')
-      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-      .trim();
-
-    // A paragraph ending in a colon introduces a list or block — its sentence
-    // is only half the thought, so keep looking.
-    if (flat.endsWith(':')) {
-      leadIn ??= flat;
-      continue;
-    }
-
-    const sentence = flat.match(/^.*?\.(?=\s|$)/)?.[0];
-    if (!sentence || sentence.length < 30) continue;
-    return truncate(sentence);
-  }
-
-  // Some Contexts are only a lead-in followed by a list or code block.
-  return leadIn ? truncate(leadIn.replace(/:$/, '.')) : null;
+  const m = md.match(/^\*\*Summary\*\*:\s*(.+)$/m);
+  if (!m) return null;
+  const text = m[1].trim();
+  return /^\*\(.*\)\*$/.test(text) ? null : text;
 }
 
 /** Drop the H1 — Starlight renders the title from frontmatter. */
@@ -124,7 +85,9 @@ for (const file of files) {
     console.warn(`⚠ ${file}: no H1 title, skipped`);
     continue;
   }
-  adrs.push({ number, slug, title, summary: extractSummary(md), body: stripTitle(md) });
+  const summary = extractSummary(md);
+  if (!summary) console.warn(`⚠ ${file}: no **Summary** in the metadata block`);
+  adrs.push({ number, slug, title, summary, body: stripTitle(md) });
 }
 
 rmSync(outDir, { recursive: true, force: true });
@@ -134,7 +97,7 @@ for (const adr of adrs) {
   const frontmatter = [
     '---',
     `title: ${yaml(adr.title)}`,
-    adr.summary ? `description: ${yaml(adr.summary)}` : null,
+    adr.summary ? `description: ${yaml(adr.summary.replace(/`/g, ''))}` : null,
     '---',
   ]
     .filter(Boolean)
@@ -147,11 +110,11 @@ const rows = [...adrs]
   .reverse()
   .map(a => {
     const summary = a.summary
-      ? `\n<p class="adr-summary">${escapeHtml(a.summary)}</p>`
+      ? `\n<p class="adr-summary">${renderInline(a.summary)}</p>`
       : '';
     return `<tr>
 <td class="adr-number">${a.number}</td>
-<td class="adr-entry"><a href="/adr/${a.slug}/">${escapeTitle(a.title)}</a>${summary}</td>
+<td class="adr-entry"><a href="/adr/${a.slug}/">${renderInline(a.title)}</a>${summary}</td>
 </tr>`;
   })
   .join('\n');

--- a/site/scripts/build-adrs.mjs
+++ b/site/scripts/build-adrs.mjs
@@ -50,9 +50,20 @@ function escapeHtml(text) {
 function renderInline(text) {
   return escapeHtml(text)
     .replace(/`([^`]+)`/g, '<code>$1</code>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, label, href) => {
+      // Cross-references are bare ADR slugs. Link only to records that are
+      // actually published — drafts would 404.
+      const slug = href.replace(/^\.?\/?/, '').replace(/\.md$/, '');
+      if (/^\d{3}-/.test(slug)) {
+        return published.has(slug) ? `<a href="/adr/${slug}/">${label}</a>` : label;
+      }
+      return `<a href="${href}">${label}</a>`;
+    })
     .replace(/\*([^*]+)\*/g, '<em>$1</em>');
 }
+
+/** Slugs of the records this build publishes, for cross-reference linking. */
+const published = new Set();
 
 /**
  * The `**Summary**:` line from the metadata block, authored at implementation
@@ -75,41 +86,69 @@ function stripTitle(md) {
  * The `**Key**: value` lines opening every ADR are consecutive, so markdown
  * joins them into one run-on paragraph. Render them as a label/value grid
  * instead, and drop the horizontal rule that followed the block.
+ *
+ * `Branch` is dropped — it names a merged branch that no longer exists.
+ * `Created` folds into the Status row, and `Supersedes` appears only when it
+ * actually points at a prior record.
  */
 function formatMetadata(md) {
-  return md.replace(
-    /^((?:\*\*[A-Za-z]+\*\*:.*\n)+)(\n---\n)?/,
-    (match, block) => {
-      const rows = [...block.matchAll(/^\*\*([A-Za-z]+)\*\*:\s*(.*)$/gm)].map(
-        ([, key, value]) =>
-          `<div class="adr-meta-row"><dt>${key}</dt><dd>${renderInline(value.trim())}</dd></div>`,
+  return md.replace(/^((?:\*\*[A-Za-z]+\*\*:.*\n)+)(\n---\n)?/, (match, block) => {
+    const fields = Object.fromEntries(
+      [...block.matchAll(/^\*\*([A-Za-z]+)\*\*:\s*(.*)$/gm)].map(([, key, value]) => [
+        key,
+        value.trim(),
+      ]),
+    );
+
+    const status = [fields.Status, fields.Created].filter(Boolean).join(' · ');
+    // Many records use Supersedes for an "(none — extends ADR-0xx)" aside;
+    // only a value that actually names a superseded record earns a row.
+    const raw = fields.Supersedes ?? '';
+    const supersedes = /^\*?\(?\s*none\b/i.test(raw.trim()) || !raw.trim() ? null : raw;
+
+    const rows = [
+      ['Summary', fields.Summary],
+      ['Status', status],
+      ['Deciders', fields.Deciders],
+      ['Supersedes', supersedes],
+    ]
+      .filter(([, value]) => value)
+      .map(
+        ([label, value]) =>
+          `<div class="adr-meta-row"><dt>${label}</dt><dd>${renderInline(value)}</dd></div>`,
       );
-      return rows.length ? `<dl class="adr-meta">\n${rows.join('\n')}\n</dl>\n` : match;
-    },
-  );
+
+    return rows.length ? `<dl class="adr-meta">\n${rows.join('\n')}\n</dl>\n` : match;
+  });
 }
 
 const files = readdirSync(srcDir)
   .filter(f => /^\d{3}-.+\.md$/.test(f))
   .sort();
 
-const adrs = [];
+const accepted = [];
 
 for (const file of files) {
   const md = readFileSync(resolve(srcDir, file), 'utf-8');
   if (extractStatus(md) !== 'ACCEPTED') continue;
 
-  const number = file.slice(0, 3);
-  const slug = file.replace(/\.md$/, '');
   const title = extractTitle(md);
   if (!title) {
     console.warn(`⚠ ${file}: no H1 title, skipped`);
     continue;
   }
+  const slug = file.replace(/\.md$/, '');
+  published.add(slug);
+  accepted.push({ file, md, slug, title, number: file.slice(0, 3) });
+}
+
+// Bodies are rendered in a second pass so cross-references can be resolved
+// against the full set of published records.
+const adrs = accepted.map(({ file, md, slug, title, number }) => {
   const summary = extractSummary(md);
   if (!summary) console.warn(`⚠ ${file}: no **Summary** in the metadata block`);
-  adrs.push({ number, slug, title, summary, body: formatMetadata(stripTitle(md)) });
-}
+  return { number, slug, title, summary, body: formatMetadata(stripTitle(md)) };
+});
 
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });

--- a/site/scripts/build-adrs.mjs
+++ b/site/scripts/build-adrs.mjs
@@ -1,0 +1,150 @@
+/**
+ * Reads ACCEPTED ADRs from adr/ and emits one Starlight page each into
+ * site/src/content/docs/adr/, plus an index page.  Run before `astro dev`
+ * or `astro build`.
+ *
+ * Usage:  node scripts/build-adrs.mjs
+ */
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const repo = resolve(root, '..');
+
+const srcDir = resolve(repo, 'adr');
+const outDir = resolve(root, 'src/content/docs/adr');
+
+/** Quote a string for a YAML double-quoted scalar. */
+function yaml(text) {
+  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/** `# ADR: Foo Bar` or `# ADR 058: Foo Bar` → `Foo Bar` */
+function extractTitle(md) {
+  const m = md.match(/^#\s+(?:ADR[\s-]*\d*\s*:\s*)?(.+)$/m);
+  return m ? m[1].trim() : null;
+}
+
+/** `**Status**: ACCEPTED — because` → `ACCEPTED` */
+function extractStatus(md) {
+  const m = md.match(/^\*\*Status\*\*:\s*(\S+)/m);
+  return m ? m[1].replace(/[^A-Z]/gi, '').toUpperCase() : null;
+}
+
+function truncate(text) {
+  return text.length > 300 ? `${text.slice(0, 297)}…` : text;
+}
+
+/**
+ * First sentence of the Context section, flattened to plain text, for use as
+ * the page description and the index summary.
+ */
+function extractSummary(md) {
+  const after = md.split(/^##\s+Context\s*$/m)[1];
+  if (!after) return null;
+  const section = after.split(/^##\s+/m)[0];
+
+  // Fenced blocks and tables read as prose once flattened — drop them first.
+  const prose = section
+    .replace(/^```[\s\S]*?^```/gm, '')
+    .replace(/^\|.*$/gm, '');
+
+  let leadIn = null;
+
+  for (const raw of prose.split('\n\n')) {
+    const para = raw.trim();
+    if (!para || para.startsWith('#') || para.startsWith('-') || para.startsWith('>')) continue;
+
+    const flat = para
+      .replace(/\s+/g, ' ')
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/\*\*([^*]*)\*\*/g, '$1')
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .trim();
+
+    // A paragraph ending in a colon introduces a list or block — its sentence
+    // is only half the thought, so keep looking.
+    if (flat.endsWith(':')) {
+      leadIn ??= flat;
+      continue;
+    }
+
+    const sentence = flat.match(/^.*?\.(?=\s|$)/)?.[0];
+    if (!sentence || sentence.length < 30) continue;
+    return truncate(sentence);
+  }
+
+  // Some Contexts are only a lead-in followed by a list or code block.
+  return leadIn ? truncate(leadIn.replace(/:$/, '.')) : null;
+}
+
+/** Drop the H1 — Starlight renders the title from frontmatter. */
+function stripTitle(md) {
+  return md.replace(/^#\s+.+$/m, '').replace(/^\n+/, '');
+}
+
+const files = readdirSync(srcDir)
+  .filter(f => /^\d{3}-.+\.md$/.test(f))
+  .sort();
+
+const adrs = [];
+
+for (const file of files) {
+  const md = readFileSync(resolve(srcDir, file), 'utf-8');
+  if (extractStatus(md) !== 'ACCEPTED') continue;
+
+  const number = file.slice(0, 3);
+  const slug = file.replace(/\.md$/, '');
+  const title = extractTitle(md);
+  if (!title) {
+    console.warn(`⚠ ${file}: no H1 title, skipped`);
+    continue;
+  }
+  adrs.push({ number, slug, title, summary: extractSummary(md), body: stripTitle(md) });
+}
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+for (const adr of adrs) {
+  const frontmatter = [
+    '---',
+    `title: ${yaml(adr.title)}`,
+    adr.summary ? `description: ${yaml(adr.summary)}` : null,
+    'sidebar:',
+    `  label: ${yaml(`${adr.number} — ${adr.title}`)}`,
+    `  order: ${Number(adr.number)}`,
+    '---',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  writeFileSync(resolve(outDir, `${adr.slug}.md`), `${frontmatter}\n\n${adr.body}`);
+}
+
+const rows = [...adrs]
+  .reverse()
+  .map(a => `| [${a.number}](/adr/${a.slug}/) | [${a.title}](/adr/${a.slug}/) | ${(a.summary ?? '').replace(/\|/g, '\\|')} |`)
+  .join('\n');
+
+const index = `---
+title: "Architecture Decision Records"
+description: "Accepted decisions shaping the Specs schema, CLI, and plugin."
+tableOfContents: false
+sidebar:
+  label: "Overview"
+  order: 0
+---
+
+Each record captures one decision about the Specs schema and tooling — the context that forced it, the options weighed, and what was chosen. Only accepted decisions are published here; the newest appear first.
+
+| # | Title | Summary |
+|---|-------|---------|
+${rows}
+`;
+
+writeFileSync(resolve(outDir, 'index.md'), index);
+console.log(`✓ Built ${adrs.length} ADR pages + index in site/src/content/docs/adr/`);

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -20,6 +20,7 @@ const SECTION_LINKS = [
   { label: 'Plugin', href: '/plugin/', prefix: '/plugin/' },
   { label: 'Commands', href: '/cli/', prefix: '/cli/' },
   { label: 'Schema', href: '/schema/', prefix: '/schema/' },
+  { label: 'ADRs', href: '/adr/', prefix: '/adr/' },
   // Points at the Settings section home for now, per explicit instruction.
   // TODO: point to the future consolidated Docs section landing page once Settings+Guides are merged.
   { label: 'Docs', href: '/settings/', prefix: '/settings/' },
@@ -117,7 +118,7 @@ const SLACK_PATHS = [
   }
 
   .section-link {
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 700;
     color: var(--sl-color-gray-2);
     text-decoration: none;

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -112,14 +112,14 @@ const SLACK_PATHS = [
   .section-links {
     display: flex;
     align-items: center;
-    gap: 2.5rem;
+    gap: 1.25rem;
     margin-inline-end: 1rem;
     white-space: nowrap;
   }
 
   .section-link {
-    font-size: 16px;
-    font-weight: 700;
+    font-size: 14px;
+    font-weight: 600;
     color: var(--sl-color-gray-2);
     text-decoration: none;
   }

--- a/site/src/components/PageTitle.astro
+++ b/site/src/components/PageTitle.astro
@@ -26,7 +26,7 @@ const isAdrRecord = /^\/adr\/[^/]+\/?$/.test(pathname);
         </svg>
         ADRs Index
       </a>
-      <p class="adr-eyebrow">ADRs</p>
+      <p class="adr-eyebrow">ADR</p>
     </div>
   )
 }
@@ -35,7 +35,7 @@ const isAdrRecord = /^\/adr\/[^/]+\/?$/.test(pathname);
 
 <style>
   .adr-context {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.15rem;
   }
 
   .adr-crumb {
@@ -57,6 +57,6 @@ const isAdrRecord = /^\/adr\/[^/]+\/?$/.test(pathname);
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--sl-color-text-accent);
+    color: var(--sl-color-gray-3);
   }
 </style>

--- a/site/src/components/PageTitle.astro
+++ b/site/src/components/PageTitle.astro
@@ -35,7 +35,13 @@ const isAdrRecord = /^\/adr\/[^/]+\/?$/.test(pathname);
 
 <style>
   .adr-context {
-    margin-bottom: 0.15rem;
+    margin-bottom: 0;
+  }
+
+  /* Starlight gives the h1 its own margin-top, which wins the margin
+     collapse against .adr-context — zero it so the eyebrow hugs the title. */
+  .adr-context + :global(h1) {
+    margin-top: 0.1rem;
   }
 
   .adr-crumb {
@@ -52,7 +58,7 @@ const isAdrRecord = /^\/adr\/[^/]+\/?$/.test(pathname);
   }
 
   .adr-eyebrow {
-    margin: 0.75rem 0 0;
+    margin: 1.1rem 0 0;
     font-size: var(--sl-text-xs);
     font-weight: 600;
     letter-spacing: 0.08em;

--- a/site/src/components/PageTitle.astro
+++ b/site/src/components/PageTitle.astro
@@ -1,0 +1,62 @@
+---
+// Custom PageTitle override for Starlight.
+// ADR record pages sit outside the sidebar tree, so they arrive with no
+// surrounding context. Give them a crumb back to the index and an eyebrow
+// naming the section, then defer to the default title rendering.
+import Default from '@astrojs/starlight/components/PageTitle.astro';
+
+const pathname = Astro.url.pathname;
+// Matches a record page (/adr/059-border-style/) but not the index (/adr/).
+const isAdrRecord = /^\/adr\/[^/]+\/?$/.test(pathname);
+---
+
+{
+  isAdrRecord && (
+    <div class="adr-context">
+      <a class="adr-crumb" href="/adr/">
+        <svg viewBox="0 0 16 16" aria-hidden="true" width="14" height="14">
+          <path
+            d="M10 3L5 8l5 5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        ADRs Index
+      </a>
+      <p class="adr-eyebrow">ADRs</p>
+    </div>
+  )
+}
+
+<Default {...Astro.props}><slot /></Default>
+
+<style>
+  .adr-context {
+    margin-bottom: 0.5rem;
+  }
+
+  .adr-crumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+  }
+
+  .adr-crumb:hover {
+    color: var(--sl-color-text-accent);
+  }
+
+  .adr-eyebrow {
+    margin: 0.75rem 0 0;
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--sl-color-text-accent);
+  }
+</style>

--- a/site/src/custom.css
+++ b/site/src/custom.css
@@ -421,7 +421,7 @@ html[data-has-hero] .hero .tagline {
 
 .adr-meta {
 	margin: 0 0 2rem;
-	padding: 1rem 1.25rem;
+	padding: 0.6rem 1.25rem;
 	border: 1px solid var(--sl-color-gray-5);
 	border-radius: 0.5rem;
 	background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
@@ -431,8 +431,8 @@ html[data-has-hero] .hero .tagline {
 .adr-meta-row {
 	display: grid;
 	grid-template-columns: 7rem 1fr;
-	gap: 0.5rem 1rem;
-	padding: 0.3rem 0;
+	gap: 0 1rem;
+	padding: 0.4rem 0;
 }
 
 .adr-meta-row + .adr-meta-row {
@@ -449,9 +449,12 @@ html[data-has-hero] .hero .tagline {
 	color: var(--sl-color-gray-1);
 }
 
+.adr-meta dd > :first-child { margin-top: 0; }
+.adr-meta dd > :last-child { margin-bottom: 0; }
+
 @media (max-width: 30rem) {
 	.adr-meta-row {
 		grid-template-columns: 1fr;
-		gap: 0.15rem;
+		gap: 0.1rem;
 	}
 }

--- a/site/src/custom.css
+++ b/site/src/custom.css
@@ -416,3 +416,42 @@ html[data-has-hero] .hero .tagline {
 	line-height: 1.5;
 	color: var(--sl-color-gray-3);
 }
+
+/* ── ADR metadata block ──────────────────────────────────────── */
+
+.adr-meta {
+	margin: 0 0 2rem;
+	padding: 1rem 1.25rem;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.5rem;
+	background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
+	font-size: var(--sl-text-sm);
+}
+
+.adr-meta-row {
+	display: grid;
+	grid-template-columns: 7rem 1fr;
+	gap: 0.5rem 1rem;
+	padding: 0.3rem 0;
+}
+
+.adr-meta-row + .adr-meta-row {
+	border-top: 1px solid var(--sl-color-gray-5);
+}
+
+.adr-meta dt {
+	font-weight: 600;
+	color: var(--sl-color-gray-2);
+}
+
+.adr-meta dd {
+	margin: 0;
+	color: var(--sl-color-gray-1);
+}
+
+@media (max-width: 30rem) {
+	.adr-meta-row {
+		grid-template-columns: 1fr;
+		gap: 0.15rem;
+	}
+}

--- a/site/src/custom.css
+++ b/site/src/custom.css
@@ -377,3 +377,42 @@ html[data-has-hero] .hero .tagline {
 	max-width: 700px;
 	line-height: 1.2;
 }
+
+/* ── ADR index ───────────────────────────────────────────────── */
+
+.adr-index {
+	width: 100%;
+	border-collapse: collapse;
+	margin-top: 1.5rem;
+}
+
+.adr-index td {
+	padding: 0.75rem 0;
+	border-bottom: 1px solid var(--sl-color-gray-5);
+	vertical-align: baseline;
+}
+
+.adr-index .adr-number {
+	width: 3.5rem;
+	padding-right: 1rem;
+	font-family: var(--__sl-font-mono);
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-gray-3);
+	white-space: nowrap;
+}
+
+.adr-index .adr-entry a {
+	font-weight: 600;
+	text-decoration: none;
+}
+
+.adr-index .adr-entry a:hover {
+	text-decoration: underline;
+}
+
+.adr-index .adr-summary {
+	margin: 0.25rem 0 0;
+	font-size: var(--sl-text-sm);
+	line-height: 1.5;
+	color: var(--sl-color-gray-3);
+}


### PR DESCRIPTION
Publishes the accepted ADRs as a docs section generated at build time, so records are authored once in `adr/` and appear on the site with no manual copying.

## How it works

- `site/scripts/build-adrs.mjs` reads `adr/*.md`, keeps the ACCEPTED records, and emits one Starlight page each into `site/src/content/docs/adr/` plus an index.
- It runs from `prebuild` and `predev`, chained after the existing `build-releases.mjs`, so `npm run dev` and `npm run build` both pick up new ADRs automatically.
- Generated output is gitignored, matching how `overview/releases.mdx` is handled.
- 59 records publish today. Drafts stay internal, so `adr/INDEX.md` remains the internal view.

## Summary field

ADRs gain a `**Summary**:` line in the metadata block — one present-tense sentence naming the new property or type as its subject. All 59 accepted records are authored.

- `/specs.adr.implement` writes it as a new gated step, at implementation time rather than draft time, since decisions evolve until then.
- `adr/adr-template.md` carries a placeholder until then.
- The index reads the field with no fallback, so an unwritten summary surfaces as a build warning and a blank row rather than as prose lifted from Context.

## Site presentation

- Sidebar: a single `Decision Records (ADRs)` link beside Releases. Individual records stay out of the nav and are reached from the index.
- Top nav: `ADRs` between Schema and Docs; section links reduced to 14px with a tighter gap.
- Index: two-column layout — number, then title with its summary beneath in muted text — under an introduction explaining what an ADR is and when to read one.
- Record pages: the run-on `**Key**: value` block becomes a label/value grid showing Summary, Status (with date), Deciders, and Supersedes only when it names an actual superseded record. Branch is dropped.
- Record pages get a crumb back to the index and an `ADR` eyebrow, since they sit outside the sidebar tree.

## Verification

- `npm run build` passes at 226 pages, up from 166.
- All 59 records publish with a summary and metadata grid; zero build warnings.
- Cross-references to unpublished drafts render as text rather than dead links.

## Notes for review

- These pages are public and read as internal engineering records — full option analysis and rejected designs. Worth a look at one rendered page to confirm that is intended.
- Summaries keep each record's own vocabulary rather than retrofitting later terminology, so ADR 013 says "icon" where ADR 017 later renames it to "glyph".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ7cvqDEapmdCwarATNwzo
