### PR TITLE
docs: restore /pro/thankyou order confirmation page

### DIFF
--- a/site/src/content/docs/pro/thankyou.mdx
+++ b/site/src/content/docs/pro/thankyou.mdx
@@ -1,0 +1,41 @@
+---
+title: Thank you for your order
+description: Welcome to Specs 2 Pro. Activate your license, manage your subscription, and find support.
+tableOfContents: false
+head:
+  - tag: style
+    content: ':root{--sl-sidebar-width:0rem}.sidebar-pane{display:none}starlight-menu-button{display:none}.right-sidebar-container{display:none}.main-pane{width:100%}'
+---
+
+Your purchase is complete, and a confirmation email is on its way with your license keys and receipt. Thank you for supporting Specs — your subscription unlocks the full set of Pro features across the Figma plugin and the CLI, and helps fund continued development. If you have any trouble at all, we're here to help.
+
+## Activate your license
+
+A subscription is not the same thing as a license. The subscription is what you bought; the licenses are what it contains — a plugin key and a CLI key per seat, tied to the email address that holds the seat and active for the duration of your billing period. Full terms, including seat counts, renewals, and team licensing, are described in the [licensing overview](/overview/licensing/).
+
+### Individual subscriptions
+
+Check the email sent to the address you used at checkout. It contains your plugin and CLI license keys — paste them into the [Specs 2 plugin](https://www.figma.com/community/plugin/1549454283615386215/specs-2-formerly-anova) and the [CLI](/cli/getting-started/) to activate Pro on each surface. You can retrieve the keys again at any time from your account in the [Polar customer portal](https://polar.sh/directed-edges-llc/portal).
+
+### Team subscriptions
+
+A Teams subscription gives you, the administrator, a pool of seats rather than a set of keys. To hand those seats out, sign in to the [Polar customer portal](https://polar.sh/directed-edges-llc/portal), choose **Manage your subscription**, and then **Invite members** — once for each seat you purchased. Each invited person receives a message with a link to claim their seat, obtain their license, and get started.
+
+Invitations must be claimed within 24 hours, after which they expire and can be re-sent from the portal. Once a team member claims their seat, they receive their own plugin and CLI license key pair by email and activate them exactly as an individual subscriber does.
+
+## Manage your subscription
+
+Use the [Polar customer portal](https://polar.sh/directed-edges-llc/portal) to view receipts, update your payment method, change your billing email, or cancel your subscription. It's also where you download invoices for expensing. Sign in with the email used at checkout — Polar sends you a one-time login link.
+
+All seat management happens in the customer portal alongside the rest of your subscription. You can see which seats are claimed, revoke a seat when someone leaves and reassign it to a new email, and adjust the total seat count up or down at any time. Changes are prorated on your month-to-month invoice — adding a seat mid-cycle adds a partial charge, removing one issues a partial credit, and volume discount tiers re-evaluate automatically whenever your seat count crosses a threshold.
+
+## Get support
+
+Questions, bug reports, and feature requests are all welcome.
+
+- Email [nathan@specsplugin.com](mailto:nathan@specsplugin.com) for anything license- or billing-related.
+- [File an issue on GitHub](https://github.com/DirectedEdges/specs/issues) to report defects or track existing requests.
+
+---
+
+Thanks again — we can't wait to see what you spec.


### PR DESCRIPTION
Restores the post-checkout confirmation page at `/pro/thankyou`, which was lost in the migration from the `specsplugin-com` repo into this repo's site build. Polar's checkout flow points here, so the URL is currently dead.

## What the page does

- **Titled "Thank you for your order"**, opening with a consolidated confirmation: the purchase is complete and a confirmation email with license keys and receipt is on its way.
- **Activate your license** draws the distinction that a subscription is not a license — the subscription contains a plugin key and a CLI key per seat — then splits into:
  - *Individual subscriptions*: keys arrive by email, retrievable again from the Polar customer portal.
  - *Team subscriptions*: the administrator invites members from the portal, once per purchased seat.
- **Manage your subscription** covers the portal itself plus all seat management (claiming, revoking, reassigning, proration).
- **Get support** points at email for billing and `DirectedEdges/specs` issues for defects.

## Notable differences from the original

- Uses a standard left-aligned doc layout rather than the centered splash/hero template, with the left sidebar and table of contents hidden via a page-scoped style — the marketing treatment read wrong for a confirmation page.
- Starlight `CardGrid`/`LinkCard` layouts are replaced with plain link lists.
- Links are site-relative (`/cli/getting-started/`, `/overview/licensing/`) instead of the old `directededges.github.io` absolutes.
- Stale support destinations updated: the Slack invite and `EightShapes/specs-plugin` issues link are replaced, and the Polar link now goes to the real customer portal rather than Polar's docs.
- Specific volume discount percentages are omitted so the numbers live only on the licensing page.

The page has no sidebar entry, so it is reachable only by direct link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
