### PR TITLE
Encode ADR authoring rules in the commands that draft and implement ADRs

### DIFF
--- a/.github/agents/Specs.adr.create.agent.md
+++ b/.github/agents/Specs.adr.create.agent.md
@@ -76,7 +76,9 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 5. **Evaluate options** *(skip if the decision is already made)*:
    - If the user's description or context indicates the decision is pre-decided (e.g., "record and implement this decision"), omit this step and mark the Options Considered section as *(Pre-decided — no alternatives evaluated)*.
-   - Otherwise, identify at least two alternative approaches, assess each against the constitution's Decision Drivers, and state which is selected with rationale.
+   - **First, list the independent decisions in scope.** Schema shape, authoring surface and semantics, and vocabulary are separate decisions. Each gets its own Options section, titled by the decision it resolves, with its own selected and rejected alternatives. Never bundle two decisions into one option — a "Selected" option carrying both forces an all-or-nothing verdict and hides one of them from evaluation entirely.
+   - If a decision is out of scope for this ADR, say so explicitly in Context and point to where it is taken. Do not resolve it in passing.
+   - Within each Options section, identify at least two alternative approaches, assess each against the constitution's Decision Drivers, and state which is selected with rationale.
 
 6. **Draft the ADR**: Fill `adr-template.md` and write to `$SPEC_FILE`:
    - **Branch**: `ADR_NAME`
@@ -87,7 +89,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Decision**: Precise list of type and schema changes (file, field, modification type)
    - **Type ↔ Schema Impact**: Confirm symmetry or document justified asymmetry
    - **Downstream Impact**: All affected consumers (`specs-cli`, `specs-from-figma`, `specs-plugin-2`) — see Key rules below
-   - **Semver Decision**: MAJOR / MINOR / PATCH with justification citing the constitution
+   - **Semver Decision**: the **target version** read verbatim from the active release branch name (e.g. `release/schema-0.31.0+cli-0.28.0` → `0.31.0`), plus the **change class** (MAJOR / MINOR / PATCH) with justification citing the constitution. Never propose a version bump — an ADR ships *inside* a release that already has a version, so `0.30.0 → 0.31.0` invents a version the release process never asked for and conflicts with the branch it merges into.
    - **Consequences**: What becomes true after acceptance
 
 7. **Claim ADR number in INDEX**: Update `adr/INDEX.md` to reserve the ADR number and prevent collisions.
@@ -111,6 +113,8 @@ You **MUST** consider the user input before proceeding (if not empty).
 ## Key rules
 
 - Status MUST be `DRAFT` — never set to `ACCEPTED` in this command.
+- The Semver section states the release branch's version and the change class. It MUST NOT contain a bump arrow.
+- One decision per Options section. The **Decision** section only records what the option sets above already resolved — if a choice appears there for the first time, it needs its own Options section.
 - The ADR describes *what* will change and *why*. It does not contain type or schema file content — those changes are applied directly by `/specs.adr.implement`.
 - **Downstream Impact table**: Include rows for all consumers affected by the change: `specs-cli`, `specs-from-figma`, and `specs-plugin-2`. Describe impact and required action in general terms (e.g., "Update value mapping", "Recompile") — do not reference internal classes, methods, or implementation details of those packages.
 - If the change clearly violates a constitution gate (e.g., adds runtime logic), state the violation explicitly in the ADR and halt rather than proceeding without justification.

--- a/.github/agents/Specs.adr.implement.agent.md
+++ b/.github/agents/Specs.adr.implement.agent.md
@@ -31,7 +31,8 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Read `package.json` for the current version
    - Read `CHANGELOG.md` for the existing format
 
-3. **Verify ADR completeness**: The ADR must have a clear Decision section (type and schema changes listed) and a Semver Decision with `CURRENT → NEW`. If either is missing or marked NEEDS CLARIFICATION, halt and ask the author to complete the ADR first.
+3. **Verify ADR completeness**: The ADR must have a clear Decision section (type and schema changes listed) and a Semver Decision naming the **target version** and the **change class**. If either is missing or marked NEEDS CLARIFICATION, halt and ask the author to complete the ADR first.
+   - The target version is the active release branch's version — an ADR ships inside a release that already has one. If the Semver section instead proposes a bump (`0.30.0 → 0.31.0`), treat the right-hand version as the target only if it matches `$RELEASE_BRANCH`; otherwise halt and ask the author to correct it.
 
 4. **Constitution gate check**: Evaluate all six gates against the ADR's stated changes. If any gate fails without a documented exception in the ADR, halt and report the violation before touching any file.
 
@@ -93,8 +94,8 @@ You **MUST** consider the user input before proceeding (if not empty).
     - **Migration line**: `` `Parent.old` → `Parent.new` ``: one sentence; imperative; describe what to read instead and how to handle the new type
     - **Gate**: After writing, verify the new entry is present in the file. If CHANGELOG.md does not contain the new version heading, halt and report — do not proceed to step 13.
 
-13. **Bump version in `package.json`**: Apply the `NEW` version from the ADR's Semver Decision.
-    - **Gate**: After writing, read `package.json` back and confirm the `"version"` field matches the ADR's `NEW` version. If it does not match, halt and report — do not proceed to step 14.
+13. **Confirm the version in `package.json`**: It must equal the ADR's **target version** — the one the release branch already carries, normally set by `/start-next-release`. Write it only if it differs; do not invent a bump beyond the release branch's version.
+    - **Gate**: After writing, read `package.json` back and confirm the `"version"` field matches the ADR's target version. If it does not match, halt and report — do not proceed to step 14.
 
 14. **Report**: List every file modified (with one-line description each). The list **must** include the ADR file, `CHANGELOG.md`, and `package.json` — if any is absent from the list, halt: steps 10, 12, or 13 were not completed. State that the author should review the diff and accept the ADR once satisfied. Remind the author that this ADR branch (`$BRANCH`) targets the release branch (`$RELEASE_BRANCH`), not `main`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,11 @@ The documentation site is built with Astro (port 4323) from `site/src/content/do
 - `cli/` — CLI overview, getting started, and per-command reference
 - `overview/` — product overview, licensing, releases
 
+**Spec output examples use YAML, never JSON.** Any Result block or example showing
+component spec output — on a schema page, a settings page, or a guide — is a `yaml`
+fenced block. YAML is what the CLI writes and what an author reads in a workspace, so
+a JSON example shows a shape the reader will never see on disk.
+
 ## Rules
 
 - **Never merge or commit to main without asking first.** Use `AskUserQuestion` with Yes/No options before running `gh pr merge`, `git merge` into main, `git push` to main, or any direct commit on the main branch.

--- a/adr/adr-template.md
+++ b/adr/adr-template.md
@@ -149,9 +149,11 @@ newField:
 
 ## Semver Decision
 
-**Version bump**: `[CURRENT] → [NEW]` (`MAJOR` / `MINOR` / `PATCH`)
+**Target version**: `[VERSION]` — the version of the active release branch this ADR merges into.
 
-**Justification**: [State which constitution rule applies — e.g., "All changes are additive optional fields → MINOR per constitution III"]
+**Change class**: `MAJOR` / `MINOR` / `PATCH` — for CHANGELOG placement, not a version bump.
+
+**Justification**: [State which constitution rule applies — e.g., "All changes are additive optional fields → MINOR-class per constitution III"]
 
 ---
 


### PR DESCRIPTION
Three ADR authoring rules existed only as session memory, so they applied when they happened to surface rather than when an ADR was being written. This puts them in the commands themselves.

## Semver states a target version, never a bump

An ADR ships *inside* a release that already has a version. Proposing `0.30.0 → 0.31.0` invents a version the release process never asked for and conflicts with the branch it merges into.

The Semver section now names:

- **Target version** — read verbatim from the active release branch (`release/schema-0.31.0+cli-0.28.0` becomes `0.31.0`)
- **Change class** — MAJOR / MINOR / PATCH, for CHANGELOG placement

This reached three files, not one: `adr-template.md` carried the arrow, the create command instructed it, and implement step 13 bumped `package.json` from the `NEW` half. That step now confirms `package.json` matches the release branch's version and writes only if it differs.

## One decision per Options section

Schema shape, authoring surface and semantics, and vocabulary are independent decisions. A "Selected" option that bundles two forces an all-or-nothing verdict and hides one from evaluation entirely.

The create command now says to list the independent decisions before writing any options, give each its own titled Options section, and say so explicitly in Context when a decision is out of scope rather than resolving it in passing. A Decision section may only record what the option sets above resolved — a choice appearing there for the first time needs its own Options section.

## Docs site YAML convention

`CLAUDE.md` now records that spec output examples on the docs site are `yaml` blocks. YAML is what the CLI writes and what an author reads in a workspace, so a JSON example shows a shape the reader never sees on disk.

## Not changed

The ADR Summary line rules were already fully encoded in implement step 10 — present tense, 15-18 words, the new property as subject, no past-tense problem clause. Nothing needed doing there.

## Verification

Documentation only — no types, schema, or code. No tests affected.
