### PR TITLE
ADR-081: A default example width on `conventions.figma`

### DIFF
--- a/adr/081-default-example-width.md
+++ b/adr/081-default-example-width.md
@@ -1,0 +1,261 @@
+# ADR: A Default Example Width on `conventions.figma`
+
+**Branch**: `081-default-example-width`
+**Created**: 2026-08-31
+**Status**: DRAFT
+**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+Anything that *renders* a spec has to choose a width. A Figma frame written from a spec
+needs a frame width before its children can lay out. A generated Storybook story needs a
+canvas width before a `100%` root fills anything. A screenshot or visual-diff harness
+needs one before it can produce a stable image.
+
+The spec does not say what that width should be, so each consumer invents one. Storybook
+falls back to its own default viewport, a renderer picks a frame width, a harness picks
+whatever the last person hardcoded. For a library authored at a mobile width, the results
+diverge sharply from the design:
+
+- A root container with `layoutSizingHorizontal: FILL` stretches to whatever the host
+  chose, so a card designed edge-to-edge at 375 renders 1200 wide.
+- Text that wraps to two lines in the library renders on one, and the vertical rhythm the
+  component was designed around disappears.
+- Two consumers reading the *same* library produce different output from the same spec,
+  and neither is wrong by any rule the spec states.
+
+The width is not a per-run preference. It is a fact about how the library was authored —
+the same value for every consumer that reads it, and a *different* value produces output
+that misrepresents the design rather than merely styling it differently. That is the exact
+test ADR-071 used to separate `Conventions` from `Settings`:
+
+> Every consumer reading the same library declares the same values. Differing values
+> produce **incorrect** output rather than merely different output.
+
+`Conventions.figma` already collects facts of this kind — `naming`, `glyphs.match`,
+`instanceExamples.scope`. It has no member for the width the library's components and
+examples are drawn at.
+
+---
+
+## Decision Drivers
+
+- **Library fact, not run choice**: the value must live where every consumer of a library
+  reads the same number. A per-run setting lets two consumers disagree about the same
+  library, which is the failure mode `Conventions` exists to prevent (ADR-071).
+- **Additive only**: no rename, no removal, no change of presence — the release must stay
+  MINOR for downstream consumers.
+- **Absence is meaningful**: a library that declares no width must remain expressible, and
+  must not be forced to adopt an invented default.
+- **Type ↔ schema symmetry** (Constitution I): every type change carries its schema
+  counterpart.
+- **No logic in this package** (Constitution II): the schema types the value; it does not
+  compute or resolve a width.
+- **Naming without abbreviation, code platforms first** (Constitution VI): the name must
+  read the same to a renderer author and a story generator.
+
+---
+
+## Options Considered
+
+### Option A: `conventions.figma.defaultExampleWidth` *(Selected)*
+
+An optional `number` on the existing `figma` block, in Figma pixel units.
+
+```yaml
+# config/conventions.yaml
+figma:
+  naming: SENTENCE
+  defaultExampleWidth: 375
+```
+
+**Pros**:
+- Sits with the other authoring facts about the library, where a consumer already looks
+  when it needs to know how the library is drawn.
+- Additive and optional — MINOR, and absence keeps its meaning: the library declares no
+  width, so the consumer uses its own.
+- One number, one meaning. Every consumer that renders the library renders it the same
+  width without coordinating out of band.
+
+**Cons / Trade-offs**:
+- The value is consumed well outside Figma — a Storybook viewport, a screenshot harness —
+  while living under a `figma` namespace. The namespace records *where the fact came
+  from*, not who is allowed to read it, which is already true of `naming` and
+  `instanceExamples`.
+
+---
+
+### Option B: `settings.render.width` *(Rejected)*
+
+Put the width with the run choices, alongside the other things a caller tunes per
+invocation.
+
+**Rejected because**: it violates the first driver, and re-opens the split ADR-071 closed.
+A setting is a choice a run is free to make differently; this is not. Two consumers of one
+library choosing different widths do not produce two valid renderings — one of them
+produces a component that does not look like the design. The width belongs where the
+library states it once.
+
+---
+
+### Option C: A top-level `conventions.defaultExampleWidth` *(Rejected)*
+
+Hoist the width out of `figma` to the root of `Conventions`, on the grounds that it is
+consumed by non-Figma tooling.
+
+**Rejected because**: `Conventions` is namespaced by the source the facts were observed in,
+and `figma` is currently its only member. A bare member at the root creates a second,
+unnamed category whose membership rule is "read by more than one platform" — a rule that
+would eventually reclassify `naming` and `instanceExamples` too. The width *is* an
+observation about the Figma library; that other tools consume it is true of nearly every
+member of the block.
+
+---
+
+### Option D: A structural `defaultExampleSize { width, height }` *(Rejected)*
+
+Carry both dimensions so a renderer can size a frame outright.
+
+**Rejected because**: it over-specifies. In every layout the schema models, height follows
+from content once width is fixed — a declared height either matches what the content
+produces, in which case it is redundant, or contradicts it, in which case a renderer has
+to decide which to believe. Width is the only free dimension.
+
+---
+
+## Decision
+
+Add one optional member to the `figma` block of `Conventions`, and its counterpart in
+`ResolvedConventions` and `conventions.schema.json`.
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Conventions.ts` | Added optional field `figma.defaultExampleWidth?: number` to `Conventions` | MINOR |
+| `Conventions.ts` | Added optional field `figma.defaultExampleWidth?: number` to `ResolvedConventions` | MINOR |
+
+**Example — new shape** (`types/Conventions.ts`):
+```yaml
+# Before
+Conventions:
+  figma:
+    naming?: 'NONE' | 'SENTENCE' | 'TITLE'
+    glyphs?: { match: string }
+    # …
+    inferNumberProps?: boolean
+    states?: Record<string, VariantStateEntry>
+
+# After
+Conventions:
+  figma:
+    naming?: 'NONE' | 'SENTENCE' | 'TITLE'
+    glyphs?: { match: string }
+    # …
+    inferNumberProps?: boolean
+    states?: Record<string, VariantStateEntry>
+    defaultExampleWidth?: number   # optional — MINOR
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `conventions.schema.json` | Added property `defaultExampleWidth` under `#/definitions/Conventions/properties/figma/properties` | MINOR |
+
+**Example — new shape** (`schema/conventions.schema.json`):
+```yaml
+# New property under #/definitions/Conventions/properties/figma/properties
+defaultExampleWidth:
+  type: number
+  exclusiveMinimum: 0
+  description: >-
+    Width in pixels the library's components and examples are authored at, and the
+    width a consumer renders them at by default. Absence means the library declares
+    no width and the consumer uses its own.
+  # not in required[] — optional field
+```
+
+### Notes
+
+**Optional, with no default.** `defaultExampleWidth` is absent from
+`DEFAULT_CONVENTIONS` and stays optional in `ResolvedConventions`. This follows the rule
+`Conventions` already states: only members with a *meaningful* default appear in the
+defaults constant. There is no universal width — 375 is a choice a library makes, not a
+fact about libraries — so inventing one in the schema would hand every consumer a number
+no library declared. Absence keeps its established meaning: the library declares no such
+convention, and the capability it enables (rendering at the library's own width) does not
+apply.
+
+**Positive number.** `exclusiveMinimum: 0` rules out zero and negatives, which are not
+widths. No upper bound is imposed; the schema does not know what canvas a consumer renders
+onto.
+
+**Pixels.** The unit is the Figma pixel, matching every other dimension the schema carries
+(`Styles` sizing, `PositionOffset`). No unit member is added — a second way to express the
+same number is a second thing for consumers to disagree about.
+
+**Naming** (Constitution VI, rule 2). No code-platform consensus term exists: Storybook
+expresses this as a viewport parameter, CSS has no equivalent, and iOS and Android express
+it as a device size. With no consensus, the name is drawn from this schema's own
+vocabulary — `instanceExamples`, `slotContentExamples`, and `propConfigurations` already
+establish "example" as the word for a rendered instance of a component. `default` marks it
+as the fallback a consumer may override for a given render. No abbreviations.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes.
+- **Parity check**: `Conventions['figma']['defaultExampleWidth']` in
+  `types/Conventions.ts` maps to
+  `#/definitions/Conventions/properties/figma/properties/defaultExampleWidth` in
+  `schema/conventions.schema.json`. `ResolvedConventions['figma']['defaultExampleWidth']`
+  has no separate schema definition, matching every other member of
+  `ResolvedConventions` — the resolved shape is a compile-time contract for consumers,
+  and only the authored shape is validated. No other type or schema definition changes.
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-cli` | Reads `config/conventions.yaml` and passes conventions to the engine; generates stories and other rendered artifacts | Accept and pass through the new key; add it to the `conventions.yaml` template; apply it as the default width for generated rendered output |
+| `specs-from-figma` | Consumes conventions when producing specs, and renders specs onto the Figma canvas | Recompile; use the declared width as the default frame width when rendering, and as the fallback when no width is given for the render |
+| `specs-plugin-2` | Reads conventions and renders components and examples on the canvas | Recompile; render at the declared width by default |
+
+Consumers MUST treat absence as "no declared width" and fall back to their own default —
+not to a hardcoded 375. A declared width is a default, not a constraint: a consumer given
+an explicit width for a particular render uses that instead.
+
+---
+
+## Semver Decision
+
+**Version**: `0.31.0` (release branch `release/schema-0.31.0+cli-0.28.0`) — **MINOR**.
+
+**Justification**: The change adds one optional field to an existing interface and one
+optional property to an existing schema object. Every document valid before remains valid,
+and no field is renamed, removed, or changed in presence — additive per the constitution's
+versioning rule ("`MINOR` for additive types or new optional fields").
+
+---
+
+## Consequences
+
+- A library can state the width its components and examples are authored at, once, and
+  every consumer that renders them uses the same number.
+- Rendered output stops depending on which tool produced it. A spec rendered to a Figma
+  frame and the same spec rendered into a Storybook story lay out at the same width.
+- A mobile-first library is expressible. `defaultExampleWidth: 375` is the difference
+  between a card that renders as designed and one that stretches across a desktop canvas.
+- Consumers that currently hardcode a render width must prefer the declared value when one
+  is present, and keep their hardcoded value only as the absent-case fallback.
+- `Conventions.figma` now carries a member that is not about *detecting* something in the
+  Figma file, but about *reproducing* it. Future render-time facts have a precedent to
+  follow, and a name to sit beside.

--- a/adr/081-default-example-width.md
+++ b/adr/081-default-example-width.md
@@ -3,7 +3,7 @@
 **Branch**: `081-default-example-width`
 **Created**: 2026-08-31
 **Status**: DRAFT
-**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Summary**: A `defaultExampleWidth` states the pixel width a library's components and examples are authored at and render at.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none)*
 

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 081 | A Default Example Width on `conventions.figma` | |
 | 079 | `metadata.conventions` Carries Only the Producing Platform | (reserved, draft in PR #363) |
 | 078 | One Conventions File per Platform, in `config/conventions/` | (reserved, draft in PR #363) |
 | 077 | The Image Component's Code Name, and the Encoding / Vocabulary Boundary | (reserved, draft in PR #363) |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -23,6 +23,8 @@ you emit without saying so.
 
 ### Added
 
+- `figma.defaultExampleWidth` in `config/conventions.yaml` — validated as a positive number, and included in the `init` template (ADR-081)
+
 - **`specs migrate <subject>` — versioned workspace migrations.** `specs migrate config`
   reads `specs.config.yaml` (or `.json`) and writes `config/conventions.yaml`,
   `config/settings.yaml` and `config/pipeline.yaml`, then renames the source to

--- a/packages/cli/src/Config/ConfigLoader.ts
+++ b/packages/cli/src/Config/ConfigLoader.ts
@@ -307,6 +307,11 @@ export class ConfigLoader {
       figma.states = raw.states;
     }
 
+    // defaultExampleWidth — a finite positive number, else the declaration is dropped
+    if (typeof raw.defaultExampleWidth === 'number' && Number.isFinite(raw.defaultExampleWidth) && raw.defaultExampleWidth > 0) {
+      figma.defaultExampleWidth = raw.defaultExampleWidth;
+    }
+
     return { figma };
   }
 

--- a/packages/cli/src/Config/ConfigTemplates.ts
+++ b/packages/cli/src/Config/ConfigTemplates.ts
@@ -102,6 +102,12 @@ figma:
   #     value: hover
   #   disabled:
   #     prop: disabled   # boolean prop — value defaults to "true"
+
+  # Width in pixels the library's components and examples are authored at, and
+  # the width they render at by default — a Figma frame written from a spec, a
+  # generated story canvas. Absence means no declared width and each consumer
+  # falls back to its own.
+  # defaultExampleWidth: 375
 `;
 }
 

--- a/packages/cli/tests/unit/config/ConfigLoader.test.ts
+++ b/packages/cli/tests/unit/config/ConfigLoader.test.ts
@@ -548,6 +548,43 @@ figma:
     });
   });
 
+  describe('conventions.figma.defaultExampleWidth validation (ADR-081)', () => {
+    it('preserves a positive number', () => {
+      writeSplitFile('conventions.yaml', 'figma:\n  defaultExampleWidth: 375');
+
+      const config = configLoader.load();
+      expect(config.conventions.figma.defaultExampleWidth).toBe(375);
+    });
+
+    it('is absent by default — a library declaring no width gets none', () => {
+      writeSplitFile('conventions.yaml', 'figma:\n  naming: NONE');
+
+      const config = configLoader.load();
+      expect(config.conventions.figma).not.toHaveProperty('defaultExampleWidth');
+    });
+
+    it('drops a non-numeric width', () => {
+      writeSplitFile('conventions.json', JSON.stringify({ figma: { defaultExampleWidth: '375px' } }));
+
+      const config = configLoader.load();
+      expect(config.conventions.figma).not.toHaveProperty('defaultExampleWidth');
+    });
+
+    it('drops a zero width', () => {
+      writeSplitFile('conventions.json', JSON.stringify({ figma: { defaultExampleWidth: 0 } }));
+
+      const config = configLoader.load();
+      expect(config.conventions.figma).not.toHaveProperty('defaultExampleWidth');
+    });
+
+    it('drops a negative width', () => {
+      writeSplitFile('conventions.json', JSON.stringify({ figma: { defaultExampleWidth: -375 } }));
+
+      const config = configLoader.load();
+      expect(config.conventions.figma).not.toHaveProperty('defaultExampleWidth');
+    });
+  });
+
   describe('conventions.figma.images validation (ADR-063)', () => {
     it('resolves a full block: backgroundImage, trimmed match, trimmed sourceProps', () => {
       writeSplitFile('conventions.json', JSON.stringify({

--- a/packages/cli/tests/unit/config/ConfigTemplates.test.ts
+++ b/packages/cli/tests/unit/config/ConfigTemplates.test.ts
@@ -60,6 +60,13 @@ describe('ConfigTemplates', () => {
       expect(template).toContain('codeOnlyProps:');
     });
 
+    it('includes a commented defaultExampleWidth with a sample width (ADR-081)', () => {
+      const template = generateConventionsTemplate();
+      expect(template).toContain('# defaultExampleWidth: 375');
+      // Commented out — a width is a library's own declaration, not a default
+      expect(yaml.parse(template).figma?.defaultExampleWidth).toBeUndefined();
+    });
+
     it('figma is the only top-level key', () => {
       const parsed = yaml.parse(generateConventionsTemplate());
       expect(Object.keys(parsed)).toEqual(['figma']);

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -11,6 +11,7 @@ Configuration now separates what is true about a Figma library from what a run c
 
 ### Added
 
+- `Conventions.figma.defaultExampleWidth` — width in pixels components and examples render at by default (ADR-081)
 - `PropConfigurationValue` — a `null` arm; a configuration states a nullable prop is unset, and an absent key inherits while `null` overrides (ADR-080)
 - `InstanceExample.propConfigurations` — accepts `null`, so an example can leave a prop unset; still refuses `PropBinding`
 - `NumberProp.enum` — the closed set of values a numeric prop accepts, so a Figma VARIANT whose options are all numbers carries its numeric type and its authored option order at once (ADR-072)

--- a/packages/schema/schema/conventions.schema.json
+++ b/packages/schema/schema/conventions.schema.json
@@ -186,6 +186,11 @@
               "additionalProperties": {
                 "$ref": "#/definitions/VariantStateEntry"
               }
+            },
+            "defaultExampleWidth": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "description": "Width in pixels the library's components and examples are authored at, and the width a consumer renders them at by default. A default, not a constraint. Absence means the library declares no width and the consumer uses its own. (ADR-081)"
             }
           },
           "additionalProperties": false

--- a/packages/schema/tests/Conventions.test-d.ts
+++ b/packages/schema/tests/Conventions.test-d.ts
@@ -89,4 +89,21 @@ const defaultedBlock: object = DEFAULT_CONVENTIONS.figma.subcomponents.match;
 
 export { defaults, defaultNaming, defaultedBlock };
 
+// ─── defaultExampleWidth (ADR-081) ────────────────────────────────────────────
+
+// Optional on the authored shape — absence means the library declares no width
+const noWidth: Conventions = { figma: {} };
+const withWidth: Conventions = { figma: { defaultExampleWidth: 375 } };
+
+// @ts-expect-error — a width is a number, not a CSS length string
+const stringWidth: Conventions = { figma: { defaultExampleWidth: '375px' } };
+
+// Stays optional after resolution — nothing can supply a width the library never declared
+const resolvedWidth: number | undefined = resolved.figma.defaultExampleWidth;
+
+// @ts-expect-error — not defaulted; there is no universal example width
+const defaultedWidth: number = DEFAULT_CONVENTIONS.figma.defaultExampleWidth;
+
+export { noWidth, withWidth, stringWidth, resolvedWidth, defaultedWidth };
+
 export { none, full, booleanState, enumState, noProp, badContract, scope, naming, constraints, numbers, blockMayBeAbsent, underResolved, glyphsWithoutMatch, noNamespace };

--- a/packages/schema/types/Conventions.ts
+++ b/packages/schema/types/Conventions.ts
@@ -97,6 +97,18 @@ export interface Conventions {
     inferNumberProps?: boolean;
     /** Concept-keyed map classifying Figma variant props as semantic states. Key = concept name (e.g. `hover`, `disabled`). Optional; absence means all variant props emit as data-* attribute selectors. @since 0.24.0 */
     states?: Record<string, VariantStateEntry>;
+    /**
+     * Width in pixels the library's components and examples are authored at, and the
+     * width a consumer renders them at by default — a rendered Figma frame, a generated
+     * story canvas, a screenshot harness.
+     *
+     * A default, not a constraint: a consumer given an explicit width for a particular
+     * render uses that instead. Optional; absence means the library declares no width
+     * and the consumer falls back to its own.
+     *
+     * @since 0.31.0
+     */
+    defaultExampleWidth?: number;
   };
 }
 
@@ -147,6 +159,8 @@ export interface ResolvedConventions {
     inferNumberProps: boolean;
     /** Concept-keyed map classifying Figma variant props as semantic states. Optional; absence means no state convention. */
     states?: Record<string, VariantStateEntry>;
+    /** Width in pixels components and examples are authored and rendered at. Optional; absence means no declared width. */
+    defaultExampleWidth?: number;
   };
 }
 
@@ -158,7 +172,8 @@ export interface ResolvedConventions {
  * two authoring facts about how props are written.
  *
  * The blocks — `glyphs`, `codeOnlyProps`, `subcomponents`, `instanceExamples`,
- * `images`, `states` — are deliberately absent and have no defaults. Their
+ * `images`, `states` — and `defaultExampleWidth` are deliberately absent and have no
+ * defaults. Their
  * absence means the library declares no such convention, which is a statement
  * nothing else can supply. Defaults *inside* a declared block are applied by
  * whoever resolves it, per the member documentation above.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -187,6 +187,7 @@ export default defineConfig({
                 { label: 'slotConstraints', slug: 'settings/slot-constraints', badge: pro },
                 { label: 'inferNumberProps', slug: 'settings/infer-number-props' },
                 { label: 'states', slug: 'settings/states', badge: experimental },
+                { label: 'defaultExampleWidth', slug: 'settings/default-example-width' },
               ],
             },
             {

--- a/site/src/content/docs/schema/conventions.md
+++ b/site/src/content/docs/schema/conventions.md
@@ -20,6 +20,7 @@ Authored in `config/conventions.yaml`. Absence of a member means the library dec
 | [`slotConstraints`](/guides/slot-constraints/) | `boolean` | `false` | The library authors slot constraints as code-only props |
 | [`inferNumberProps`](/guides/number-inference/) | `boolean` | `false` | The library authors numeric props as Figma `TEXT` props with numeric defaults |
 | [`states`](/settings/states/) | `object` | — | Concept-keyed map classifying Figma variant props as semantic states |
+| [`defaultExampleWidth`](/settings/default-example-width/) | `number` | — | Width in pixels components and examples are authored at, and render at by default. Absent = no declared width |
 
 ### `figma.glyphs`
 

--- a/site/src/content/docs/settings/default-example-width.md
+++ b/site/src/content/docs/settings/default-example-width.md
@@ -1,0 +1,41 @@
+---
+title: "Default Example Width"
+description: "The width a library's components and examples are authored at, and render at by default"
+---
+
+Anything that renders a spec has to pick a width first — a Figma frame written back from a spec, a generated story canvas, a screenshot harness. Without a declared one, each tool picks its own, and a library authored at a mobile width renders wrong: a root container set to fill stretches across a desktop canvas, and text that wraps to two lines in the design renders on one.
+
+`defaultExampleWidth` is a library fact, declared in `config/conventions.yaml`. Every consumer of the library reads the same number, so the same spec lays out the same way wherever it is rendered.
+
+## Configuration
+
+```yaml
+figma:
+  defaultExampleWidth: 375  # Render components and examples 375px wide
+```
+
+## Result
+
+The value travels with the spec's conventions, and consumers use it as the width for rendered output:
+
+```yaml
+conventions:
+  figma:
+    defaultExampleWidth: 375
+```
+
+A renderer writing a component back to Figma creates its frame 375 wide. A generated story sets its canvas to 375. Both show the component at the width it was designed at.
+
+Omit the key and the library declares no width — each consumer falls back to its own default, which is the behavior before this convention existed.
+
+## Options
+
+- **Type**: number (pixels)
+- **Default**: *(absent — the library declares no width)*
+- **Effect**: When set to a positive number, rendered components and examples default to that width. When absent, each consumer uses its own default.
+
+A declared width is a default, not a constraint. A consumer given an explicit width for a particular render uses that instead.
+
+## Path
+
+`figma.defaultExampleWidth` in `config/conventions.yaml`


### PR DESCRIPTION
Adds `conventions.figma.defaultExampleWidth` — an optional positive number stating the pixel width a library's components and examples are authored at, and the width consumers render them at by default.

## Why

Anything that renders a spec has to pick a width first — a Figma frame written back from a spec, a generated story canvas, a screenshot harness. Nothing in the spec says which, so each consumer invents one. For a library authored at a mobile width the results diverge from the design: a fill-width root stretches across a desktop canvas, and text that wraps to two lines renders on one.

That width is not a per-run preference. It is a fact about how the library was authored — the same number for every consumer, where a *different* value produces output that misrepresents the design rather than merely styling it differently. That is the test ADR-071 used to separate `Conventions` from `Settings`, so it lands on `Conventions.figma`.

## What changed

**`packages/schema`**

- `Conventions.figma.defaultExampleWidth?: number` and its `ResolvedConventions` counterpart
- `conventions.schema.json` — `defaultExampleWidth` with `exclusiveMinimum: 0`
- Optional, and deliberately **not** in `DEFAULT_CONVENTIONS` — there is no universal width, and absence is the statement that a library declares none
- Type tests covering the optional authored shape, the resolved shape, a rejected string width, and the absent default

**`packages/cli`**

- `ConfigLoader` resolves the key, dropping anything that is not a finite positive number
- The `config/conventions.yaml` init template carries it commented out with `375` as the sample
- Loader and template tests

**`site`**

- New `settings/default-example-width` page, sidebar entry, and a row in the `schema/conventions` table

## Semver

`0.31.0` — **MINOR**. One optional field on an existing interface, one optional property on an existing schema object. Every document valid before remains valid.

## Downstream

Documented in the ADR, not done here: `specs-from-figma`, `figma-from-specs` and `specs-plugin-2` should use the declared width as the default frame width when rendering, and keep their current hardcoded value only as the absent-case fallback.

## Notes

- The ADR is `DRAFT`; run `/specs.adr.accept` after review.
- `adr/INDEX.md` claims 081 on this branch only. The cherry-pick onto `main` and the release branch is not done — it needs a push to `main`.
- 54 tests in `packages/cli/tests` fail in a clean worktree (`DEFAULT_SETTINGS` resolves to `undefined` through the workspace link). Identical count before and after this change — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
