### PR TITLE
fix: carry Figma dev status through scan and stop dropping manifest rows (#362)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -85,6 +85,21 @@ you emit without saying so.
 - `--split-components`, `--split-concerns` and `--use-subfolders` on `specs generate`,
   replaced by the negative flags above.
 
+### Fixed
+
+- **`scan` records the dev status Figma actually set, including `COMPLETED`** — Every status
+  on a node is carried through to the manifest's Dev Status column verbatim instead of being
+  collapsed to `READY_FOR_DEV` or `NONE`, so a component marked complete is no longer
+  indistinguishable from one nobody has touched. Selection is unchanged: `scan` still checks
+  only `READY_FOR_DEV` rows by default, and `generate` still builds only what is checked.
+- **A manifest row with an unfamiliar dev status is kept and left unselected, not dropped** —
+  The parser previously accepted only two status values and silently discarded any row it
+  could not match, so the component vanished from the run while the summary line still read
+  as healthy. Such a row is now parsed, reported with a warning, and left unchecked.
+- **`scan` and `generate` warn about manifest rows they cannot read** — Any line that looks
+  like a component row but fails to parse now prints a warning naming the row instead of
+  disappearing.
+
 
 ## [0.27.0] - 2026-08-17
 

--- a/packages/cli/src/commands/GenerateCommand.ts
+++ b/packages/cli/src/commands/GenerateCommand.ts
@@ -404,9 +404,14 @@ export const Generate = new Command('generate')
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
-        const { components, metadata } = isV2Manifest
+        const parsed = isV2Manifest
           ? ManifestParserV2.parse(sourceContent)
           : ManifestParser.parse(sourceContent);
+        const { components, metadata } = parsed;
+
+        for (const warning of ('warnings' in parsed ? parsed.warnings : [])) {
+          console.warn(`⚠ ${warning}`);
+        }
 
         if (components.length === 0) {
           console.error('Error: No components found in manifest');

--- a/packages/cli/src/commands/ScanCommand.ts
+++ b/packages/cli/src/commands/ScanCommand.ts
@@ -145,7 +145,9 @@ function readPriorManifest(outputPath: string): ManifestRowV2[] | null {
   }
 
   if (ManifestParserV2.isV2(content)) {
-    return ManifestParserV2.parse(content).components;
+    const { components, warnings } = ManifestParserV2.parse(content);
+    for (const warning of warnings) console.warn(`⚠ ${warning}`);
+    return components;
   }
   return null;
 }

--- a/packages/cli/src/utilities/ComponentDiscovery.ts
+++ b/packages/cli/src/utilities/ComponentDiscovery.ts
@@ -26,7 +26,26 @@ interface RestApiNode {
   devStatus?: { type?: string; description?: string };
 }
 
-export type DevStatus = 'READY_FOR_DEV' | 'NONE';
+/** Dev statuses Figma itself sets, plus 'NONE' for a node with no status. */
+export type KnownDevStatus = 'READY_FOR_DEV' | 'COMPLETED' | 'NONE';
+
+export const KNOWN_DEV_STATUSES: readonly KnownDevStatus[] = ['READY_FOR_DEV', 'COMPLETED', 'NONE'];
+
+/**
+ * A dev status as carried from Figma. Values outside `KnownDevStatus` are passed
+ * through verbatim rather than collapsed, so a status this CLI predates stays visible.
+ */
+export type DevStatus = KnownDevStatus | (string & {});
+
+export function isKnownDevStatus(value: string): value is KnownDevStatus {
+  return (KNOWN_DEV_STATUSES as readonly string[]).includes(value);
+}
+
+/** Normalize a node's devStatus, carrying unknown values through untouched. */
+function readDevStatus(node: RestApiNode): DevStatus {
+  const type = node.devStatus?.type?.trim();
+  return type ? type.toUpperCase() : 'NONE';
+}
 
 /**
  * Minimal structure for REST API file data
@@ -49,7 +68,7 @@ export interface ComponentInfo {
   name: string;
   /** Node type (COMPONENT or COMPONENT_SET) */
   type: string;
-  /** Dev-ready status from Figma. 'NONE' when the property is absent on the node. */
+  /** Dev status from Figma, verbatim. 'NONE' when the property is absent on the node. */
   devStatus: DevStatus;
 }
 
@@ -125,7 +144,7 @@ export class ComponentDiscovery {
           id: node.id,
           name: node.name,
           type: node.type,
-          devStatus: node.devStatus?.type === 'READY_FOR_DEV' ? 'READY_FOR_DEV' : 'NONE'
+          devStatus: readDevStatus(node)
         });
         continue;
       }
@@ -145,7 +164,7 @@ export class ComponentDiscovery {
           id: node.id,
           name: node.name,
           type: node.type,
-          devStatus: node.devStatus?.type === 'READY_FOR_DEV' ? 'READY_FOR_DEV' : 'NONE'
+          devStatus: readDevStatus(node)
         });
       }
     }

--- a/packages/cli/src/utilities/ManifestParserV2.ts
+++ b/packages/cli/src/utilities/ManifestParserV2.ts
@@ -11,7 +11,7 @@
  *   | [ ] | Card | 1:45 | COMPONENT | NONE |
  */
 
-import type { DevStatus } from './ComponentDiscovery.js';
+import { isKnownDevStatus, type DevStatus } from './ComponentDiscovery.js';
 
 export interface ManifestRowV2 {
   id: string;
@@ -31,6 +31,8 @@ export interface ManifestMetadataV2 {
 export interface ManifestResultV2 {
   components: ManifestRowV2[];
   metadata: ManifestMetadataV2;
+  /** One entry per row that could not be parsed or carried an unrecognized status. */
+  warnings: string[];
 }
 
 const SCAN_FORMAT_VERSION_REGEX = /\*\*Scan format version:\*\*\s+(\d+)/m;
@@ -39,8 +41,13 @@ const VARIABLES_HEADER_REGEX = /\*\*Variables:\*\*\s+(.+?)$/m;
 const FILE_LAST_MODIFIED_REGEX = /\*\*File last modified:\*\*\s+(.+?)$/m;
 
 // | [x] | Name | id | TYPE | DEV_STATUS |
+// The status column is open: any token is accepted so a status this CLI does not
+// know is still parsed into a row (unselected) rather than dropping the row.
 const ROW_REGEX =
-  /^\|\s*\[([x ])\]\s*\|\s*(.+?)\s*\|\s*(\d+:\d+)\s*\|\s*(COMPONENT_SET|COMPONENT)\s*\|\s*(READY_FOR_DEV|NONE)\s*\|/i;
+  /^\|\s*\[([x ])\]\s*\|\s*(.+?)\s*\|\s*(\d+:\d+)\s*\|\s*(COMPONENT_SET|COMPONENT)\s*\|\s*([A-Za-z0-9_]+)\s*\|/i;
+
+// Any line whose first cell is a checkbox is meant to be a component row.
+const CHECKBOX_ROW_REGEX = /^\|\s*\[[^\]]*\]\s*\|/;
 
 export class ManifestParserV2 {
   /** Returns true when the content declares scan format version 2 (or higher). */
@@ -66,6 +73,7 @@ export class ManifestParserV2 {
     if (lastModifiedMatch) metadata.fileLastModified = lastModifiedMatch[1].trim();
 
     const components: ManifestRowV2[] = [];
+    const warnings: string[] = [];
     let inComponentsSection = false;
     for (const line of content.split('\n')) {
       const heading = line.match(/^##\s+(.+?)\s*$/);
@@ -75,19 +83,31 @@ export class ManifestParserV2 {
       }
       if (!inComponentsSection) continue;
       const match = line.match(ROW_REGEX);
-      if (!match) continue;
-      const [, checkbox, name, id, type, devStatus] = match;
+      if (!match) {
+        if (CHECKBOX_ROW_REGEX.test(line)) {
+          warnings.push(`Skipped unparseable manifest row: ${line.trim()}`);
+        }
+        continue;
+      }
+      const [, checkbox, name, id, type, rawStatus] = match;
+      const devStatus: DevStatus = rawStatus.toUpperCase();
+      const known = isKnownDevStatus(devStatus);
+      if (!known) {
+        warnings.push(
+          `Unrecognized dev status "${devStatus}" on row ${id} — treating the component as unselected.`
+        );
+      }
       components.push({
         id,
         // `specs scan` escapes pipes in cell values (`escapeCell`: | → \|).
         // Undo that here so names round-trip back to their literal form.
         name: name.trim().replace(/\\\|/g, '|'),
         type: type.toUpperCase() as 'COMPONENT' | 'COMPONENT_SET',
-        included: checkbox.toLowerCase() === 'x',
-        devStatus: devStatus.toUpperCase() as DevStatus
+        included: known && checkbox.toLowerCase() === 'x',
+        devStatus
       });
     }
 
-    return { components, metadata };
+    return { components, metadata, warnings };
   }
 }

--- a/packages/cli/tests/unit/utilities/ComponentDiscovery.test.ts
+++ b/packages/cli/tests/unit/utilities/ComponentDiscovery.test.ts
@@ -200,6 +200,49 @@ describe('ComponentDiscovery', () => {
       expect(discovery.getFileLastModified()).toBe('2026-05-08T17:48:26Z');
     });
 
+    it('should carry non-READY_FOR_DEV statuses through verbatim', async () => {
+      const filePath = path.join(testDir, 'library.json');
+      const data = {
+        name: 'Test Library',
+        document: {
+          id: '0:0',
+          name: 'Document',
+          type: 'DOCUMENT',
+          children: [
+            {
+              id: '1:1',
+              name: 'Page',
+              type: 'CANVAS',
+              children: [
+                {
+                  id: '9313:18494',
+                  name: 'Text Field',
+                  type: 'COMPONENT_SET',
+                  devStatus: { type: 'COMPLETED', description: '' },
+                  children: []
+                },
+                {
+                  id: '9313:18495',
+                  name: 'Future Set',
+                  type: 'COMPONENT_SET',
+                  devStatus: { type: 'in_review' },
+                  children: []
+                }
+              ]
+            }
+          ]
+        }
+      };
+
+      fs.writeJSONSync(filePath, data);
+
+      const discovery = await ComponentDiscovery.fromFile(filePath);
+      const components = discovery.findAllComponents();
+
+      expect(components.find(c => c.id === '9313:18494')?.devStatus).toBe('COMPLETED');
+      expect(components.find(c => c.id === '9313:18495')?.devStatus).toBe('IN_REVIEW');
+    });
+
     it('should exclude variant children from results', async () => {
       const filePath = path.join(testDir, 'library.json');
       const data = {

--- a/packages/cli/tests/unit/utilities/ManifestParserV2.test.ts
+++ b/packages/cli/tests/unit/utilities/ManifestParserV2.test.ts
@@ -81,4 +81,69 @@ describe('ManifestParserV2', () => {
     expect(components[0].name).toBe('Toggle | On/Off');
     expect(components[0].id).toBe('1:23');
   });
+  it('parses COMPLETED rows without warning and preserves the checkbox', () => {
+    const fixture = [
+      '**Scan format version:** 2',
+      '',
+      '## Components',
+      '',
+      '| ✓ | Name | ID | Type | Dev Status |',
+      '|------|------|------|------|------------|',
+      '| [x] | Text Field | 9313:18494 | COMPONENT_SET | COMPLETED |',
+      ''
+    ].join('\n');
+
+    const { components, warnings } = ManifestParserV2.parse(fixture);
+    expect(components).toEqual([
+      {
+        id: '9313:18494',
+        name: 'Text Field',
+        type: 'COMPONENT_SET',
+        included: true,
+        devStatus: 'COMPLETED'
+      }
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps a row with an unrecognized status, unselected, and warns', () => {
+    const fixture = [
+      '**Scan format version:** 2',
+      '',
+      '## Components',
+      '',
+      '| ✓ | Name | ID | Type | Dev Status |',
+      '|------|------|------|------|------------|',
+      '| [x] | Text Field | 9313:18494 | COMPONENT_SET | IN_REVIEW |',
+      ''
+    ].join('\n');
+
+    const { components, warnings } = ManifestParserV2.parse(fixture);
+    expect(components).toHaveLength(1);
+    expect(components[0]).toMatchObject({ id: '9313:18494', devStatus: 'IN_REVIEW', included: false });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('IN_REVIEW');
+  });
+
+  it('warns instead of silently dropping a malformed checkbox row', () => {
+    const fixture = [
+      '**Scan format version:** 2',
+      '',
+      '## Components',
+      '',
+      '| ✓ | Name | ID | Type | Dev Status |',
+      '|------|------|------|------|------------|',
+      '| [x] | Broken | not-an-id | COMPONENT_SET | NONE |',
+      ''
+    ].join('\n');
+
+    const { components, warnings } = ManifestParserV2.parse(fixture);
+    expect(components).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Broken');
+  });
+
+  it('reports no warnings for a clean manifest', () => {
+    expect(ManifestParserV2.parse(V2_FIXTURE).warnings).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

`specs scan` mapped Figma's `devStatus.type` onto a closed two-value set, so `COMPLETED`
became `NONE` and a finished component looked identical to one nobody had touched. The v2
manifest parser then accepted only `READY_FOR_DEV|NONE` in the status column and **dropped**
any row it could not match, so a component could disappear from a run while the
`✓ Loaded manifest: N components (M selected)` line still read as healthy.

Three changes, matching the issue's suggested fix:

- `ComponentDiscovery` carries `devStatus.type` through verbatim (uppercased; `NONE` only
  when the property is absent). `DevStatus` is now `'READY_FOR_DEV' | 'COMPLETED' | 'NONE'`
  widened to accept a status this CLI predates, rather than a closed pair.
- `ManifestParserV2`'s row regex accepts any status token. An unrecognized status keeps the
  row and leaves it **unselected** instead of discarding it.
- `ManifestParserV2.parse` returns `warnings`, which `scan` and `generate` print. A line
  that looks like a component row but fails to parse is now reported, not silently skipped.

**`generate` behavior is unchanged** — default inclusion still checks only `READY_FOR_DEV`,
and `generate` still builds only checked rows. This PR makes the status *visible* and
selectable by hand; it does not widen what gets built.

The two smaller behaviours noted at the end of the issue (shared `library.yaml` overwrites,
renamed-component stale specs) are deliberately not addressed here.

## Test coverage

Unit tests added:
- `ComponentDiscovery` carries `COMPLETED` and an unknown status (`in_review` → `IN_REVIEW`)
  through instead of collapsing them.
- `ManifestParserV2` parses a `COMPLETED` row with no warning and preserves its checkbox.
- An unrecognized status keeps the row, forces `included: false`, and emits a warning.
- A malformed checkbox row produces a warning instead of vanishing.
- A clean manifest reports no warnings.

Full CLI suite: **681 passed, 2 skipped, 0 failed.**

Verified against real workspaces with the built CLI:
- `de-library` (103 components, 27 `READY_FOR_DEV`) — manifest re-scan is identical apart
  from the timestamp; no row or selection changed.
- `ck` (132 components, no dev status anywhere) — identical apart from timestamp and path.
- `eg-roles` (fetched fresh; 3429 components with no status, 68 `READY_FOR_DEV`) — scan
  selected exactly the 68 `READY_FOR_DEV` components.
- A `de-library` copy with nodes flipped to `COMPLETED` and `IN_REVIEW` — `COMPLETED` now
  appears in the Dev Status column (previously `NONE`), and re-scanning over a hand-edited
  `IN_REVIEW` row prints the warning and keeps the row (103 components, not 102).

Closes DirectedEdges/specs#362
