### PR TITLE
ADR-080: `null` as a Prop Configuration Value

### DIFF
--- a/adr/080-null-prop-configuration.md
+++ b/adr/080-null-prop-configuration.md
@@ -1,0 +1,225 @@
+# ADR: `null` as a Prop Configuration Value
+
+**Branch**: `080-null-prop-configuration`
+**Created**: 2026-08-31
+**Status**: DRAFT
+**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+A nullable prop can be unset. `SlotProp`, `StringProp`, `NumberProp`, and `ImageProp`
+default to `nullable: true`, and a slot prop paired with a visibility boolean is
+explicitly marked nullable with `default: null` — the pairing is what makes "no header"
+expressible at all.
+
+`PropConfigurations` cannot say it. `PropConfigurationValue` admits a scalar, a
+`PropBinding`, a `SlotContentRef`, or an `ImageBinding` — but not `null`:
+
+```yaml
+# types/PropConfigurations.ts — current
+PropConfigurationValue:
+  - string
+  - number
+  - boolean
+  - PropBinding
+  - SlotContentRef
+  - ImageBinding
+```
+
+So a configuration can express *which* content fills a slot and never that the slot is
+empty. Producers that have to record an unset nullable prop are pushed into expressing
+it some other way — most commonly by keeping the paired visibility boolean alongside the
+content value:
+
+```yaml
+# A configuration that shows no header, as it can be expressed today
+propConfigurations:
+  header:
+    $slotContent: "#/components/card/slotContentExamples/cardHeader"
+  headerVisible: false
+```
+
+Two things are wrong with that. The boolean is not a prop of the component being
+configured — `PropPairings` folds it into the content prop and removes it from `props`,
+so the configuration names a prop that the API does not have. And the content value and
+the boolean disagree: the slot is bound and hidden at the same time, leaving every
+consumer to decide which half to believe. A consumer reading only the props it knows
+sees a bound slot, and renders content the design does not show.
+
+The gap is narrow and structural: the prop is nullable, the configuration type is not.
+
+---
+
+## Decision Drivers
+
+- **A configuration says what a prop is set to** — including `null`, when the prop is
+  nullable. Nothing outside the value should have to be consulted to know that.
+- **One value carries the whole meaning** — a configuration must not need a second,
+  paired key to be interpreted, and must never name a prop absent from `props`.
+- **No platform-specific reads** — a consumer must not resolve a configuration by
+  reading `$extensions`. Producer metadata explains provenance; it never carries meaning
+  a consumer needs.
+- **Layering must survive the round trip** — configurations layer, so an unset must be
+  expressible as a value that overrides an inherited one. Absence already means "inherit";
+  it cannot also mean "unset".
+- **Additive only** — no existing document may become invalid.
+- **Type ↔ schema parity** — every type arm has a schema arm.
+
+---
+
+## Options Considered
+
+*(Pre-decided — no alternatives evaluated.)*
+
+The decision follows from the nullable prop itself: a prop typed `nullable: true` with
+`default: null` has `null` in its value domain, and a configuration that selects a value
+for that prop must be able to select that one. No alternative was weighed, because any
+other encoding reintroduces the second key this ADR exists to remove.
+
+---
+
+## Decision
+
+Widen `PropConfigurationValue` to admit `null`.
+
+`null` under a prop key means the prop is **unset** in this configuration. It is a value,
+not an absence: an absent key inherits, a `null` key overrides an inherited value with
+"no value".
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `PropConfigurations.ts` | Added `null` arm to `PropConfigurationValue` | MINOR |
+
+**Example — new shape** (`types/PropConfigurations.ts`):
+
+```yaml
+# Before
+PropConfigurationValue:
+  - string
+  - number
+  - boolean
+  - PropBinding
+  - SlotContentRef
+  - ImageBinding
+
+# After
+PropConfigurationValue:
+  - string
+  - number
+  - boolean
+  - "null"          # the prop is unset in this configuration
+  - PropBinding
+  - SlotContentRef
+  - ImageBinding
+```
+
+The configuration above becomes a single key, with no boolean beside it:
+
+```yaml
+# A configuration that shows no header
+propConfigurations:
+  header: null
+
+# A configuration that shows one
+propConfigurations:
+  header:
+    $slotContent: "#/components/card/slotContentExamples/cardHeader"
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Added `{ "type": "null" }` arm to `#/definitions/PropConfigurationValue` | MINOR |
+
+**Example — new shape** (`schema/component.schema.json`):
+
+```yaml
+# #/definitions/PropConfigurationValue
+oneOf:
+  - type: string
+  - type: number
+  - type: boolean
+  - type: "null"        # new arm — the prop is unset in this configuration
+  - $ref: "#/definitions/PropBinding"
+  - $ref: "#/definitions/SlotContentRef"
+  - $ref: "#/definitions/ImageBinding"
+```
+
+### Notes
+
+**Where the value may appear.** `null` is admissible under any prop key whose prop is
+nullable, in every position `PropConfigurations` occupies:
+
+- `Element.propConfigurations` — a nested instance
+- `InstanceExample.propConfigurations` — a whole-component example
+- `Variant.configuration` — a variant's own configuration
+- `NestedPropConfiguration` — a path-addressed descendant (`$nested`)
+
+**Layering.** Configurations layer, and `null` layers as a value. A base that binds a
+slot and a layer that sets it `null` resolves to unset; the reverse resolves to bound. A
+layer that omits the key inherits whatever the base carried. This is the property that
+makes an unset expressible per-variant, and it is why absence and `null` must stay
+distinct.
+
+**Validity.** `null` under a non-nullable prop is not meaningful. This ADR does not add
+cross-field validation to express that — the schema types the value domain, and prop
+nullability continues to be described by the prop itself.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes.
+- **Parity check**: The `null` arm of the `PropConfigurationValue` union in
+  `types/PropConfigurations.ts` maps to the `{ "type": "null" }` member of the `oneOf` at
+  `#/definitions/PropConfigurationValue` in `schema/component.schema.json`. No other type
+  or schema definition changes; `PropConfigurations` and `NestedPropConfiguration`
+  reference the widened value type and inherit the new arm.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Can emit an unset nullable prop as a value, and stop emitting a paired visibility boolean alongside a content value | Consolidate the paired boolean into the content prop before emitting; emit `null` when unset |
+| `specs-cli` | Reads configurations when producing code artifacts | Treat a `null` configuration as "prop unset" — no content — rather than skipping the key |
+| `specs-plugin-2` | Reads and renders configurations | Recompile; treat `null` as unset when applying a configuration |
+
+Consumers that layer configurations MUST distinguish an absent key from a `null` one:
+absent inherits, `null` overrides with unset.
+
+---
+
+## Semver Decision
+
+**Version**: `0.31.0` (release branch `release/schema-0.31.0+cli-0.28.0`) — **MINOR**.
+
+**Justification**: The change adds an arm to a union type and a member to a schema
+`oneOf`. Every document valid before remains valid, and no field is renamed, removed, or
+changed in presence — additive per the constitution's versioning rule ("`MINOR` for
+additive types or new optional fields").
+
+---
+
+## Consequences
+
+- A configuration can state that a nullable prop is unset, in every position
+  `PropConfigurations` appears.
+- A content prop paired with a visibility boolean is expressible as one key. Producers
+  can stop emitting the boolean, which was never a prop of the component being configured.
+- Consumers no longer need `$extensions` to interpret a configuration — the value is the
+  whole meaning.
+- Absence and `null` are now semantically distinct in layered configurations: absent
+  inherits, `null` overrides with unset. Consumers that treated a missing key and an
+  empty value alike must separate them.
+- Documents produced before this ADR remain valid, and may still carry a paired boolean
+  beside a content value. Producers are expected to stop writing that shape; readers
+  that encounter it should prefer the content value.

--- a/adr/080-null-prop-configuration.md
+++ b/adr/080-null-prop-configuration.md
@@ -2,7 +2,7 @@
 
 **Branch**: `080-null-prop-configuration`
 **Created**: 2026-08-31
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Summary**: A `null` prop configuration value joins the scalars, `PropBinding`, `SlotContentRef` and `ImageBinding` a configuration already carries.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*

--- a/adr/080-null-prop-configuration.md
+++ b/adr/080-null-prop-configuration.md
@@ -3,7 +3,7 @@
 **Branch**: `080-null-prop-configuration`
 **Created**: 2026-08-31
 **Status**: DRAFT
-**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Summary**: A `null` prop configuration value joins the scalars, `PropBinding`, `SlotContentRef` and `ImageBinding` a configuration already carries.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 
@@ -95,6 +95,7 @@ not an absence: an absent key inherits, a `null` key overrides an inherited valu
 | File | Change | Bump |
 |------|--------|------|
 | `PropConfigurations.ts` | Added `null` arm to `PropConfigurationValue` | MINOR |
+| `InstanceExample.ts` | Added `null` arm to the inline value union on `propConfigurations` | MINOR |
 
 **Example — new shape** (`types/PropConfigurations.ts`):
 
@@ -137,6 +138,7 @@ propConfigurations:
 | File | Change | Bump |
 |------|--------|------|
 | `component.schema.json` | Added `{ "type": "null" }` arm to `#/definitions/PropConfigurationValue` | MINOR |
+| `component.schema.json` | Added `{ "type": "null" }` arm to `#/definitions/InstanceExample/properties/propConfigurations/additionalProperties` | MINOR |
 
 **Example — new shape** (`schema/component.schema.json`):
 
@@ -155,12 +157,18 @@ oneOf:
 ### Notes
 
 **Where the value may appear.** `null` is admissible under any prop key whose prop is
-nullable, in every position `PropConfigurations` occupies:
+nullable, in every position a prop configuration occupies:
 
 - `Element.propConfigurations` — a nested instance
-- `InstanceExample.propConfigurations` — a whole-component example
 - `Variant.configuration` — a variant's own configuration
 - `NestedPropConfiguration` — a path-addressed descendant (`$nested`)
+- `InstanceExample.propConfigurations` — a whole-component example
+
+The first three reference `PropConfigurations`, and inherit the widened value type.
+`InstanceExample.propConfigurations` does **not**: it declares its own inline union so it
+can exclude `PropBinding` (ADR-048 — an example is a documented configuration, not a live
+binding). That union is widened separately and by hand. It gains `null` and keeps its
+exclusion of `PropBinding`.
 
 **Layering.** Configurations layer, and `null` layers as a value. A base that binds a
 slot and a layer that sets it `null` resolves to unset; the reverse resolves to bound. A

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 080 | `null` as a Prop Configuration Value | |
 | 079 | `metadata.conventions` Carries Only the Producing Platform | (reserved, draft in PR #363) |
 | 078 | One Conventions File per Platform, in `config/conventions/` | (reserved, draft in PR #363) |
 | 077 | The Image Component's Code Name, and the Encoding / Vocabulary Boundary | (reserved, draft in PR #363) |
@@ -24,6 +23,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 080 | `null` as a Prop Configuration Value | Adds a `null` arm to `PropConfigurationValue` and to `InstanceExample.propConfigurations`; absent inherits, `null` overrides with unset |
 | 071 | Separate Library Conventions from Tooling Settings | `Conventions`, `Settings` and `Pipeline` replace `Config`, separating library facts from run choices and declared work |
 | 069 | Rename `clipContent` to `clipsContent` | Renames the clip flag to the key the data carries, so container clipping and CSS `overflow` resolve for the first time |
 | 066 | Lossless Key Formatting — Safe Key Grammar and Figma Name Preservation | Adds opt-in `format.figmaKeys` (`NONE` default), a safe key grammar, and `com.figma.name` on anatomy and props; renames `originalName` |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -11,6 +11,8 @@ Configuration now separates what is true about a Figma library from what a run c
 
 ### Added
 
+- `PropConfigurationValue` — a `null` arm; a configuration states a nullable prop is unset, and an absent key inherits while `null` overrides (ADR-080)
+- `InstanceExample.propConfigurations` — accepts `null`, so an example can leave a prop unset; still refuses `PropBinding`
 - `NumberProp.enum` — the closed set of values a numeric prop accepts, so a Figma VARIANT whose options are all numbers carries its numeric type and its authored option order at once (ADR-072)
 - `Conventions` — facts about the Figma library, namespaced by source under `figma`; blocks are optional and their absence means the library declares no such convention
 - `Settings` — run choices grouped by concern (`data`, `spec`, `assets`), each carrying its own `directory`

--- a/packages/schema/schema/component.schema.json
+++ b/packages/schema/schema/component.schema.json
@@ -91,7 +91,7 @@
         },
         "propConfigurations": {
           "type": "object",
-          "description": "Prop values for this example. Scalar types for scalar props; SlotContentRef for slot props. PropBinding is not permitted here.",
+          "description": "Prop values for this example. Scalar types for scalar props; SlotContentRef for slot props; null when the prop is unset in this example (ADR-080). PropBinding is not permitted here.",
           "additionalProperties": {
             "oneOf": [
               {
@@ -102,6 +102,9 @@
               },
               {
                 "type": "boolean"
+              },
+              {
+                "type": "null"
               },
               {
                 "$ref": "#/definitions/SlotContentRef"
@@ -528,7 +531,7 @@
       ]
     },
     "PropConfigurationValue": {
-      "description": "The value of a single prop configuration entry (ADR-049): a scalar, a PropBinding for pass-through to a parent prop, a SlotContentRef under a slot-prop key for a named slot-content fill, or an ImageBinding under an image-prop key forwarding an image into a nested image instance (ADR-063).",
+      "description": "The value of a single prop configuration entry (ADR-049): a scalar, a PropBinding for pass-through to a parent prop, a SlotContentRef under a slot-prop key for a named slot-content fill, or an ImageBinding under an image-prop key forwarding an image into a nested image instance (ADR-063), or null when the prop is unset in this configuration \u2014 a value, not an absence: an absent key inherits, a null key overrides an inherited value with no value (ADR-080).",
       "oneOf": [
         {
           "type": "string"
@@ -538,6 +541,9 @@
         },
         {
           "type": "boolean"
+        },
+        {
+          "type": "null"
         },
         {
           "$ref": "#/definitions/PropBinding"

--- a/packages/schema/tests/PropConfigurations.test-d.ts
+++ b/packages/schema/tests/PropConfigurations.test-d.ts
@@ -1,0 +1,81 @@
+/**
+ * Type-level tests for `PropConfigurationValue`'s `null` arm (ADR-080).
+ *
+ * `null` means the prop is unset in this configuration — a value, not an
+ * absence. These files are intentionally never executed; they are compiled
+ * with tsc to assert the type shape is correct.
+ */
+import type {
+  PropConfigurationValue,
+  PropConfigurations,
+  NestedPropConfiguration,
+  Element,
+  InstanceExample,
+  Variant,
+} from '../types/index.js';
+
+// ─── null is a PropConfigurationValue ───────────────────────────────────────
+
+const unset: PropConfigurationValue = null;
+const scalar: PropConfigurationValue = 'Surface';
+const flag: PropConfigurationValue = false;
+const count: PropConfigurationValue = 3;
+const bound: PropConfigurationValue = { $binding: '#/props/label' };
+const filled: PropConfigurationValue = {
+  $slotContent: '#/components/card/slotContentExamples/cardHeader',
+};
+
+// A value union member that was never valid stays invalid.
+// @ts-expect-error: undefined is not a PropConfigurationValue — an absent key is
+// how a configuration says nothing, and it is not the same as an explicit null.
+const absent: PropConfigurationValue = undefined;
+
+// ─── null under a prop key, in every position PropConfigurations occupies ───
+
+// A configuration that leaves a nullable slot unset.
+const unsetSlot: PropConfigurations = { header: null };
+
+// The same prop, set.
+const setSlot: PropConfigurations = {
+  header: { $slotContent: '#/components/card/slotContentExamples/cardHeader' },
+};
+
+// Element — a nested instance.
+const element: Element = {
+  instanceOf: 'card',
+  propConfigurations: { header: null, bordered: 'Solid' },
+};
+
+// InstanceExample — a whole-component example.
+const example: InstanceExample = {
+  title: 'Card without a header',
+  propConfigurations: { header: null },
+};
+
+// Variant.configuration.
+const variant: Variant = {
+  configuration: { header: null },
+};
+
+// NestedPropConfiguration — a path-addressed descendant ($nested).
+const nested: NestedPropConfiguration = {
+  path: ['contentContainer', 'badge'],
+  children: null,
+};
+
+const withNested: PropConfigurations = { $nested: [nested] };
+
+// ─── Layering: absent and null are distinct ─────────────────────────────────
+
+// A base that binds the slot.
+const base: PropConfigurations = {
+  header: { $slotContent: '#/components/card/slotContentExamples/cardHeader' },
+};
+
+// A layer that unsets it — an explicit value, which overrides.
+const overridesWithUnset: PropConfigurations = { header: null };
+
+// A layer that omits it — inherits whatever the base carried.
+const inherits: PropConfigurations = { bordered: 'Solid' };
+
+export type {};

--- a/packages/schema/tests/SlotContentExamples.test.ts
+++ b/packages/schema/tests/SlotContentExamples.test.ts
@@ -166,6 +166,18 @@ describe('PropConfigurations.$nested structural conformance (ADR-052)', () => {
     );
   });
 
+  it('PropConfigurationValue admits null — the prop is unset in this configuration (ADR-080)', () => {
+    const kinds = (schema.definitions.PropConfigurationValue.oneOf as any[]).map((s) => s.type ?? s.$ref);
+    expect(kinds).toContain('null');
+  });
+
+  it('InstanceExample.propConfigurations admits null, and still refuses PropBinding (ADR-080)', () => {
+    const value = schema.definitions.InstanceExample.properties.propConfigurations.additionalProperties;
+    const kinds = (value.oneOf as any[]).map((s) => s.type ?? s.$ref);
+    expect(kinds).toContain('null');
+    expect(kinds).not.toContain('#/definitions/PropBinding');
+  });
+
   it('NestedPropConfiguration requires path (array of strings, minItems 1)', () => {
     expect(nestedDef.required).toContain('path');
     expect(nestedDef.properties.path.type).toBe('array');

--- a/packages/schema/types/InstanceExample.ts
+++ b/packages/schema/types/InstanceExample.ts
@@ -17,10 +17,11 @@ export type InstanceExample = {
 
   /**
    * Prop values for this example. Scalar types for scalar props;
-   * `SlotContentRef` (into `Component.slotContentExamples`) for slot props.
+   * `SlotContentRef` (into `Component.slotContentExamples`) for slot props;
+   * `null` when the prop is unset in this example (ADR-080).
    * `PropBinding` is not permitted here.
    */
-  propConfigurations?: Record<string, string | number | boolean | SlotContentRef>;
+  propConfigurations?: Record<string, string | number | boolean | null | SlotContentRef>;
 };
 
 /**

--- a/packages/schema/types/PropConfigurations.ts
+++ b/packages/schema/types/PropConfigurations.ts
@@ -6,6 +6,10 @@ import { ImageBinding } from "./Image.js";
  * The value of a single prop configuration entry (ADR-049).
  *
  * - Scalar values (`string | number | boolean`) — static prop values.
+ * - `null` — the prop is **unset** in this configuration (ADR-080). A value, not
+ *   an absence: an absent key inherits from the layer beneath, a `null` key
+ *   overrides an inherited value with "no value". Meaningful only under a
+ *   nullable prop.
  * - `PropBinding` — pass-through binding to a parent prop, e.g.
  *   `{ $binding: "#/props/label" }`. Forwards a parent prop value into a
  *   nested instance's prop.
@@ -21,6 +25,7 @@ export type PropConfigurationValue =
   | string
   | number
   | boolean
+  | null
   | PropBinding
   | SlotContentRef
   | ImageBinding;

--- a/site/src/content/docs/schema/instance-examples.md
+++ b/site/src/content/docs/schema/instance-examples.md
@@ -11,7 +11,7 @@ An `InstanceExample` is a pre-configured usage of a *whole* component — a docu
 ```ts
 type InstanceExample = {
   title?: string;
-  propConfigurations?: Record<string, string | number | boolean | SlotContentRef>;
+  propConfigurations?: Record<string, string | number | boolean | null | SlotContentRef>;
 };
 
 type InstanceExamples = Record<string, InstanceExample>;
@@ -22,9 +22,24 @@ type InstanceExamples = Record<string, InstanceExample>;
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `title` | `string` | No | Human-readable label for this example |
-| `propConfigurations` | `Record<string, string \| number \| boolean \| `[`SlotContentRef`](/schema/slot-content-ref/)`>` | No | Prop values — scalars for scalar props, a `SlotContentRef` for slot props |
+| `propConfigurations` | `Record<string, string \| number \| boolean \| null \| `[`SlotContentRef`](/schema/slot-content-ref/)`>` | No | Prop values — scalars for scalar props, a `SlotContentRef` for slot props, `null` for a prop this example leaves unset |
 
 A [`PropBinding`](/schema/prop-binding/) is **not** permitted in `propConfigurations` — an instance example is a static configuration, not a binding.
+
+`null` under a prop key means the example leaves that prop unset (since 0.31.0). An example that shows no header says so with the header prop itself, rather than with a separate flag beside it:
+
+```yaml
+instanceExamples:
+  cardWithHeader:
+    title: Card with a header
+    propConfigurations:
+      header:
+        $slotContent: "#/components/card/slotContentExamples/cardHeader"
+  cardWithoutHeader:
+    title: Card without a header
+    propConfigurations:
+      header: null
+```
 
 Slot fills encountered inside an example instance are contributed to the shared [`slotContentExamples`](/schema/slot-content/) registry (de-duplicated against existing entries), so an `InstanceExample` holds no slot content of its own — only a `SlotContentRef` into that registry.
 

--- a/site/src/content/docs/schema/prop-configurations.md
+++ b/site/src/content/docs/schema/prop-configurations.md
@@ -8,18 +8,37 @@ A flat map of prop names to the values they must hold for a condition to apply, 
 ```ts
 type PropConfigurations = Record<
   string,
-  string | number | boolean | PropBinding | CompositionRef | ImageBinding
+  string | number | boolean | null | PropBinding | CompositionRef | ImageBinding
 >;
 ```
 
 | Arm | Where it applies | Description |
 |-----|------------------|-------------|
 | `string \| number \| boolean` | Anywhere `PropConfigurations` is used | Static scalar prop value |
+| `null` | Anywhere `PropConfigurations` is used, under a nullable prop | The prop is unset in this configuration (since 0.31.0) |
 | `PropBinding` (`{ $binding }`) | `Element.propConfigurations` only | Pass-through binding to a parent prop |
 | `CompositionRef` (`{ $composition }`) | `Element.propConfigurations` only, under a slot-prop key | JSON Pointer to a named `Composition` (in `Component.slotContent` or in an external composition file) used to fill a nested instance's slot |
 | `ImageBinding` (`{ $binding, examples? }`) | `Element.propConfigurations` only, under an image-prop key | Forwards a parent image prop into a nested image instance's source prop, carrying authoring-default example images (since 0.28.0) |
 
-`InstanceExample.propConfigurations` is scalar-only by design — `PropBinding` and `CompositionRef` are not permitted there.
+`InstanceExample.propConfigurations` accepts scalars, `null`, and slot-content references — `PropBinding` is not permitted there.
+
+## Unset props
+
+`null` means the prop is **unset** in this configuration. It is a value, not an absence, and the distinction matters because configurations layer:
+
+- an **absent** key inherits whatever the layer beneath it set
+- a **`null`** key overrides an inherited value with "no value"
+
+A nullable prop is therefore fully described by its own key. Nothing beside it — a paired visibility flag, a producer extension — needs to be read to know whether the prop is set:
+
+```yaml
+# The header slot is filled
+header:
+  $slotContent: "#/components/card/slotContentExamples/cardHeader"
+
+# The header slot is unset — this component shows no header
+header: null
+```
 
 ## Usage
 
@@ -28,7 +47,7 @@ PropConfigurations appear in four places:
 - **Variant `configuration`** — declares which prop combination activates a [variant](/schema/variants.md/#variant). When all listed props match their specified values, the variant's overrides are applied.
 - **`invalidVariantCombinations`** — an array on the [Component](/schema/component/) root that declares prop combinations which should never occur together.
 - **`Element.propConfigurations`** — sets prop values on a nested instance element; accepts the full union (scalars, `PropBinding`, `CompositionRef`).
-- **`InstanceExample.propConfigurations`** — documents a complete scalar-prop configuration; scalars only.
+- **`InstanceExample.propConfigurations`** — documents a complete configuration; scalars, `null`, and slot-content references.
 
 ## Example
 


### PR DESCRIPTION
Draft ADR widening `PropConfigurationValue` to admit `null`, so a configuration can state that a nullable prop is unset.

## Why

A nullable prop can be unset; a configuration cannot say so. `PropConfigurationValue` admits a scalar, a `PropBinding`, a `SlotContentRef`, or an `ImageBinding` — not `null`. Producers that need to record an unset nullable prop keep the paired visibility boolean beside the content value:

```yaml
propConfigurations:
  header:
    $slotContent: "#/components/card/slotContentExamples/cardHeader"
  headerVisible: false
```

Two problems with that shape:

- The boolean is not a prop of the component being configured — prop pairing folds it into the content prop and removes it from `props`.
- The content value and the boolean disagree: the slot is bound and hidden at once, and every consumer has to pick a half to believe.

## What changes

- `types/PropConfigurations.ts` — add a `null` arm to `PropConfigurationValue` (MINOR)
- `schema/component.schema.json` — add `{ "type": "null" }` to `#/definitions/PropConfigurationValue` (MINOR)

`null` under a prop key means the prop is unset in that configuration. It is a value, not an absence.

## Layering

Configurations layer, so the distinction is load-bearing:

- an **absent** key inherits from the base
- a **`null`** key overrides an inherited value with unset

Consumers that treated a missing key and an empty value alike must separate them.

## Status

DRAFT — Options section marked pre-decided; the decision follows from the nullable prop itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)