### PR TITLE
Rename clipContent to clipsContent (ADR-069)

### DIFF
--- a/adr/069-clips-content.md
+++ b/adr/069-clips-content.md
@@ -2,8 +2,8 @@
 
 **Branch**: `069-clips-content`
 **Created**: 2026-08-14
-**Status**: DRAFT
-**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Status**: ACCEPTED
+**Summary**: A `clipsContent` boolean style replaces `clipContent`, joining `visible` and `locked` as element state consumers map to `overflow`.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 
@@ -219,9 +219,9 @@ clipsContent:
 
 ## Semver Decision
 
-**Version bump**: `0.30.0 → 0.31.0` (`MAJOR`-class change)
+**Target version**: `0.30.0` — the version of the active release branch (`release/schema-0.30.0+cli-0.27.0`). This ADR ships within that release and proposes no bump of its own.
 
-**Justification**: Renaming a named field within an exported type and renaming a schema property are both breaking changes under Constitution III and the Versioning rule ("`MAJOR` for any breaking change to a type signature, field name, field presence, or schema structure"). The package is pre-1.0, so the breaking change is carried by a MINOR-position bump per 0.x convention, and MUST be called out as breaking in `CHANGELOG.md`.
+**Change class**: `MAJOR`-class (breaking). Renaming a named field within an exported type and renaming a schema property are both breaking changes under Constitution III and the Versioning rule ("`MAJOR` for any breaking change to a type signature, field name, field presence, or schema structure"). It MUST be called out as breaking in `CHANGELOG.md` under the release's entry.
 
 **Naming governance citation**: Constitution VI **rule 1** — 2+ code platforms agree. For the construct, UIKit, Android View, SwiftUI, and Compose agree on on/off. For the object-vs-boundary naming axis the code platforms tie, and the tiebreak is drawn from the schema's own vocabulary rather than from Figma. Rule 3 (defer to Figma) is **not** invoked anywhere in this ADR.
 

--- a/adr/069-clips-content.md
+++ b/adr/069-clips-content.md
@@ -1,0 +1,169 @@
+# ADR: Rename `clipContent` to `clipsContent`
+
+**Branch**: `069-clips-content`
+**Created**: 2026-08-14
+**Status**: DRAFT
+**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+`Styles` declares a boolean style named `clipContent`:
+
+```yaml
+# types/Styles.ts — current
+Styles:
+  clipContent: Style
+```
+
+The name is wrong. The property it describes is Figma's node property `clipsContent` — third-person singular, with the `s`. Because the declared key never matched the key the data actually carries, nothing downstream has ever matched on it:
+
+- The `styles.schema.json` property `clipContent` never validates against emitted spec output.
+- The `StyleKey` union member `'clipContent'` never selects a real style.
+- The CSS mapping rule for `clipContent → overflow` never fires, so `overflow: hidden` / `overflow: visible` is never emitted.
+
+This is a defect, not a design gap: the feature was built end to end and has been inert since it shipped because of a one-character naming error.
+
+---
+
+## Decision Drivers
+
+- **Correctness first**: a public field name that matches nothing is worse than no field at all — it advertises a capability the contract cannot deliver.
+- **Type ↔ schema symmetry**: the type, the schema property, and the `StyleKey` union must all move together (Constitution IV).
+- **Naming governance (Constitution VI)**: the chosen name must be justified against the code-platform preference order, not adopted by default.
+- **No abbreviations, full words**: both candidate names satisfy this; it is not a differentiator.
+- **Breaking-change discipline (Constitution III)**: renaming a named field within an exported type is breaking and MUST be versioned accordingly.
+
+---
+
+## Options Considered
+
+### Option A: Rename to `clipsContent` *(Selected)*
+
+Rename the field, the schema property, and the `StyleKey` member to `clipsContent`.
+
+**Pros**:
+- Matches the name the data has always carried, so the style, its schema property, and the CSS mapping become live for the first time.
+- Constitution VI rule 3 applies: no code platform expresses a strong opinion on a *boolean* clip flag — CSS models overflow as a multi-valued enum (`overflow`), SwiftUI as a `.clipped()` modifier, Compose as `.clip(...)` — so none of them offers a boolean field name to borrow. Where no code platform has a competing term, Figma's vocabulary stands.
+- Smallest possible change surface: one word, three declaration sites.
+
+**Cons / Trade-offs**:
+- Breaking rename of a published field name, even though no consumer can be relying on it working.
+
+---
+
+### Option B: Keep `clipContent` and translate upstream *(Rejected)*
+
+Leave the schema name alone and have the transformer rename `clipsContent` → `clipContent` on the way out.
+
+**Rejected because**: it preserves a name chosen by mistake and pays for it with a permanent translation step, contradicting Constitution VI's rationale that only genuine naming decisions — not typos — justify making the transformer translate.
+
+---
+
+### Option C: Rename to an overflow-shaped enum *(Rejected)*
+
+Replace the boolean with a CSS-shaped `overflow: 'HIDDEN' | 'VISIBLE'` style.
+
+**Rejected because**: it redesigns the property under cover of a bug fix, widening a one-word correction into a modeled-value change with its own downstream migration. If an overflow enum is wanted, it deserves its own ADR.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Styles.ts` | Renamed field `clipContent` → `clipsContent` on `Styles` | MAJOR |
+| `Styles.ts` | Renamed `StyleKey` union member `'clipContent'` → `'clipsContent'` | MAJOR |
+
+**Example — new shape** (`types/Styles.ts`):
+```yaml
+# Before
+Styles:
+  effects: TokenReference | Effects
+  clipContent: Style
+  cornerRadius: Style | Corners
+
+# After
+Styles:
+  effects: TokenReference | Effects
+  clipsContent: Style
+  cornerRadius: Style | Corners
+```
+
+```yaml
+# StyleKey — before
+StyleKey:
+  - effects
+  - clipContent
+  - cornerRadius
+
+# StyleKey — after
+StyleKey:
+  - effects
+  - clipsContent
+  - cornerRadius
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `styles.schema.json` | Renamed property `clipContent` → `clipsContent` | MAJOR |
+
+**Example — new shape** (`schema/styles.schema.json`):
+```yaml
+# Before — under #/definitions/Styles/properties
+clipContent:
+  $ref: "#/definitions/BooleanStyleValue"
+  description: "Clip content"
+
+# After
+clipsContent:
+  $ref: "#/definitions/BooleanStyleValue"
+  description: "Whether the element clips content that overflows its bounds"
+```
+
+### Notes
+
+- The type (`Style`), the schema `$ref` (`BooleanStyleValue`), and the property's optionality are all unchanged — only the key changes.
+- No deprecation alias is introduced. An alias would keep a name alive that has never resolved to a value, and would require consumers to handle two keys for one concept.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes.
+- **Parity check**: `Styles.clipsContent` ↔ `#/definitions/Styles/properties/clipsContent`; the `StyleKey` union member `'clipsContent'` names the same key. All three rename in one change; no drift is introduced.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-cli` | The CSS mapping keyed on the old name stops being dead code once the key matches | Update the key used by the style-to-CSS mapping and its mapping documentation; recompile |
+| `specs-from-figma` | Emitted output already uses `clipsContent`; it now validates against the schema | Recompile against the new types; confirm no code references the old key |
+| `specs-plugin-2` | Consumes the same style key surface | Recompile; update any reference to the old key |
+| Docs site | A styles reference page is published under the old name | Rename the page and update references to the new key |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.30.0 → 0.31.0` (`MAJOR`-class change)
+
+**Justification**: Renaming a named field within an exported type and renaming a schema property are both breaking changes under Constitution III and the Versioning rule ("`MAJOR` for any breaking change to a type signature, field name, field presence, or schema structure"). The package is pre-1.0, so the breaking change is carried by a MINOR-position bump per 0.x convention, and MUST be called out as breaking in `CHANGELOG.md`.
+
+---
+
+## Consequences
+
+- `clipsContent` resolves against real data for the first time, so the style appears in spec output and the schema validates it.
+- Consumers that map this style — including the CSS `overflow` mapping — begin producing output where they previously produced nothing.
+- The name `clipContent` is gone with no alias; any consumer referencing it fails at compile time rather than silently matching nothing.
+- Published spec documents produced before this change carry no `clipContent` key to migrate, since the key was never emitted.

--- a/adr/069-clips-content.md
+++ b/adr/069-clips-content.md
@@ -19,59 +19,122 @@ Styles:
   clipContent: Style
 ```
 
-The name is wrong. The property it describes is Figma's node property `clipsContent` — third-person singular, with the `s`. Because the declared key never matched the key the data actually carries, nothing downstream has ever matched on it:
+The name matches nothing. The property describes whether an element cuts off content that overflows its box, and the key the data actually carries is `clipsContent`. Because the declared key and the carried key differ by one character, every consumer of the declared key has been inert since it shipped:
 
 - The `styles.schema.json` property `clipContent` never validates against emitted spec output.
 - The `StyleKey` union member `'clipContent'` never selects a real style.
 - The CSS mapping rule for `clipContent → overflow` never fires, so `overflow: hidden` / `overflow: visible` is never emitted.
 
-This is a defect, not a design gap: the feature was built end to end and has been inert since it shipped because of a one-character naming error.
+The defect is a typo. But correcting a typo still means publishing a field name, and a published field name is a contract with every consumer — so this ADR treats both halves as open questions rather than assuming the answer:
+
+1. **The construct** — is an on/off boolean the right way to model clipping at all, or should this be an enum?
+2. **The name** — given the construct, what should the field be called?
+
+The risk to guard against is that `clipsContent` happens to be Figma's spelling. Constitution VI is explicit that Figma is the data source, not the naming authority. Arriving at Figma's spelling is acceptable; arriving at it *because* it is Figma's spelling is not. Each decision below is therefore settled on code-platform evidence and on terms the schema already uses, and each records what would have changed the answer.
+
+---
+
+## Cross-platform survey
+
+Both decisions draw on the same evidence, gathered once here.
+
+| Platform | API | Construct | Name shape |
+|----------|-----|-----------|------------|
+| UIKit | `UIView.clipsToBounds: Bool` | Boolean | third-person verb + boundary |
+| SwiftUI | `.clipped()`, `.clipShape(_:)` | Modifier presence (on/off) | past participle |
+| Android View | `ViewGroup.clipChildren`, `View.clipToOutline` | Boolean | verb + object / verb + boundary |
+| Jetpack Compose | `Modifier.clip(shape)`, `Modifier.clipToBounds()` | Modifier presence (on/off) | verb + boundary |
+| CSS | `overflow: visible \| hidden \| clip \| scroll \| auto` | Enum | overflow noun |
+| React Native | `overflow: 'visible' \| 'hidden' \| 'scroll'` | Enum (CSS subset) | overflow noun |
+| Flutter | `clipBehavior: Clip` (`none`, `hardEdge`, `antiAlias`, `antiAliasWithSaveLayer`) | Enum | verb + behavior noun |
+| Figma | `clipsContent: boolean` | Boolean | third-person verb + object |
 
 ---
 
 ## Decision Drivers
 
-- **Correctness first**: a public field name that matches nothing is worse than no field at all — it advertises a capability the contract cannot deliver.
-- **Type ↔ schema symmetry**: the type, the schema property, and the `StyleKey` union must all move together (Constitution IV).
-- **Naming governance (Constitution VI)**: the chosen name must be justified against the code-platform preference order, not adopted by default.
-- **No abbreviations, full words**: both candidate names satisfy this; it is not a differentiator.
-- **Breaking-change discipline (Constitution III)**: renaming a named field within an exported type is breaking and MUST be versioned accordingly.
+- **Construct neutrality**: the shape must be the one code platforms agree on, and must not carry values this schema has no way to populate.
+- **Name neutrality**: every naming tiebreak must resolve on code-platform evidence or on vocabulary the schema already uses — never on "Figma spells it this way".
+- **Falsifiability**: each decision states what evidence would have produced a different answer, so a reviewer can check the reasoning rather than trust it.
+- **Type ↔ schema symmetry**: the type, the schema property, and the `StyleKey` union must move together (Constitution IV).
+- **Breaking-change discipline**: renaming a named field within an exported type is breaking and MUST be versioned accordingly (Constitution III).
 
 ---
 
-## Options Considered
+## Decision 1 — Construct: boolean or enum?
 
-### Option A: Rename to `clipsContent` *(Selected)*
+### Option A: Keep the boolean (`Style` / `BooleanStyleValue`) *(Selected)*
 
-Rename the field, the schema property, and the `StyleKey` member to `clipsContent`.
+Model clipping as an on/off style, unchanged from today.
 
 **Pros**:
-- Matches the name the data has always carried, so the style, its schema property, and the CSS mapping become live for the first time.
-- Constitution VI rule 3 applies: no code platform expresses a strong opinion on a *boolean* clip flag — CSS models overflow as a multi-valued enum (`overflow`), SwiftUI as a `.clipped()` modifier, Compose as `.clip(...)` — so none of them offers a boolean field name to borrow. Where no code platform has a competing term, Figma's vocabulary stands.
-- Smallest possible change surface: one word, three declaration sites.
+- **Constitution VI rule 1 applies — 2+ code platforms agree, independent of Figma.** Four of the seven code platforms surveyed model clipping as on/off: UIKit and Android View as literal booleans, SwiftUI and Compose as modifier presence. Figma's agreement is a fifth data point, not the basis.
+- **The three enums degenerate to a boolean in this domain.** Their extra values fall into two buckets, neither of which this schema can express:
+  - *Scrolling* — CSS/React Native `scroll` and `auto` describe a scrolling affordance, a runtime interaction behavior. The schema has no scroll concept anywhere in `Styles`, and a static design surface produces no scroll state to extract.
+  - *Rasterization quality* — Flutter's `hardEdge` / `antiAlias` / `antiAliasWithSaveLayer` describe how the clip is rendered, a render-time performance trade-off with no design-surface counterpart.
+
+  Remove what the schema cannot populate and CSS `overflow` collapses to `visible` vs `hidden`, and Flutter's `Clip` collapses to `none` vs everything-else. Both are booleans wearing an enum's clothes.
+- **Widening at the consumer boundary is lossless; narrowing is not.** A boolean projects cleanly onto every enum — the existing CSS mapping already does exactly this (`true → overflow: hidden`, `false → overflow: visible`). An enum in the schema would instead force platforms with a boolean to narrow, and would advertise values no extractor can ever produce.
+- Reuses the existing `BooleanStyleValue` schema definition, so the value stays token-bindable like other boolean styles (`visible`, `locked`, `wrap`).
 
 **Cons / Trade-offs**:
-- Breaking rename of a published field name, even though no consumer can be relying on it working.
+- If the schema ever models scrolling containers, clipping and scrollability will need to be reconciled — a boolean cannot express `overflow: scroll`. That is a genuine future cost, but it is a *new capability* deserving its own ADR, not a reason to pre-build an enum whose extra values would sit permanently unpopulated.
+
+**What would have changed this**: if a majority of code platforms modeled clipping with a value set that survives the design-surface filter — three or more distinct, extractable clipping modes rather than on/off — the enum would win.
 
 ---
 
-### Option B: Keep `clipContent` and translate upstream *(Rejected)*
+### Option B: CSS-shaped `overflow` enum *(Rejected)*
 
-Leave the schema name alone and have the transformer rename `clipsContent` → `clipContent` on the way out.
+Replace the boolean with `overflow: 'VISIBLE' | 'HIDDEN' | 'CLIP'`.
 
-**Rejected because**: it preserves a name chosen by mistake and pays for it with a permanent translation step, contradicting Constitution VI's rationale that only genuine naming decisions — not typos — justify making the transformer translate.
+**Rejected because**: it violates the construct-neutrality driver from the opposite direction — it adopts the *web's* model as the neutral one. CSS and React Native are one platform family, not two independent votes, so this is closer to a single-platform preference than the rule-1 consensus Option A has. It also imports `scroll`/`auto` semantics the schema cannot populate, and collides with the existing `textOverflow` style (`CLIP` | `ELLIPSIS`) — two unrelated `overflow`-named properties with a shared `CLIP` value that means different things.
 
 ---
 
-### Option C: Rename to an overflow-shaped enum *(Rejected)*
+### Option C: Flutter-shaped `clipBehavior` enum *(Rejected)*
 
-Replace the boolean with a CSS-shaped `overflow: 'HIDDEN' | 'VISIBLE'` style.
+Adopt a named enum modeled on Flutter's `Clip`.
 
-**Rejected because**: it redesigns the property under cover of a bug fix, widening a one-word correction into a modeled-value change with its own downstream migration. If an overflow enum is wanted, it deserves its own ADR.
+**Rejected because**: its distinctions are rasterization quality, which is a rendering implementation concern rather than a design decision, and nothing on a design surface determines which value to emit. It is a single-platform model with no second platform agreeing.
+
+---
+
+## Decision 2 — Name: what should the boolean be called?
+
+Given a boolean, the survey offers three naming shapes. Two axes are in play — what the name points at (the clipped object vs. the clipping boundary), and the verb form.
+
+### Option A: `clipsContent` *(Selected)*
+
+**Pros**:
+- **Object-naming beats boundary-naming on schema-internal grounds.** The platforms split evenly on this axis — Android `clipChildren` and Figma `clipsContent` name the clipped object; UIKit `clipsToBounds` and Compose `clipToBounds` name the boundary. The tiebreak is not Figma's vote, it is that **`Styles` has no `bounds` concept to point at.** The schema models extent as `width`/`height`/`min*`/`max*` with no bounds object, so a `*ToBounds` name would reference a term the schema never defines. `content` is already the schema's word for what an element contains.
+- **`content` generalizes where `children` does not.** Android's `clipChildren` names child views specifically, but clipping applies equally to overflowing text and paint on elements with no children. `content` covers all three; `children` would be wrong for a clipped `TEXT` element.
+- **The verb form is settled by internal consistency, not by Figma.** Booleans in `Styles` read as state predicates describing the element — `visible`, `locked`, `wrap` — not as commands. `clipsContent` reads as a predicate ("this element clips content"); the current `clipContent` reads as an imperative instruction, which is why it looks out of place beside its neighbors. UIKit's `clipsToBounds` independently confirms the third-person form for a boolean clip flag.
+
+**Cons / Trade-offs**:
+- The result is spelled the same as Figma's property. Every tiebreak above was decided on code-platform or in-schema evidence, and the coincidence is what it is — but the reasoning, not the match, is what should be reviewed.
+
+**What would have changed this**: if `Styles` modeled a bounds or frame object, `clipsToBounds` would carry two code platforms (UIKit, Compose) plus an in-schema referent and would win. It does not, so it cannot.
+
+---
+
+### Option B: `clipsToBounds` *(Rejected)*
+
+**Rejected because**: it names a referent the schema does not define. `Styles` has no bounds object, so the name would point at a concept a consumer cannot look up — trading a Figma-shaped name for a UIKit-shaped one without improving neutrality.
+
+---
+
+### Option C: Keep `clipContent`, translate in the transformer *(Rejected)*
+
+Leave the schema name alone and rename `clipsContent` → `clipContent` on the way out.
+
+**Rejected because**: Constitution VI's rationale for making the transformer translate is to spare consumers a *deliberate* naming decision. This name was not decided, it was mistyped. Paying a permanent translation step to preserve a typo inverts the rule. It also keeps the imperative verb form that reads wrong beside `visible` and `locked`.
 
 ---
 
 ## Decision
+
+Model clipping as a boolean, and rename the field, the schema property, and the `StyleKey` member to `clipsContent`.
 
 ### Type changes (`types/`)
 
@@ -125,13 +188,14 @@ clipContent:
 # After
 clipsContent:
   $ref: "#/definitions/BooleanStyleValue"
-  description: "Whether the element clips content that overflows its bounds"
+  description: "Whether the element clips content that overflows its box"
 ```
 
 ### Notes
 
-- The type (`Style`), the schema `$ref` (`BooleanStyleValue`), and the property's optionality are all unchanged — only the key changes.
-- No deprecation alias is introduced. An alias would keep a name alive that has never resolved to a value, and would require consumers to handle two keys for one concept.
+- The construct is unchanged: the type stays `Style`, the schema `$ref` stays `BooleanStyleValue`, and the property stays optional. Only the key changes. Decision 1 records that the boolean was re-examined and re-affirmed rather than inherited by default.
+- No deprecation alias is introduced. An alias would keep alive a name that has never resolved to a value, and would require consumers to handle two keys for one concept.
+- The description is rewritten from `"Clip content"` — an imperative fragment restating the old field name — to a statement of what the boolean means.
 
 ---
 
@@ -159,11 +223,15 @@ clipsContent:
 
 **Justification**: Renaming a named field within an exported type and renaming a schema property are both breaking changes under Constitution III and the Versioning rule ("`MAJOR` for any breaking change to a type signature, field name, field presence, or schema structure"). The package is pre-1.0, so the breaking change is carried by a MINOR-position bump per 0.x convention, and MUST be called out as breaking in `CHANGELOG.md`.
 
+**Naming governance citation**: Constitution VI **rule 1** — 2+ code platforms agree. For the construct, UIKit, Android View, SwiftUI, and Compose agree on on/off. For the object-vs-boundary naming axis the code platforms tie, and the tiebreak is drawn from the schema's own vocabulary rather than from Figma. Rule 3 (defer to Figma) is **not** invoked anywhere in this ADR.
+
 ---
 
 ## Consequences
 
 - `clipsContent` resolves against real data for the first time, so the style appears in spec output and the schema validates it.
 - Consumers that map this style — including the CSS `overflow` mapping — begin producing output where they previously produced nothing.
+- The boolean construct is now on the record as examined and justified, so a future proposal to widen it to an enum has a documented bar to clear: it must name extractable clipping modes beyond on/off.
+- Scrolling remains unrepresentable in `Styles`. If the schema ever gains scroll semantics, the relationship between clipping and scrollability needs its own ADR.
 - The name `clipContent` is gone with no alias; any consumer referencing it fails at compile time rather than silently matching nothing.
 - Published spec documents produced before this change carry no `clipContent` key to migrate, since the key was never emitted.

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 069 | Rename `clipContent` to `clipsContent` | |
 | 045 | Processing Provenance Signals | (reserved, draft in PR #60) |
 | 044 | Duplicate Layer Name Disambiguation | (reserved, draft in PR #60) |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 069 | Rename `clipContent` to `clipsContent` | |
 | 045 | Processing Provenance Signals | (reserved, draft in PR #60) |
 | 044 | Duplicate Layer Name Disambiguation | (reserved, draft in PR #60) |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |
@@ -15,6 +14,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 069 | Rename `clipContent` to `clipsContent` | Renames the clip flag to the key the data carries, so container clipping and CSS `overflow` resolve for the first time |
 | 066 | Lossless Key Formatting — Safe Key Grammar and Figma Name Preservation | Adds opt-in `format.figmaKeys` (`NONE` default), a safe key grammar, and `com.figma.name` on anatomy and props; renames `originalName` |
 | 065 | Document the `nullable` Default and Add `NumberProp.nullable` | Absent `nullable` means true for `StringProp`/`NumberProp`/`SlotProp`/`ImageProp`, false for `EnumProp`; adds `NumberProp.nullable` |
 | 064 | Tighten `textAlignHorizontal` to a Logical-Direction String Enum | Narrow from `Style` to `TextAlignHorizontal \| null` (`'START' \| 'CENTER' \| 'END' \| 'JUSTIFY'`); Figma `LEFT`/`RIGHT`/`JUSTIFIED` remapped |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CSS `overflow` output — keyed on the renamed `Styles.clipsContent`, so `overflow: hidden` / `overflow: visible` is emitted for the first time (ADR-069)
+
 ### Removed
 
 

--- a/packages/cli/src/transforms/Css.mapping.md
+++ b/packages/cli/src/transforms/Css.mapping.md
@@ -144,8 +144,8 @@ if present, else `currentColor`. Gradients deferred to phase 2.
 | Spec key | CSS property | Notes |
 |----------|-------------|-------|
 | `visible: false` | `display: none` | Only emitted when explicitly false. |
-| `clipContent: true` | `overflow: hidden` | |
-| `clipContent: false` | `overflow: visible` | |
+| `clipsContent: true` | `overflow: hidden` | |
+| `clipsContent: false` | `overflow: visible` | |
 
 ### Transform
 

--- a/packages/cli/src/transforms/css/styleToCSS.ts
+++ b/packages/cli/src/transforms/css/styleToCSS.ts
@@ -265,9 +265,9 @@ export function styleToCSS(styles: Record<string, unknown>, tokensFormat = 'TOKE
 
   // ── Overflow ─────────────────────────────────────────────────────────────────
 
-  if ('clipContent' in styles && styles.clipContent !== undefined) {
-    if (styles.clipContent === true) decls.push('overflow: hidden');
-    else if (styles.clipContent === false) decls.push('overflow: visible');
+  if ('clipsContent' in styles && styles.clipsContent !== undefined) {
+    if (styles.clipsContent === true) decls.push('overflow: hidden');
+    else if (styles.clipsContent === false) decls.push('overflow: visible');
   }
 
   // ── Transform ────────────────────────────────────────────────────────────────

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `FigmaAnatomyElementExtension.name` — renamed from `originalName`; now records the Figma layer name for key divergence as well as wrapper collapse (ADR-066)
+- `Styles.clipsContent` — renamed from `clipContent`; boolean clip flag, type and token-bindability unchanged (ADR-069)
 
 ### Removed
 
 ### Migration
+
+`Styles.clipContent` → `Styles.clipsContent`: read `clipsContent` instead; the value shape is unchanged. No stored spec carries the old key — it never matched emitted output.
 
 `FigmaAnatomyElementExtension.originalName` → `FigmaAnatomyElementExtension.name`: read `$extensions['com.figma'].name` instead; the value and its collapse-provenance meaning are unchanged. Consumers that read the extension through an inline structural type will not see a compile error — update those call sites explicitly.
 

--- a/packages/schema/schema/styles.schema.json
+++ b/packages/schema/schema/styles.schema.json
@@ -18,7 +18,7 @@
         "fillColor": { "$ref": "#/definitions/ColorStyleValue", "description": "Glyph fill color. Present on GLYPH element type only. Represented in Figma as fills." },
         "textColor": { "$ref": "#/definitions/ColorStyleValue", "description": "Text fill color. Present on TEXT element type only. Represented in Figma as fills." },
         "effects": { "$ref": "#/definitions/EffectsStyleValue", "description": "Effect output. TokenReference when the node references a named effects style; Effects when effects are defined inline. Replaces effectStyleId." },
-        "clipContent": { "$ref": "#/definitions/BooleanStyleValue", "description": "Clip content" },
+        "clipsContent": { "$ref": "#/definitions/BooleanStyleValue", "description": "Whether the element clips content that overflows its box" },
         "cornerRadius": { "$ref": "#/definitions/CornersStyleValue", "description": "Corner radius. Scalar when uniform; Corners object when per-corner values differ." },
         "width": { "$ref": "#/definitions/NumberStyleValue", "description": "Width in pixels" },
         "height": { "$ref": "#/definitions/NumberStyleValue", "description": "Height in pixels" },

--- a/packages/schema/tests/Styles.test-d.ts
+++ b/packages/schema/tests/Styles.test-d.ts
@@ -585,6 +585,24 @@ const withWrapToken: Styles = {
   wrap: { $token: 'Layout.Wrap', $type: 'boolean' } satisfies TokenReference,
 };
 
+// ─── Styles.clipsContent (boolean Style) ────────────────────────────────────
+
+// Boolean values
+const withClipsContentTrue: Styles = { clipsContent: true };
+const withClipsContentFalse: Styles = { clipsContent: false };
+
+// null is valid (Style includes null)
+const withClipsContentNull: Styles = { clipsContent: null };
+
+// TokenReference is valid (Style includes TokenReference)
+const withClipsContentToken: Styles = {
+  clipsContent: { $token: 'Layout.ClipsContent', $type: 'boolean' } satisfies TokenReference,
+};
+
+// The pre-ADR-069 name is no longer a Styles key
+// @ts-expect-error: clipContent was renamed to clipsContent
+const withOldClipName: Styles = { clipContent: true };
+
 // ─── Styles.wrapAlignment (WrapAlignment | null) ────────────────────────────
 
 // Valid enum values on Styles

--- a/packages/schema/types/Styles.ts
+++ b/packages/schema/types/Styles.ts
@@ -15,7 +15,8 @@ export type Styles = Partial<{
   /** Glyph fill color. Present on GLYPH element type only. Represented in Figma as fills. @since 0.13.0 */
   fillColor: ColorStyle;
   effects: TokenReference | Effects;
-  clipContent: Style;
+  /** Whether the element clips content that overflows its box. @since 0.30.0 */
+  clipsContent: Style;
   /** Corner radius. Scalar when uniform; `Corners` object when per-corner values differ. @since 1.0.0 */
   cornerRadius: Style | Corners;
   width: Style;
@@ -343,7 +344,7 @@ export type StyleKey =
   | 'backgroundImage'
   | 'fillColor'
   | 'effects'
-  | 'clipContent'
+  | 'clipsContent'
   | 'cornerRadius'
   | 'width'
   | 'height'

--- a/site/src/content/docs/schema/styles.md
+++ b/site/src/content/docs/schema/styles.md
@@ -15,7 +15,7 @@ The `Styles` object holds visual properties for an element. Every property is op
 | [`bottom`](/schema/styles/bottom/) | `PositionOffset` | `y` and constraints <small>[ADR 041](https://github.com/DirectedEdges/specs/blob/main/adr/041-layout-positioning.md)</small> |
 | [`centerHorizontalOffset`](/schema/styles/center-horizontal-offset/) | `PositionOffset` | `x` and constraints <small>[ADR 041](https://github.com/DirectedEdges/specs/blob/main/adr/041-layout-positioning.md)</small> |
 | [`centerVerticalOffset`](/schema/styles/center-vertical-offset/) | `PositionOffset` | `y` and constraints <small>[ADR 041](https://github.com/DirectedEdges/specs/blob/main/adr/041-layout-positioning.md)</small> |
-| [`clipContent`](/schema/styles/clip-content/) | `Style` | — |
+| [`clipsContent`](/schema/styles/clips-content/) | `Style` | — |
 | [`cornerRadius`](/schema/styles/corner-radius/) | `Style`<br>`Corners` | — |
 | [`cornerSmoothing`](/schema/styles/corner-smoothing/) | `Style` | — |
 | [`crossAxisAlignment`](/schema/styles/cross-axis-alignment/) | `CrossAxisAlignment` | `counterAxisAlignItems` <small>[ADR 040](https://github.com/DirectedEdges/specs/blob/main/adr/040-layout-alignment.md)</small> |

--- a/site/src/content/docs/schema/styles/clips-content.md
+++ b/site/src/content/docs/schema/styles/clips-content.md
@@ -1,9 +1,9 @@
 ---
-title: "clipContent"
-description: "Whether a container clips overflowing children"
+title: "clipsContent"
+description: "Whether a container clips overflowing content"
 ---
 
-Whether the container clips content that overflows its bounds.
+Whether the container clips content that overflows its box.
 
 #### Type(s)
 

--- a/site/src/content/docs/settings/collapse-primitive-wrapper.md
+++ b/site/src/content/docs/settings/collapse-primitive-wrapper.md
@@ -47,7 +47,7 @@ A component qualifies for collapse when **all** of the following are true:
 - That child's type is `text` or `glyph`.
 - The child has no children of its own.
 - The root carries no slot binding on its children.
-- The root carries none of the following styles after default/zero values are stripped: `clipContent`, `cornerRadius`, `strokes`, `strokeAlign`, `strokeWeight`, `itemSpacing`, `padding`, `effects`, `backgroundColor`, `cornerSmoothing`.
+- The root carries none of the following styles after default/zero values are stripped: `clipsContent`, `cornerRadius`, `strokes`, `strokeAlign`, `strokeWeight`, `itemSpacing`, `padding`, `effects`, `backgroundColor`, `cornerSmoothing`.
 
 Collapse is **all-or-nothing**: if any variant in the component set fails the eligibility check, no collapse occurs for any variant.
 


### PR DESCRIPTION
Implements ADR-069.

The `Styles` field `clipContent` never matched the key the data carries (`clipsContent`), so everything downstream of the declared name has been inert since it shipped:

- the `styles.schema.json` property never validated against emitted output
- the `StyleKey` union member never selected a real style
- the CLI's `clipContent → overflow` mapping never fired, so `overflow: hidden` / `overflow: visible` was never emitted

## What changed

- `Styles.clipContent` → `Styles.clipsContent`, and the matching `StyleKey` union member
- `styles.schema.json` property renamed; description rewritten from the imperative fragment `"Clip content"` to what the boolean means
- CLI `styleToCSS` and `Css.mapping.md` rekeyed
- Docs page renamed `clip-content.md` → `clips-content.md`, with the `styles.md` link and the `collapse-primitive-wrapper.md` reference updated
- Type-level tests added for the boolean/null/`TokenReference` arms, plus a `@ts-expect-error` asserting the old key is gone
- CHANGELOG entries on both schema (Changed + Migration) and CLI

## Notes for review

The ADR treats the construct and the name as two separate decisions rather than assuming a typo fix is only a spelling change:

- **Construct** — the boolean is re-affirmed on Constitution VI rule 1, not rule 3. Four code platforms model clipping as on/off (UIKit, Android View as booleans; SwiftUI, Compose as modifier presence). The three enum platforms don't contradict this: their extra values are scrolling (CSS/RN `scroll`/`auto`) or rasterization quality (Flutter's `antiAlias` family), and the schema can express neither. Filtered to what a design surface produces, all three enums collapse to visible-vs-hidden.
- **Name** — the platforms tie on object-naming vs boundary-naming, so the tiebreak comes from the schema itself: `Styles` defines no `bounds` object, so `clipsToBounds` would point at a term the schema never defines. Verb form follows `visible`/`locked`/`wrap`, which read as state predicates rather than commands.

The result matches Figma's spelling. Every tiebreak was decided on code-platform or in-schema grounds, and each decision records what would have changed it — rule 3 is invoked nowhere.

**No version bump.** This ships within the active release at `0.30.0`; the Semver section states the release version and the change class rather than proposing a bump.

**Not run:** the CLI vitest suite — the worktree has no `node_modules`. No test in `packages/cli` references `styleToCSS` or `overflow`, so there is no existing coverage of the rekeyed lines. Schema gates all pass: `tsc -p tsconfig.build.json`, `validate-schema.sh` (5/5), and `tsc --strict tests/*.test-d.ts`.

Closes ADR-069.
