### PR TITLE
docs(adr): draft ADR-083 — collapsing a slot-only wrapper

### DIFF
--- a/adr/083-slot-wrapper-collapse.md
+++ b/adr/083-slot-wrapper-collapse.md
@@ -3,7 +3,7 @@
 **Branch**: `083-slot-wrapper-collapse`
 **Created**: 2026-09-01
 **Status**: DRAFT
-**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Summary**: `collapsePrimitiveWrapper` extends to a root wrapping one `slot`, merging both containers and keeping the slot's value on shared keys.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — amends ADR-058)*
 
@@ -83,8 +83,21 @@ Widen `spec.collapsePrimitiveWrapper` to cover a slot-only wrapper. **No member 
 A component collapses when **all** hold:
 
 - The root element's type is `container`
-- The root has exactly one anatomy-visible child, and that child's type is `slot`
+- The root has exactly one anatomy-visible child
+- That child is a container whose `children` is bound to a slot property, and that property is the component's **only** slot
+- No variant overrides the binding — it holds in `default` and is never replaced
 - Every valid variant is eligible — collapse stays all-or-nothing, as in ADR-058
+
+The test is the **binding**, not the anatomy label. The eligible child is a container layer whose `children` maps to the sole slot prop:
+
+```yaml
+# default.elements.<layer>
+children:
+  children: { $binding: "#/props/children" }
+  styles:   { layoutMode: HORIZONTAL, layoutSizingHorizontal: FILL }
+```
+
+Requiring the slot to be the component's only one keeps the collapsed root unambiguous: a component with two slots has two places children can go, and promoting one onto the root would silently privilege it. Requiring the binding to hold across every variant keeps collapse all-or-nothing, matching ADR-058.
 
 No style participates in eligibility. Both nodes are containers, so the merge discards nothing.
 
@@ -111,6 +124,25 @@ elements:
 ```
 
 The collapsed form needs no new representation — a slot binding on a container's `children` is already expressible.
+
+### The Figma layer name survives
+
+Where a layer's Figma name diverges from its spec key, that name is recorded in `$extensions['com.figma'].name` (ADR-066). The merge must not drop it: the collapsed element carries the **slot layer's** extension, consistent with the slot winning every other shared key.
+
+```yaml
+# Before
+elements:
+  root:     { $extensions: { com.figma: { name: "Layout" } } }
+  children: { $extensions: { com.figma: { name: "Children" } } }
+
+# After — the slot layer's name is what expansion needs to rebuild
+elements:
+  root:
+    $extensions: { com.figma: { name: "Children" } }
+    children: { $binding: "#/props/children" }
+```
+
+On expansion the rebuilt inner box takes that name, and the wrapper is named for the component. The wrapper's own original name is not recoverable — it is the layer the collapse exists to remove, and no member carries a second name.
 
 ### Expansion, for the reverse direction
 

--- a/adr/083-slot-wrapper-collapse.md
+++ b/adr/083-slot-wrapper-collapse.md
@@ -2,7 +2,7 @@
 
 **Branch**: `083-slot-wrapper-collapse`
 **Created**: 2026-09-01
-**Status**: DRAFT
+**Status**: ACCEPTED
 **Summary**: `collapsePrimitiveWrapper` extends to a root wrapping one `slot`, merging both containers and keeping the slot's value on shared keys.
 **Deciders**: Nathan Curtis (author)
 **Supersedes**: *(none — amends ADR-058)*

--- a/adr/083-slot-wrapper-collapse.md
+++ b/adr/083-slot-wrapper-collapse.md
@@ -40,39 +40,25 @@ Across a 115-component catalogue, exactly **four** components are a root contain
 | list | disjoint; no shared key differs |
 | bottom bar | root `VERTICAL` vs slot `HORIZONTAL`; differing `height`, `cornerRadius` |
 
-The bottom bar is genuinely two boxes — a vertical bar containing a horizontal row — and must not collapse. Any rule has to exclude it.
+The bottom bar is the interesting case: a vertical wrapper around a horizontal row, with a surface and padding of its own. It still collapses — the slot's `HORIZONTAL` wins, and the wrapper's `VERTICAL` is exactly the meaningless axis a single-child box carries. Its surface and padding are preserved by the split rule.
 
-### "Style-free" is a disqualifying set, not a binary
+### Why no style test is needed
 
-ADR-058's wrapper is not literally free of styles. Its eligibility bars a specific list:
+ADR-058 needs an eligibility list because the two nodes it merges are **different kinds**: a container and a `text` or `glyph` leaf. A container's styles have nowhere to go on a leaf, so the ADR enumerates the ones whose loss would matter.
 
-```yaml
-# ADR-058 disqualifying styles on the wrapper
-- clipContent
-- cornerRadius
-- strokes
-- strokeAlign
-- strokeWeight
-- itemSpacing
-- padding
-- effects
-- backgroundColor
-- cornerSmoothing
-```
+The slot case is not that. **Both nodes are containers with the same style signature** — every key one can carry, the other can carry, and both mean the same thing on either. Nothing has to be discarded to merge them, so nothing has to be tested for.
 
-Everything outside that list — `layoutMode`, `layoutSizingHorizontal`, `layoutSizingVertical`, `primaryAxisSizingMode`, `width`, `height` — is already tolerated on a collapsing wrapper. The question was never "does the wrapper have styles" but "which styles mean something."
-
-Applied literally to the four candidates, that list blocks **all of them**, and three on `clipContent` alone — which on a pure wrapper is an overflow rule rather than design intent, and which the slot child carries identically in every one of those three.
+That also disposes of the wrapper's own `layoutMode`. A wrapper holds exactly one child — the slot box — and a lone child lays out the same in a row as in a column. The wrapper's layout axis is close to meaningless by construction, which is what makes the merge safe rather than a judgement call.
 
 ---
 
 ## Decision Drivers
 
-- **Consistency with ADR-058** — the same argument that justifies collapsing a text wrapper justifies collapsing a slot wrapper; the eligibility test should differ only where the two cases genuinely differ
-- **A real box must survive** — a root carrying its own surface (`backgroundColor`, `cornerRadius`, `strokes`, `effects`) is not a wrapper, and no rule may flatten it
-- **Round-trip stability** — `figma-from-specs` reverses ADR-058's collapse, and its expansion assumes a style-free wrapper. A slot wrapper carries styles, so the reversal needs a stated rule
+- **Consistency with ADR-058** — the same argument that justifies collapsing a text wrapper justifies collapsing a slot wrapper
+- **Same kind, same signature** — root and slot are both containers, so the merge discards nothing and needs no eligibility test
+- **Round-trip stability** — `figma-from-specs` reverses ADR-058's collapse; the slot case needs a stated rule for splitting merged styles back across two boxes
 - **Absence must reproduce current behaviour exactly** — a workspace that does not enable the setting sees no change
-- **No logic in this package (Constitution II)** — the schema declares the setting; the collapse and its inverse live in the consuming packages
+- **No logic in this package (Constitution II)** — the schema declares the setting; collapse and expansion live in the consuming packages
 - **Type ↔ schema symmetry (Constitution I)** — whatever changes in `types/` changes in `schema/`
 - **Minimal, stable, intentional public API (Constitution III)** — reuse the existing setting rather than adding a second one that would have to be explained against the first
 
@@ -80,9 +66,9 @@ Applied literally to the four candidates, that list blocks **all of them**, and 
 
 ## Options Considered
 
-*(Pre-decided — the eligibility rule and the governing setting were settled before drafting.)*
+*(Pre-decided — the merge rule, the split rule and the governing setting were settled before drafting.)*
 
-Two eligibility rules were weighed. **Any non-conflicting merge** was selected: collapse when the root and its sole slot child share no style key with differing values, paired with a fixed rule for splitting them back on expansion. The alternative — collapse only when the two are **identical or the root lacks the key** — would let expansion reproduce the original layer styling exactly, but excludes the list component and buys that exactness with a narrower rule. Spec → Figma → spec stability is the contract that matters; byte-identical Figma layer styling is not.
+An eligibility test gated on the root's styles was drafted and discarded. It assumed the two nodes might lose something in the merge, which is true when merging a container into a leaf (ADR-058) and false when merging a container into a container. Testing styles here would refuse components for carrying values that survive the merge intact.
 
 Adding a second setting was also considered and rejected: a reader would have to learn why two switches exist for one idea, and every workspace wanting either would set both.
 
@@ -98,15 +84,13 @@ A component collapses when **all** hold:
 
 - The root element's type is `container`
 - The root has exactly one anatomy-visible child, and that child's type is `slot`
-- No style key present on **both** the root and the slot child has differing values
-- The root carries none of `backgroundColor`, `cornerRadius`, `cornerSmoothing`, `strokes`, `strokeAlign`, `strokeWeight`, `effects` — a root with its own surface is a box, not a wrapper
 - Every valid variant is eligible — collapse stays all-or-nothing, as in ADR-058
 
-`clipContent`, `itemSpacing` and `padding` are **not** disqualifying here, unlike ADR-058. In the slot case they are either identical on both boxes, or present on only one and therefore mergeable without a choice.
+No style participates in eligibility. Both nodes are containers, so the merge discards nothing.
 
-### The collapsed form needs no new representation
+### Merging — the slot wins
 
-The slot binding moves onto the root, which the schema already expresses:
+Styles merge onto one element, and where both carry a key, **the slot's value is kept**. The slot is the box the children actually sit in, so its layout is the one the composed result must preserve; the wrapper's is an artifact of holding a single child.
 
 ```yaml
 # Before — two boxes
@@ -114,27 +98,37 @@ anatomy:
   root: { type: container }
   children: { type: slot }
 elements:
-  root: { styles: { layoutMode: HORIZONTAL } }
-  children: { styles: { itemSpacing: 8 } }
+  root:     { styles: { layoutMode: VERTICAL, padding: 8, backgroundColor: "#fff" } }
+  children: { styles: { layoutMode: HORIZONTAL, itemSpacing: 4 } }
 
-# After — one box, styles merged
+# After — one box; layoutMode taken from the slot
 anatomy:
   root: { type: container }
 elements:
   root:
-    styles: { layoutMode: HORIZONTAL, itemSpacing: 8 }
+    styles: { layoutMode: HORIZONTAL, padding: 8, backgroundColor: "#fff", itemSpacing: 4 }
     children: { $binding: "#/props/children" }
 ```
 
+The collapsed form needs no new representation — a slot binding on a container's `children` is already expressible.
+
 ### Expansion, for the reverse direction
 
-Rebuilding two layers from one requires a rule, since the merge does not record which box a style came from:
+Rebuilding two boxes from one requires a rule, since the merge does not record which box a style came from. Styles split by what they act on:
 
-- Sizing and clipping — `layoutSizingHorizontal`, `layoutSizingVertical`, `primaryAxisSizingMode`, `width`, `height`, `clipContent` — go to the **outer wrapper**
-- Spacing and alignment — `itemSpacing`, `padding`, `crossAxisAlignment`, `mainAxisAlignment` — go to the **slot box**, where they act on the children
-- `layoutMode` goes to **both**, as it did before the merge
+| Style group | Goes to | Keys |
+|---|---|---|
+| **Parent layout** — how a box arranges what it holds | **both** boxes | `layoutMode`, `itemSpacing`, `padding`, `mainAxisAlignment`, `crossAxisAlignment`, `wrap`, `wrapAlignment` |
+| **Child layout** — how a box sizes within its own parent | the **slot** box | `layoutSizingHorizontal`, `layoutSizingVertical`, `primaryAxisSizingMode` |
+| **Everything else** | the **root** | `backgroundColor`, `backgroundImage`, `cornerRadius`, `cornerSmoothing`, `strokes`, `strokeAlign`, `strokeWeight`, `effects`, `clipsContent`, `opacity`, `rotation`, … |
 
-Layer styling may therefore be distributed differently than a designer authored it, while the re-generated spec is identical.
+Parent-layout keys go to both because the chain has two boxes and the children must arrange as they did in the collapsed one. Most are no-ops on the wrapper by construction — it holds exactly one child, so `itemSpacing` has nothing to space and the alignments have nothing to distribute, and its `layoutMode` axis cannot show.
+
+`padding` is the exception, and it is worth stating plainly: applied to both boxes it insets twice, so a collapsed box expressing `padding: 8` re-expands as 16px of total inset. It is the one parent-layout key whose effect on a single-child wrapper is not a no-op.
+
+Visual styles stay on the root, where a surface belongs: the outer box is what a caller sees, and painting a background on the inner box would sit it inside any padding rather than behind it.
+
+Layer styling may therefore be distributed differently than a designer authored it, while the re-generated spec is identical. That is the trade: spec → Figma → spec is stable; Figma → Figma is not byte-identical.
 
 ### Type changes (`types/`)
 
@@ -186,7 +180,8 @@ Absence or `false` reproduces current behaviour exactly. A workspace that alread
 ## Consequences
 
 - Components authored as a root container around a single slot emit one box, and so satisfy ADR-076's precondition for a container primitive binding
-- ADR-058's eligibility list no longer reads as universal: `clipContent`, `itemSpacing` and `padding` disqualify a primitive wrapper but not a slot one, because the two cases lose different things
+- ADR-058's eligibility list is not universal, and this ADR explains why it does not carry over: that list exists because a container is merged into a **leaf**, where container styles have nowhere to go. Merging a container into a container discards nothing, so no list is needed
 - A root with its own surface never collapses, so a component that is genuinely two boxes stays two boxes
 - The reverse direction gains a stated rule for splitting merged styles. Figma layer styling may differ from what a designer authored while spec → Figma → spec stays stable — an explicit trade, not an accident
+- **`padding` doubles on expansion.** Every other parent-layout key is a no-op on a single-child wrapper; `padding` is not, so a round-tripped component insets twice unless the rule carves it out
 - **Enabling the setting now does more than it did.** A workspace already setting it to `true` sees specs change shape for this class of component with no configuration change of its own. This is the cost of one setting rather than two, accepted deliberately

--- a/adr/083-slot-wrapper-collapse.md
+++ b/adr/083-slot-wrapper-collapse.md
@@ -1,0 +1,192 @@
+# ADR: Collapsing a Slot-Only Wrapper
+
+**Branch**: `083-slot-wrapper-collapse`
+**Created**: 2026-09-01
+**Status**: DRAFT
+**Summary**: *(written at implementation — see `/specs.adr.implement`)*
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none — amends ADR-058)*
+
+---
+
+## Context
+
+ADR-058 introduced `spec.collapsePrimitiveWrapper`. When true, a component whose root is a plain container holding a single `text` or `glyph` leaf is collapsed: the wrapper is stripped and the leaf becomes the spec root. Its stated rationale is that such a wrapper is *"a Figma-side convenience with no design-system meaning."*
+
+That ADR explicitly refuses the same shape when the child is a **slot**:
+
+> Collapse is blocked by … a root with a slot binding on its children (the wrapper has semantic slot structure).
+
+The refusal treats a slot binding as evidence that the wrapper means something. Often it is not. A layout component authored in Figma as a frame containing one slot frame is the same convenience: one box that lays out its children, expressed as two layers because that is how a slot is authored.
+
+### What the refusal costs
+
+A container primitive binding (ADR-074, ADR-076) substitutes a design-system component for a box that holds children. ADR-076 records the precondition:
+
+> **A bound component's root must be the box its children land in.**
+
+A component authored as root + slot fails it. The collapsed-away wrapper survives into generated markup, so everything the substituted element carried — spacing, padding, alignment, sizing — lands on an outer box whose only child is the wrapper. Spacing is silently lost, and a wrapper carrying a zero flex-basis inside a hug-height parent collapses the subtree to nothing. Neither failure raises an error.
+
+Collapsing the slot-only wrapper removes the second box and makes such components valid binding targets.
+
+### The shape, measured
+
+Across a 115-component catalogue, exactly **four** components are a root container with one slot child:
+
+| Component | Root styles vs slot styles |
+|---|---|
+| layout | identical |
+| action list | identical |
+| list | disjoint; no shared key differs |
+| bottom bar | root `VERTICAL` vs slot `HORIZONTAL`; differing `height`, `cornerRadius` |
+
+The bottom bar is genuinely two boxes — a vertical bar containing a horizontal row — and must not collapse. Any rule has to exclude it.
+
+### "Style-free" is a disqualifying set, not a binary
+
+ADR-058's wrapper is not literally free of styles. Its eligibility bars a specific list:
+
+```yaml
+# ADR-058 disqualifying styles on the wrapper
+- clipContent
+- cornerRadius
+- strokes
+- strokeAlign
+- strokeWeight
+- itemSpacing
+- padding
+- effects
+- backgroundColor
+- cornerSmoothing
+```
+
+Everything outside that list — `layoutMode`, `layoutSizingHorizontal`, `layoutSizingVertical`, `primaryAxisSizingMode`, `width`, `height` — is already tolerated on a collapsing wrapper. The question was never "does the wrapper have styles" but "which styles mean something."
+
+Applied literally to the four candidates, that list blocks **all of them**, and three on `clipContent` alone — which on a pure wrapper is an overflow rule rather than design intent, and which the slot child carries identically in every one of those three.
+
+---
+
+## Decision Drivers
+
+- **Consistency with ADR-058** — the same argument that justifies collapsing a text wrapper justifies collapsing a slot wrapper; the eligibility test should differ only where the two cases genuinely differ
+- **A real box must survive** — a root carrying its own surface (`backgroundColor`, `cornerRadius`, `strokes`, `effects`) is not a wrapper, and no rule may flatten it
+- **Round-trip stability** — `figma-from-specs` reverses ADR-058's collapse, and its expansion assumes a style-free wrapper. A slot wrapper carries styles, so the reversal needs a stated rule
+- **Absence must reproduce current behaviour exactly** — a workspace that does not enable the setting sees no change
+- **No logic in this package (Constitution II)** — the schema declares the setting; the collapse and its inverse live in the consuming packages
+- **Type ↔ schema symmetry (Constitution I)** — whatever changes in `types/` changes in `schema/`
+- **Minimal, stable, intentional public API (Constitution III)** — reuse the existing setting rather than adding a second one that would have to be explained against the first
+
+---
+
+## Options Considered
+
+*(Pre-decided — the eligibility rule and the governing setting were settled before drafting.)*
+
+Two eligibility rules were weighed. **Any non-conflicting merge** was selected: collapse when the root and its sole slot child share no style key with differing values, paired with a fixed rule for splitting them back on expansion. The alternative — collapse only when the two are **identical or the root lacks the key** — would let expansion reproduce the original layer styling exactly, but excludes the list component and buys that exactness with a narrower rule. Spec → Figma → spec stability is the contract that matters; byte-identical Figma layer styling is not.
+
+Adding a second setting was also considered and rejected: a reader would have to learn why two switches exist for one idea, and every workspace wanting either would set both.
+
+---
+
+## Decision
+
+Widen `spec.collapsePrimitiveWrapper` to cover a slot-only wrapper. **No member is added, removed, or retyped** — the setting's documented meaning widens, and the behaviour it selects is implemented by consumers.
+
+### Eligibility
+
+A component collapses when **all** hold:
+
+- The root element's type is `container`
+- The root has exactly one anatomy-visible child, and that child's type is `slot`
+- No style key present on **both** the root and the slot child has differing values
+- The root carries none of `backgroundColor`, `cornerRadius`, `cornerSmoothing`, `strokes`, `strokeAlign`, `strokeWeight`, `effects` — a root with its own surface is a box, not a wrapper
+- Every valid variant is eligible — collapse stays all-or-nothing, as in ADR-058
+
+`clipContent`, `itemSpacing` and `padding` are **not** disqualifying here, unlike ADR-058. In the slot case they are either identical on both boxes, or present on only one and therefore mergeable without a choice.
+
+### The collapsed form needs no new representation
+
+The slot binding moves onto the root, which the schema already expresses:
+
+```yaml
+# Before — two boxes
+anatomy:
+  root: { type: container }
+  children: { type: slot }
+elements:
+  root: { styles: { layoutMode: HORIZONTAL } }
+  children: { styles: { itemSpacing: 8 } }
+
+# After — one box, styles merged
+anatomy:
+  root: { type: container }
+elements:
+  root:
+    styles: { layoutMode: HORIZONTAL, itemSpacing: 8 }
+    children: { $binding: "#/props/children" }
+```
+
+### Expansion, for the reverse direction
+
+Rebuilding two layers from one requires a rule, since the merge does not record which box a style came from:
+
+- Sizing and clipping — `layoutSizingHorizontal`, `layoutSizingVertical`, `primaryAxisSizingMode`, `width`, `height`, `clipContent` — go to the **outer wrapper**
+- Spacing and alignment — `itemSpacing`, `padding`, `crossAxisAlignment`, `mainAxisAlignment` — go to the **slot box**, where they act on the children
+- `layoutMode` goes to **both**, as it did before the merge
+
+Layer styling may therefore be distributed differently than a designer authored it, while the re-generated spec is identical.
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `types/Settings.ts` | `Settings.spec.collapsePrimitiveWrapper` — doc comment widened to include a slot-only wrapper and to state the eligibility difference from ADR-058 | PATCH |
+| `types/Settings.ts` | `ResolvedSettings.spec.collapsePrimitiveWrapper` — same | PATCH |
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `schema/settings.schema.json` | `description` of `spec.collapsePrimitiveWrapper` widened to match | PATCH |
+
+### Notes
+
+The setting keeps its name. "Primitive wrapper" reads as the wrapper being removed rather than the leaf being promoted (ADR-058's own naming rationale), and that reading holds for a slot child as well as a text or glyph one.
+
+Absence or `false` reproduces current behaviour exactly. A workspace that already sets it to `true` **will** see specs change shape for components of this form — the deliberate consequence of widening one setting rather than adding a second.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes — documentation-only, applied to both artifacts
+- **Parity check**: `Settings.spec.collapsePrimitiveWrapper` and `ResolvedSettings.spec.collapsePrimitiveWrapper` ↔ `settings.schema.json` `#/properties/spec/properties/collapsePrimitiveWrapper`. No property is added or removed, so parity is preserved by construction
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `specs-from-figma` | Widen collapse eligibility to a slot-only root and merge the two elements' styles | Implement |
+| `figma-from-specs` | Reverse the collapse for a slot-only root, splitting merged styles per the expansion rule | Implement |
+| `specs-cli` | None — the setting is passed through unchanged | Recompile |
+| `specs-plugin-2` | Output for components of this form changes when the setting is enabled | Recompile |
+
+---
+
+## Semver Decision
+
+**Version**: `0.31.0` (release branch `release/schema-0.31.0+cli-0.28.0`) — **PATCH**
+
+**Justification**: no type, property, or default changes. The setting already exists (`@since 0.26.0`); only its documented meaning widens, and the behaviour it selects belongs to the consuming packages (Constitution II). The observable change in generated specs is a consumer behaviour change, not a change to this package's contract.
+
+---
+
+## Consequences
+
+- Components authored as a root container around a single slot emit one box, and so satisfy ADR-076's precondition for a container primitive binding
+- ADR-058's eligibility list no longer reads as universal: `clipContent`, `itemSpacing` and `padding` disqualify a primitive wrapper but not a slot one, because the two cases lose different things
+- A root with its own surface never collapses, so a component that is genuinely two boxes stays two boxes
+- The reverse direction gains a stated rule for splitting merged styles. Figma layer styling may differ from what a designer authored while spec → Figma → spec stays stable — an explicit trade, not an accident
+- **Enabling the setting now does more than it did.** A workspace already setting it to `true` sees specs change shape for this class of component with no configuration change of its own. This is the cost of one setting rather than two, accepted deliberately

--- a/adr/083-slot-wrapper-collapse.md
+++ b/adr/083-slot-wrapper-collapse.md
@@ -124,7 +124,7 @@ Rebuilding two boxes from one requires a rule, since the merge does not record w
 
 Parent-layout keys go to both because the chain has two boxes and the children must arrange as they did in the collapsed one. Most are no-ops on the wrapper by construction — it holds exactly one child, so `itemSpacing` has nothing to space and the alignments have nothing to distribute, and its `layoutMode` axis cannot show.
 
-`padding` is the exception, and it is worth stating plainly: applied to both boxes it insets twice, so a collapsed box expressing `padding: 8` re-expands as 16px of total inset. It is the one parent-layout key whose effect on a single-child wrapper is not a no-op.
+Values are never summed. A root with `padding: 8` and a slot with `padding: 12` collapses to `12` — the slot's value — and re-expands as `12` on both boxes. A slot carrying padding at all is an authoring mistake rather than a case the split rule has to accommodate: padding belongs to the box with the surface, and the slot has none.
 
 Visual styles stay on the root, where a surface belongs: the outer box is what a caller sees, and painting a background on the inner box would sit it inside any padding rather than behind it.
 
@@ -183,5 +183,5 @@ Absence or `false` reproduces current behaviour exactly. A workspace that alread
 - ADR-058's eligibility list is not universal, and this ADR explains why it does not carry over: that list exists because a container is merged into a **leaf**, where container styles have nowhere to go. Merging a container into a container discards nothing, so no list is needed
 - A root with its own surface never collapses, so a component that is genuinely two boxes stays two boxes
 - The reverse direction gains a stated rule for splitting merged styles. Figma layer styling may differ from what a designer authored while spec → Figma → spec stays stable — an explicit trade, not an accident
-- **`padding` doubles on expansion.** Every other parent-layout key is a no-op on a single-child wrapper; `padding` is not, so a round-tripped component insets twice unless the rule carves it out
+- A slot that carries `padding` is an authoring mistake, not a case the split rule accommodates — padding belongs to the box with the surface
 - **Enabling the setting now does more than it did.** A workspace already setting it to `true` sees specs change shape for this class of component with no configuration change of its own. This is the cost of one setting rather than two, accepted deliberately

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 083 | Collapsing a Slot-Only Wrapper |  |
 | 079 | `metadata.conventions` Carries Only the Producing Platform | (reserved, draft in PR #363) |
 | 078 | One Conventions File per Platform, in `config/conventions/` | (reserved, draft in PR #363) |
 | 077 | The Image Component's Code Name, and the Encoding / Vocabulary Boundary | (reserved, draft in PR #363) |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,6 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 083 | Collapsing a Slot-Only Wrapper |  |
 | 079 | `metadata.conventions` Carries Only the Producing Platform | (reserved, draft in PR #363) |
 | 078 | One Conventions File per Platform, in `config/conventions/` | (reserved, draft in PR #363) |
 | 077 | The Image Component's Code Name, and the Encoding / Vocabulary Boundary | (reserved, draft in PR #363) |
@@ -24,6 +23,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 083 | Collapsing a Slot-Only Wrapper | `collapsePrimitiveWrapper` also collapses a root wrapping one slot; both nodes are containers so no style is tested, and the slot's value wins |
 | 080 | `null` as a Prop Configuration Value | Adds a `null` arm to `PropConfigurationValue` and to `InstanceExample.propConfigurations`; absent inherits, `null` overrides with unset |
 | 071 | Separate Library Conventions from Tooling Settings | `Conventions`, `Settings` and `Pipeline` replace `Config`, separating library facts from run choices and declared work |
 | 069 | Rename `clipContent` to `clipsContent` | Renames the clip flag to the key the data carries, so container clipping and CSS `overflow` resolve for the first time |

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -23,6 +23,7 @@ Configuration now separates what is true about a Figma library from what a run c
 
 ### Changed
 
+- `Settings.spec.collapsePrimitiveWrapper` — also collapses a root wrapping one slot, keeping the slot's value on shared keys (ADR-083)
 - **`Settings.spec.splitComponents`, `splitConcerns` and `useSubfolders` now default to `true`** and are required on `ResolvedSettings`. The split layout — one folder per component, one file per concern — is what `transform`, `analyze` and `render` read, so the shape of generated output is not a per-consumer choice. They previously carried no default, leaving each consumer to pick its own; both consumers picked `false`, which is the layout nothing downstream can use. Recorded spec `metadata.settings.spec` now carries all three on every spec.
 
 - `Metadata.config` → `Metadata.conventions` and `Metadata.settings` — each half comparable across specs on its own

--- a/packages/schema/schema/settings.schema.json
+++ b/packages/schema/schema/settings.schema.json
@@ -145,7 +145,7 @@
             "collapsePrimitiveWrapper": {
               "type": "boolean",
               "default": false,
-              "description": "Strip a plain container wrapping a single text or glyph element and promote the leaf to spec root."
+              "description": "Strip a root container that only wraps one child and promote the child to spec root. A text or glyph leaf requires the wrapper to carry no meaningful container styles (ADR-058); a slot child needs no style test, because both nodes are containers, and the slot's value wins on any shared key (ADR-083)."
             },
             "invalidVariants": {
               "type": "boolean",

--- a/packages/schema/types/Settings.ts
+++ b/packages/schema/types/Settings.ts
@@ -75,10 +75,22 @@ export interface Settings {
     /** Level of detail in output. Optional; defaults to LAYERED. */
     details?: 'FULL' | 'LAYERED';
     /**
-     * When true, a component whose root is a plain container wrapping a single `text` or
-     * `glyph` element (no meaningful container styles, no slot bindings) is collapsed:
-     * the wrapper is stripped and the leaf becomes the spec root. All-or-nothing across
-     * variants — if any variant fails eligibility, no collapse occurs. Defaults to false.
+     * When true, a root container that only wraps one child is collapsed away, and the
+     * child becomes the spec root. Two shapes qualify, and they are tested differently
+     * because they lose different things:
+     *
+     * - **A `text` or `glyph` leaf** (ADR-058). A container is merged into a leaf, where
+     *   container styles have nowhere to go, so the wrapper must carry none that matter:
+     *   `clipContent`, `cornerRadius`, `strokes`, `strokeAlign`, `strokeWeight`,
+     *   `itemSpacing`, `padding`, `effects`, `backgroundColor`, `cornerSmoothing`.
+     * - **A `slot`** (ADR-083). Both nodes are containers with the same style signature,
+     *   so the merge discards nothing and no style is tested. Where both carry a key, the
+     *   slot's value wins — it is the box the children sit in — and the slot binding moves
+     *   onto the root.
+     *
+     * All-or-nothing across variants: if any variant fails eligibility, no collapse
+     * occurs. Defaults to false.
+     *
      * @since 0.26.0
      */
     collapsePrimitiveWrapper?: boolean;
@@ -140,7 +152,7 @@ export interface ResolvedSettings {
     variantDepth: 1 | 2 | 3 | 9999;
     /** Level of detail in output. */
     details: 'FULL' | 'LAYERED';
-    /** Plain container wrappers around a single text/glyph child are stripped. */
+    /** Plain container wrappers around a single text, glyph or slot child are stripped. */
     collapsePrimitiveWrapper: boolean;
     /** Include invalid variants. */
     invalidVariants: boolean;

--- a/site/src/content/docs/schema/settings.md
+++ b/site/src/content/docs/schema/settings.md
@@ -40,7 +40,7 @@ Authored in `config/settings.yaml`. Members are grouped by concern, and each con
 | [`color`](/settings/color/) | `ColorFormat` | `'HEX'` | Color value output format |
 | [`variantDepth`](/guides/variant-depth/) | `1 \| 2 \| 3 \| 9999` | `9999` | Maximum variant nesting depth (9999 = unlimited) |
 | [`details`](/guides/variant-layering/) | `'FULL' \| 'LAYERED'` | `'LAYERED'` | Output detail level |
-| [`collapsePrimitiveWrapper`](/settings/collapse-primitive-wrapper/) | `boolean` | `false` | Strip plain container wrappers around a single text/glyph child and promote the leaf to spec root |
+| [`collapsePrimitiveWrapper`](/settings/collapse-primitive-wrapper/) | `boolean` | `false` | Strip a root container that only wraps one child — a text/glyph leaf, or a slot — and promote the child to spec root |
 | [`invalidVariants`](/settings/invalid-variants/) | `boolean` | `false` | Include variants marked invalid |
 | [`invalidCombinations`](/guides/invalid-variant-combinations/) | `boolean` | `true` | Include `invalidVariantCombinations` list |
 | [`emptyVariants`](/settings/empty-variants/) | `boolean` | `false` | Include variants with no element overrides |

--- a/site/src/content/docs/settings/collapse-primitive-wrapper.md
+++ b/site/src/content/docs/settings/collapse-primitive-wrapper.md
@@ -1,9 +1,14 @@
 ---
 title: "Collapse Primitive Wrapper"
-description: "Strip plain container wrappers around a single text or glyph element and promote the leaf to spec root"
+description: "Strip a root container that only wraps one child — a text or glyph leaf, or a slot — and promote the child to spec root"
 ---
 
-A run choice in `config/settings.yaml`. When enabled, a component whose root is a plain, style-free container holding a single `text` or `glyph` child is collapsed: the wrapper is stripped and the leaf becomes the spec root. This eliminates structural noise for purely typographic or icon primitives — such as Heading, Paragraph, Body, Label, or Icon components — where the container adds no design-system meaning.
+A run choice in `config/settings.yaml`. When enabled, a component whose root is a container holding exactly one child is collapsed: the wrapper is stripped and the child becomes the spec root.
+
+Two shapes qualify, and they are tested differently because they lose different things:
+
+- **A `text` or `glyph` leaf.** A container merges into a leaf, where container styles have nowhere to go, so the wrapper must carry none that matter. This eliminates structural noise for typographic and icon primitives — Heading, Paragraph, Body, Label, Icon — where the container adds no design-system meaning.
+- **A slot.** Both nodes are containers with the same style signature, so the merge discards nothing and no style is tested. This applies to layout primitives — a frame whose only content is the slot its children fill.
 
 ## Configuration
 
@@ -43,18 +48,57 @@ A component qualifies for collapse when **all** of the following are true:
 
 - The root element type is `container`.
 - The root has exactly one anatomy-visible child.
+And **either** of the following.
+
+For a **leaf** child:
+
 - That child's type is `text` or `glyph`.
 - The child has no children of its own.
 - The root carries no slot binding on its children.
 - The root carries none of the following styles after default/zero values are stripped: `clipsContent`, `cornerRadius`, `strokes`, `strokeAlign`, `strokeWeight`, `itemSpacing`, `padding`, `effects`, `backgroundColor`, `cornerSmoothing`.
 
+For a **slot** child:
+
+- That child is a container whose `children` is bound to a slot property, and that property is the component's only slot.
+- No variant overrides the binding.
+- No style test applies — both nodes are containers, so nothing is discarded. Where both carry a style key, the slot's value is kept.
+
 Collapse is **all-or-nothing**: if any variant in the component set fails the eligibility check, no collapse occurs for any variant.
+
+## Collapsing a slot
+
+**Without** collapse (`false`) a Layout component emits two boxes:
+
+```yaml
+anatomy:
+  root:
+    type: container
+  children:
+    type: slot
+    parent: root
+```
+
+**With** collapse (`true`) the wrapper is stripped and the slot binding moves onto the root:
+
+```yaml
+anatomy:
+  root:
+    type: container
+    $extensions:
+      com.figma.name: Children
+elements:
+  root:
+    children:
+      $binding: "#/props/children"
+```
+
+As with a leaf, `$extensions.com.figma.name` carries the surviving layer's Figma name so the source layer remains traceable.
 
 ## Options
 
 - **Type**: boolean
 - **Default**: `false`
-- **Effect**: When `true`, eligible wrapper-only components are collapsed so the leaf element becomes the spec root. When `false`, the container is emitted as root regardless of structure.
+- **Effect**: When `true`, eligible wrapper-only components are collapsed so the child — a leaf or a slot — becomes the spec root. When `false`, the container is emitted as root regardless of structure.
 
 ## Path
 


### PR DESCRIPTION
Extends ADR-058's primitive wrapper collapse to a root whose sole anatomy child is a slot, governed by the existing collapsePrimitiveWrapper setting. Context and prior analysis in #377.

Claims 083 in the index (082 is taken by origin/082-component-description).