### PR TITLE
chore: neutral example identifiers

### DIFF
--- a/adr/030-subcomponent-refs.md
+++ b/adr/030-subcomponent-refs.md
@@ -11,7 +11,7 @@
 
 ## Context
 
-When a component contains subcomponents, anatomy items and elements that are instances of those subcomponents currently record `instanceOf` as a plain formatted string (e.g., `"egdsRadioButtonFormLabel"`). This is opaque — a consumer cannot distinguish a subcomponent reference from an arbitrary component name, nor can tooling follow the relationship programmatically.
+When a component contains subcomponents, anatomy items and elements that are instances of those subcomponents currently record `instanceOf` as a plain formatted string (e.g., `"dsRadioButtonFormLabel"`). This is opaque — a consumer cannot distinguish a subcomponent reference from an arbitrary component name, nor can tooling follow the relationship programmatically.
 
 The `$ref` pattern already exists in this package: `ElementTypeRef` uses `{ $ref: string }` on `AnatomyElement.type` to express a machine-followable pointer to an external definition. The same pattern should apply to `instanceOf` when the target is a sibling subcomponent within the same spec.
 

--- a/packages/cli/src/Types/Transformer.ts
+++ b/packages/cli/src/Types/Transformer.ts
@@ -3,7 +3,7 @@ import type { ProcessingStates } from '../transforms/states.js';
 export interface TransformerContext {
   /** Absolute path to the component's output subfolder. */
   outputDir: string;
-  /** camelCase component folder name (e.g. `egdsButton`). */
+  /** camelCase component folder name (e.g. `dsButton`). */
   componentKey: string;
   /** Token format from config.format.tokens. Drives CSS variable resolution. */
   tokensFormat: string;

--- a/packages/cli/src/transforms/Css.mapping.md
+++ b/packages/cli/src/transforms/Css.mapping.md
@@ -15,7 +15,7 @@ Each key in `default.elements` becomes a CSS class:
 | any other | `.{component}__{element-in-kebab}` |
 
 Component and element keys are converted from camelCase to kebab-case:
-`egdsButton` → `.egds-button`, `startVisualAndLabel` → `.egds-button__start-visual-and-label`.
+`dsButton` → `.ds-button`, `startVisualAndLabel` → `.ds-button__start-visual-and-label`.
 
 ---
 
@@ -26,7 +26,7 @@ on the root class:
 
 ```
 configuration: { appearance: outline, state: hover }
-  → .egds-button[data-appearance="outline"][data-state="hover"]
+  → .ds-button[data-appearance="outline"][data-state="hover"]
 ```
 
 Variants are emitted in **schema order** — this is intentional. `variants.yaml` orders
@@ -36,7 +36,7 @@ CSS cascade matching the variant-layering algorithm. Do not reorder.
 Child element overrides under a variant use a descendant selector:
 
 ```css
-.egds-button[data-appearance="outline"] .egds-button__label { ... }
+.ds-button[data-appearance="outline"] .ds-button__label { ... }
 ```
 
 ---

--- a/packages/cli/tests/unit/writers/DataTransformers.test.ts
+++ b/packages/cli/tests/unit/writers/DataTransformers.test.ts
@@ -9,7 +9,7 @@ import {
 describe('splitComponentByConcern', () => {
   it('defaults missing props to {} (regression #84)', () => {
     const { api } = splitComponentByConcern({
-      title: 'egdsDivider',
+      title: 'dsDivider',
       anatomy: {},
       metadata: {},
     });
@@ -82,15 +82,15 @@ describe('splitComponentByConcern — examples concern', () => {
 });
 
 describe('splitComponentByConcern — images registry (ADR-063)', () => {
-  it('routes images into examples and counts as example data — the egdsAvatar case', () => {
+  it('routes images into examples and counts as example data — the dsAvatar case', () => {
     const { api, variants, examples } = splitComponentByConcern({
-      title: 'egdsAvatar',
+      title: 'dsAvatar',
       anatomy: {},
       default: {},
-      images: { egdsAvatar__image: { src: '_images/d54334d2.png' } },
+      images: { dsAvatar__image: { src: '_images/d54334d2.png' } },
       metadata: {},
     });
-    expect(examples.images).toEqual({ egdsAvatar__image: { src: '_images/d54334d2.png' } });
+    expect(examples.images).toEqual({ dsAvatar__image: { src: '_images/d54334d2.png' } });
     expect((api as Record<string, unknown>).images).toBeUndefined();
     expect((variants as Record<string, unknown>).images).toBeUndefined();
     // Images alone must be enough for examples.yaml to be written.

--- a/site/src/content/docs/cli/analyze/keys.md
+++ b/site/src/content/docs/cli/analyze/keys.md
@@ -104,7 +104,7 @@ byCause:
     names:
       - Alternate Half
       - Children minItems
-      - EGDS Bottom Sheet
+      - DS Bottom Sheet
 ```
 
 ### byName


### PR DESCRIPTION
Replaces client-library identifiers with neutral ones across docs, code comments, and test fixtures in this public repo.

| File | Was | Now |
|---|---|---|
| `adr/030-subcomponent-refs.md` | `"egdsRadioButtonFormLabel"` | `"dsRadioButtonFormLabel"` |
| `packages/cli/src/transforms/Css.mapping.md` | `egdsButton`, `.egds-button*` | `dsButton`, `.ds-button*` |
| `packages/cli/src/Types/Transformer.ts` | `egdsButton` (JSDoc) | `dsButton` |
| `packages/cli/tests/unit/writers/DataTransformers.test.ts` | `egdsDivider`, `egdsAvatar`, `egdsAvatar__image` | `dsDivider`, `dsAvatar`, `dsAvatar__image` |
| `site/src/content/docs/cli/analyze/keys.md` | `EGDS Bottom Sheet` | `DS Bottom Sheet` |

No behavior change — identifiers only, in examples and fixtures.

`packages/cli/tests/unit/writers/DataTransformers.test.ts` — 15 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
