### PR TITLE
Fetch a Figma branch without configuring it as a source

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**`specs fetch --source <url>` fetches a Figma branch that is not in your config**, naming it
+after the branch and fetching the same data kinds as the file it branches from. Payloads land
+beside the library's as `<parent>-<branch>.file.json`, so a branch you compare a few times and
+throw away never needs a config edit.
+
 ### Changed
+
+**`specs scan --source <alias>` accepts a source fetched with `--source`**, resolving it from
+the payload on disk when config has no entry for it.
+
+**`specs generate --get-images` pulls images from the file the specs came from**, rather than
+always from the configured source — so specs generated from a branch get the branch's images.
 
 ### Removed
 

--- a/packages/cli/src/commands/FetchCommand.ts
+++ b/packages/cli/src/commands/FetchCommand.ts
@@ -28,8 +28,27 @@ const ERROR_CODES = {
 };
 
 import type { SourceEntry } from '@directededges/specs-schema';
+import { resolveFigmaFileKey, slugifyBranchName, FigmaKeyError } from '../utilities/figmaFileKey.js';
 
 type FetchKind = 'file' | 'variables' | 'styles' | 'icons';
+
+/**
+ * A source to fetch. `config` sources come from `data.sources`; `adhoc` sources are
+ * named on the command line by `--source`, live only for the run that names them,
+ * and exist so a Figma branch can be fetched and diffed without editing config.
+ */
+interface FetchSource {
+  alias: string;
+  key: string;
+  fetch: FetchKind[];
+  origin: 'config' | 'adhoc';
+  /** Ad-hoc only: the file this key branches from, per the API's `branch_data`. */
+  mainFileKey?: string;
+  /** Ad-hoc only: the configured alias whose key equals `mainFileKey`. */
+  parentAlias?: string;
+  /** Ad-hoc only: the branch's name as Figma reports it on the parent file. */
+  branchName?: string;
+}
 
 export { collectGlyphComponents };
 
@@ -59,14 +78,56 @@ function splitOnly(value?: string): string[] {
     .filter(Boolean);
 }
 
-function normalizeSources(sources?: Record<string, SourceEntry>): Array<{ alias: string; key: string; fetch: FetchKind[] }> {
+function normalizeSources(sources?: Record<string, SourceEntry>): FetchSource[] {
   if (!sources) return [];
 
   return Object.entries(sources).map(([alias, entry]) => ({
     alias,
     key: entry.key,
-    fetch: (entry.fetch ?? []).filter(isFetchKind)
+    fetch: (entry.fetch ?? []).filter(isFetchKind),
+    origin: 'config' as const
   }));
+}
+
+/** One `--source` value: `<url|key>`, or `<alias>=<url|key>` to name it yourself. */
+interface AdHocSpec { alias?: string; key: string; raw: string }
+
+export function parseAdHocSource(value: string): AdHocSpec {
+  const raw = value.trim();
+  // Split on the first `=` only: a key never contains one, and a URL's query string may.
+  const separator = raw.indexOf('=');
+  const looksAliased = separator > 0 && !raw.slice(0, separator).includes('/');
+
+  const alias = looksAliased ? raw.slice(0, separator).trim() : undefined;
+  const target = looksAliased ? raw.slice(separator + 1).trim() : raw;
+
+  if (alias !== undefined && !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(alias)) {
+    throw new FigmaKeyError(`Not a usable source alias: "${alias}"\n  Aliases become filenames — use letters, digits, "-" and "_"`);
+  }
+
+  return { alias, key: resolveFigmaFileKey(target), raw };
+}
+
+interface BranchProbe {
+  name?: string;
+  mainFileKey?: string;
+}
+
+/**
+ * Read a file's identity without downloading it: `depth=1` returns the document node and
+ * nothing below it, and `branch_data=true` adds `mainFileKey` when the key is a branch.
+ * The payload a diff reads is the full file; this is only about naming the source and
+ * knowing which configured source's data kinds to copy — and it means a bad key or token
+ * fails before the large request rather than after it.
+ */
+async function probeFile(key: string, token: string): Promise<{ status: number; headers: Headers; data: BranchProbe }> {
+  const url = `https://api.figma.com/v1/files/${key}?depth=1&branch_data=true`;
+  const response = await figmaFetch(url, token);
+  if (response.status !== 200) {
+    return { status: response.status, headers: response.headers, data: {} };
+  }
+  const body = await streamToString(response.stream);
+  return { status: response.status, headers: response.headers, data: JSON.parse(body) as BranchProbe };
 }
 
 async function figmaFetch(url: string, token: string): Promise<{ status: number; body: string; headers: Headers; stream: ReadableStream<Uint8Array> | null }> {
@@ -143,7 +204,16 @@ function configReference(configPath: string | null): string {
   return configPath || 'the workspace settings (config/settings.yaml)';
 }
 
-export function formatNotFoundError(alias: string, kind: string, configPath: string | null): string {
+export function formatNotFoundError(alias: string, kind: string, configPath: string | null, origin: 'config' | 'adhoc' = 'config'): string {
+  if (origin === 'adhoc') {
+    return [
+      `Error: File not found (404) while fetching ${alias}.${kind}`,
+      `  Figma returned 404 for the key passed as --source ${alias}.`,
+      '    • Check the URL you pasted still opens in Figma (a deleted branch keeps its URL)',
+      '    • Your FIGMA_TOKEN account must be able to open it'
+    ].join('\n');
+  }
+
   return [
     `Error: File not found (404) while fetching ${alias}.${kind}`,
     `  Figma returned 404 for the file key configured for "${alias}".`,
@@ -154,9 +224,19 @@ export function formatNotFoundError(alias: string, kind: string, configPath: str
   ].join('\n');
 }
 
-export function formatAuthError(status: number, alias: string, kind: string, configPath: string | null, key?: string): string {
+export function formatAuthError(status: number, alias: string, kind: string, configPath: string | null, key?: string, origin: 'config' | 'adhoc' = 'config'): string {
   if (status === 403) {
     const keyHint = key ? `  File key: ${key}` : '';
+    if (origin === 'adhoc') {
+      return [
+        `Error: Access denied (403) while fetching ${alias}.${kind}`,
+        '  Your FIGMA_TOKEN is valid but cannot access the file passed as --source.',
+        '    • Personal access tokens only reach files your account can view',
+        '    • If your org enforces SAML/SSO, personal access tokens are blocked',
+        '      Use an OAuth token or ask your admin to allow PATs',
+        ...(keyHint ? [keyHint] : [])
+      ].join('\n');
+    }
     return [
       `Error: Access denied (403) while fetching ${alias}.${kind}`,
       '  Your FIGMA_TOKEN is valid but cannot access this file.',
@@ -185,6 +265,7 @@ export interface FetchOptions {
   dataDir?: string;
   outDir?: string; // deprecated alias for --data-dir
   only?: string;
+  source?: string[];
   geometry: boolean;
   verbose: boolean;
 }
@@ -195,6 +276,11 @@ export const Fetch = new Command('fetch')
   .option('--data-dir <dir>', 'Override data directory (default: data.directory from the workspace settings, or ./data)')
   .option('--outDir <dir>', 'Deprecated: use --data-dir')
   .option('--only <name[,name...]>', 'Fetch only these — a file alias from sources, a data kind (file, variables, styles, icons), or both')
+  .option(
+    '--source <[alias=]url|key>',
+    'Fetch a file or branch that is not in config — pass its Figma URL or key. Repeatable. Names itself after the branch unless you pass alias=',
+    (value: string, previous: string[] = []) => previous.concat(value)
+  )
   .option('--no-geometry', 'Omit geometry data (fillGeometry, strokeGeometry, size, relativeTransform) from file payloads')
   .option('--verbose', 'Enable detailed logging', false)
   .action(async (options: FetchOptions) => {
@@ -217,7 +303,8 @@ export const Fetch = new Command('fetch')
       const outDir = path.resolve(configDir, outDirValue);
 
       const fileEntries = normalizeSources(config.settings.data?.sources);
-      if (fileEntries.length === 0) {
+      const adHocValues = options.source ?? [];
+      if (fileEntries.length === 0 && adHocValues.length === 0) {
         console.error('Error: No sources configured');
         console.error('Add to config/settings.yaml:');
         console.error('  data:');
@@ -255,7 +342,84 @@ export const Fetch = new Command('fetch')
         process.exit(ERROR_CODES.INVALID_ARGS);
       }
 
-      const selected = onlyAliases.length > 0 ? fileEntries.filter(f => onlyAliases.includes(f.alias)) : fileEntries;
+      // -------------------------------------------------------------------
+      // Ad-hoc sources (--source): a file or branch fetched without being in config.
+      // Resolving one is a small `depth=1` request first — it names the source after the
+      // file, matches a branch to the configured source it came from, and fails on a bad
+      // key or token before any large download starts.
+      // -------------------------------------------------------------------
+      const adHoc: FetchSource[] = [];
+      for (const value of adHocValues) {
+        let spec: AdHocSpec;
+        try {
+          spec = parseAdHocSource(value);
+        } catch (err) {
+          console.error(`Error: --source ${value}`);
+          console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+          process.exit(ERROR_CODES.INVALID_ARGS);
+          return;
+        }
+
+        const label = spec.alias ?? spec.key;
+        const probe = await probeFile(spec.key, token);
+        if (probe.status !== 200) {
+          const classification = classifyHttpStatus(probe.status);
+          if (classification === 'auth') {
+            console.error(formatAuthError(probe.status, label, 'file', configPath, options.verbose ? spec.key : undefined, 'adhoc'));
+            process.exit(ERROR_CODES.AUTH_ERROR);
+          }
+          if (classification === 'rate') {
+            console.error(formatRateLimitError(label, 'file', probe.headers));
+            process.exit(ERROR_CODES.RATE_LIMIT);
+          }
+          if (probe.status === 404) {
+            console.error(formatNotFoundError(label, 'file', configPath, 'adhoc'));
+          } else {
+            console.error(`Error: HTTP ${probe.status} while resolving --source ${value}`);
+          }
+          process.exit(ERROR_CODES.NETWORK_ERROR);
+        }
+
+        // `mainFileKey` names the file this key branches from. It is used for one thing:
+        // matching the branch to a configured source so it fetches the same data kinds,
+        // which is what makes the two payloads comparable. A branch of a file that is not
+        // configured is a normal thing to fetch, and says nothing.
+        const mainFileKey = probe.data.mainFileKey;
+        const parent = mainFileKey ? fileEntries.find(f => f.key === mainFileKey) : undefined;
+        const branchName = probe.data.name;
+
+        const alias = spec.alias
+          ?? (branchName ? `${parent ? `${parent.alias}-` : ''}${slugifyBranchName(branchName)}` : undefined)
+          ?? `source-${spec.key.slice(0, 8).toLowerCase()}`;
+
+        // Writing to a configured alias's filenames would overwrite the durable payload
+        // this branch is meant to be compared against.
+        if (fileEntries.some(f => f.alias === alias)) {
+          console.error(`Error: --source ${value} resolves to the alias "${alias}", which is already a configured source.`);
+          console.error(`  Name it yourself instead: --source ${alias}-branch=${spec.raw}`);
+          process.exit(ERROR_CODES.INVALID_ARGS);
+        }
+        if (adHoc.some(f => f.alias === alias)) {
+          console.error(`Error: two --source values resolve to the same alias "${alias}". Name at least one of them: --source <alias>=<url>`);
+          process.exit(ERROR_CODES.INVALID_ARGS);
+        }
+
+        // A branch is fetched the way its parent is, so the two payloads are comparable.
+        // With no parent to inherit from, `--only` decides, and a bare file payload is
+        // the floor — every downstream command needs it.
+        const kinds = parent ? parent.fetch : (onlyKinds.length > 0 ? [...onlyKinds] : ['file' as FetchKind]);
+
+        adHoc.push({ alias, key: spec.key, fetch: kinds, origin: 'adhoc', mainFileKey, parentAlias: parent?.alias, branchName });
+        console.log(`✓ Resolved: ${alias}${parent ? ` (branch of ${parent.alias})` : ''} → ${kinds.join(', ')}`);
+      }
+
+      // Naming ad-hoc sources means fetching those: re-downloading the configured
+      // library is a large request the caller did not ask for. `--only <alias>` still
+      // adds configured sources back alongside them.
+      const configSelected = onlyAliases.length > 0
+        ? fileEntries.filter(f => onlyAliases.includes(f.alias))
+        : (adHoc.length > 0 ? [] : fileEntries);
+      const selected = [...configSelected, ...adHoc];
 
       // A kind the caller asked for that no selected source is configured to fetch would
       // otherwise do nothing at all and say nothing about why.
@@ -301,7 +465,7 @@ export const Fetch = new Command('fetch')
           const classification = classifyHttpStatus(status);
 
           if (classification === 'auth') {
-            console.error(formatAuthError(status, entry.alias, kind, configPath, options.verbose ? entry.key : undefined));
+            console.error(formatAuthError(status, entry.alias, kind, configPath, options.verbose ? entry.key : undefined, entry.origin));
             process.exit(ERROR_CODES.AUTH_ERROR);
           }
 
@@ -312,7 +476,7 @@ export const Fetch = new Command('fetch')
 
           if (classification === 'error') {
             if (status === 404) {
-              console.error(formatNotFoundError(entry.alias, kind, configPath));
+              console.error(formatNotFoundError(entry.alias, kind, configPath, entry.origin));
             } else {
               console.error(`Error: HTTP ${status} while fetching ${entry.alias}.${kind}`);
             }
@@ -358,14 +522,14 @@ export const Fetch = new Command('fetch')
         if (entry.fetch.includes('icons') && wants('icons')) {
           const pattern = config.conventions.figma.glyphs?.match;
           if (!pattern) {
-            console.error(`Error: data.sources.${entry.alias}.fetch includes "icons" but conventions.figma.glyphs.match is not set`);
+            console.error(`Error: ${entry.origin === 'adhoc' ? `source "${entry.alias}"` : `data.sources.${entry.alias}.fetch`} includes "icons" but conventions.figma.glyphs.match is not set`);
             process.exit(ERROR_CODES.INVALID_ARGS);
           }
           // Icons are consumed by generated component output, so they live in
           // the durable spec workspace (beside _images/), not the data cache.
           const specDirectory = config.settings.spec.directory;
           if (!specDirectory) {
-            console.error(`Error: data.sources.${entry.alias}.fetch includes "icons" but spec.directory is not set in the workspace settings`);
+            console.error(`Error: ${entry.origin === 'adhoc' ? `source "${entry.alias}"` : `data.sources.${entry.alias}.fetch`} includes "icons" but spec.directory is not set in the workspace settings`);
             process.exit(ERROR_CODES.INVALID_ARGS);
           }
           const filePath = path.join(outDir, `${entry.alias}.file.json`);
@@ -377,7 +541,14 @@ export const Fetch = new Command('fetch')
           const stopSpinner = startSpinner(`Downloading: ${entry.alias} icons`);
           const fileJson = JSON.parse(await fs.readFile(filePath, 'utf-8')) as { document?: unknown };
           const glyphs = collectGlyphComponents(fileJson.document, pattern);
-          const iconsDir = path.join(path.resolve(configDir, specDirectory), '_icons');
+          // An ad-hoc source's glyphs are a second version of the same icons under the
+          // same slugs. Writing them to `_icons/` would overwrite the durable library's
+          // assets, so they get their own directory — isolated, and deleted with the
+          // rest of the source's payloads.
+          const iconsDir = path.join(
+            path.resolve(configDir, specDirectory),
+            entry.origin === 'adhoc' ? `_icons-${entry.alias}` : '_icons'
+          );
           await fs.ensureDir(iconsDir);
 
           let downloaded = 0;
@@ -421,6 +592,26 @@ export const Fetch = new Command('fetch')
         }
       }
 
+      // An ad-hoc source's key exists nowhere but the command line that named it, and
+      // later commands (`generate --get-images`, and anything diffing these payloads)
+      // need to know which file the alias came from. Recorded beside the payloads so it
+      // is deleted with them.
+      for (const entry of adHoc) {
+        await fs.writeFile(
+          path.join(outDir, `${entry.alias}.source.json`),
+          JSON.stringify({
+            alias: entry.alias,
+            key: entry.key,
+            fetch: entry.fetch,
+            mainFileKey: entry.mainFileKey ?? null,
+            parentAlias: entry.parentAlias ?? null,
+            branchName: entry.branchName ?? null,
+            fetchedAt: new Date().toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+      }
+
       clearInlineStatus();
 
       // Refresh the render caches from everything now on disk — the sources fetched this
@@ -431,7 +622,10 @@ export const Fetch = new Command('fetch')
         const dataDir = path.resolve(configDir, dataDirectory);
         const report = refreshCache({
           dataDir,
-          aliases: Object.keys(config.settings.data?.sources ?? {}),
+          // Ad-hoc aliases first: entries collide by node id and name, and later aliases
+          // win, so a branch contributes only what the configured sources don't already
+          // define. A branch fetch must not change how the durable library resolves.
+          aliases: [...adHoc.map(s => s.alias), ...Object.keys(config.settings.data?.sources ?? {})],
           glyphNamePattern: config.conventions.figma.glyphs?.match,
         });
         reportCache(report);

--- a/packages/cli/src/commands/GenerateCommand.ts
+++ b/packages/cli/src/commands/GenerateCommand.ts
@@ -95,6 +95,44 @@ function resolveFileSourceAlias(sources: Record<string, SourceEntry> | undefined
 }
 
 /**
+ * The Figma file key to pull image fills from: whichever file the specs being written
+ * were generated from. For a configured source that is its `key`; for a source fetched
+ * by `specs fetch --source` — a branch, typically — it is the sidecar written beside the
+ * payload, since nothing in config knows that key. Falling back to the configured source
+ * would download the main file's images for specs generated from a branch.
+ */
+function resolveImageFileKey(
+  config: CLIConfig,
+  sourceDir: string,
+  payloadPath: string | undefined
+): { key: string } | { error: string } {
+  const alias = payloadPath && payloadPath.endsWith('.file.json')
+    ? path.basename(payloadPath, '.file.json')
+    : resolveFileSourceAlias(config.settings.data?.sources);
+
+  if (!alias) {
+    return { error: 'Error: --get-images requires a configured source file key (data.sources.<alias>.key in the workspace settings)' };
+  }
+
+  const configured = config.settings.data?.sources?.[alias]?.key;
+  if (configured) return { key: configured };
+
+  const sidecar = path.join(sourceDir, `${alias}.source.json`);
+  if (fs.existsSync(sidecar)) {
+    const recorded = JSON.parse(fs.readFileSync(sidecar, 'utf-8')) as { key?: string };
+    if (recorded.key) return { key: recorded.key };
+  }
+
+  return {
+    error: [
+      `Error: --get-images cannot resolve the Figma file key for "${alias}"`,
+      `  "${alias}" is not in data.sources, and ${path.relative(process.cwd(), sidecar)} is missing or has no key.`,
+      `  Re-fetch it (\`specs fetch --source ${alias}=<url>\`), or generate without --get-images.`
+    ].join('\n')
+  };
+}
+
+/**
  * Write processed components to stdout or via the config-driven output writers.
  * Shared by file/manifest mode (REST-sourced) and selection mode (bridge-sourced) —
  * once a spec exists as a plain object, output resolution/writing is identical.
@@ -104,7 +142,9 @@ async function writeGeneratedOutput(
   errors: Array<{ component: string; error: string }>,
   isManifest: boolean,
   options: GenerateOptions,
-  config: CLIConfig
+  config: CLIConfig,
+  /** The `<alias>.file.json` these specs were generated from, when there was one. */
+  payloadPath?: string
 ): Promise<void> {
   // -------------------------------------------------------------------
   // File mode stdout (no -o)
@@ -195,12 +235,17 @@ async function writeGeneratedOutput(
           console.error('Error: --get-images requires the FIGMA_TOKEN environment variable (same token as `specs fetch`)');
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
-        const fileSourceAlias = resolveFileSourceAlias(config.settings.data?.sources);
-        const fileKey = fileSourceAlias ? config.settings.data?.sources?.[fileSourceAlias]?.key : undefined;
-        if (!fileKey) {
-          console.error('Error: --get-images requires a configured source file key (data.sources.<alias>.key in the workspace settings)');
+        const sourceDir = options.dataDir
+          ? path.resolve(options.dataDir)
+          : config.settings.data?.directory
+            ? path.resolve(config.settings.data.directory)
+            : path.join(process.cwd(), 'data');
+        const resolved = resolveImageFileKey(config, sourceDir, payloadPath);
+        if ('error' in resolved) {
+          console.error(resolved.error);
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
+        const fileKey = resolved.key;
 
         console.log(`Requesting image download URLs from Figma (${missing.size} image(s))...`);
         const urls = await ImageFillsResolver.fetchImageUrls(fileKey, token);
@@ -396,6 +441,9 @@ export const Generate = new Command('generate')
       let componentIds: string[];
       let componentNames: Map<string, string>; // id → display name
       let libraryJson: Record<string, any>;
+      // The Figma payload these specs come from — carried to --get-images so images are
+      // pulled from that file, which for an ad-hoc source is not the configured one.
+      let payloadPath: string | undefined;
 
       if (isManifest) {
         // MANIFEST MODE
@@ -448,6 +496,7 @@ export const Generate = new Command('generate')
           process.exit(ERROR_CODES.FILE_ERROR);
         }
 
+        payloadPath = sourceFile;
         libraryJson = await fs.readJSON(sourceFile);
 
         // `--component` used to apply only in file mode, so asking for one component here
@@ -489,6 +538,7 @@ export const Generate = new Command('generate')
           process.exit(ERROR_CODES.INVALID_ARGS);
         }
 
+        payloadPath = sourcePath;
         libraryJson = JSON.parse(sourceContent);
         componentIds = [options.component];
         const resolvedName =
@@ -670,7 +720,7 @@ export const Generate = new Command('generate')
         process.exit(ERROR_CODES.GENERAL_ERROR);
       }
 
-      await writeGeneratedOutput(processedComponents, errors, isManifest, options, config);
+      await writeGeneratedOutput(processedComponents, errors, isManifest, options, config, payloadPath);
 
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/commands/ScanCommand.ts
+++ b/packages/cli/src/commands/ScanCommand.ts
@@ -258,7 +258,11 @@ export const Scan = new Command('scan')
           ([, entry]) => Array.isArray(entry.fetch) && entry.fetch.includes('file')
         );
 
-        if (fileSources.length === 0) {
+        // An alias fetched with `specs fetch --source` is never in config, so an alias
+        // with a payload on disk is as real a source as a configured one.
+        const fetchedOnDisk = (alias: string) => fs.existsSync(path.join(resolvedDir, `${alias}.file.json`));
+
+        if (fileSources.length === 0 && !(options.source && fetchedOnDisk(options.source))) {
           console.error('Error: No <file> argument provided and no sources configured in the workspace settings');
           console.error('Tip: run `specs fetch` first, or pass a file path explicitly (e.g., `specs scan data/library.file.json`)');
           process.exit(ERROR_CODES.INVALID_ARGS);
@@ -267,13 +271,14 @@ export const Scan = new Command('scan')
         let alias: string;
         if (options.source) {
           const match = fileSources.find(([name]) => name === options.source);
-          if (!match) {
+          if (!match && !fetchedOnDisk(options.source)) {
             const available = fileSources.map(([name]) => name).join(', ');
             console.error(`Error: --source "${options.source}" did not match a configured source with file data`);
-            console.error(`Available: ${available}`);
+            console.error(`Available: ${available || '(none)'}`);
+            console.error(`Tip: an unconfigured source needs its payload fetched first — \`specs fetch --source ${options.source}=<url>\``);
             process.exit(ERROR_CODES.INVALID_ARGS);
           }
-          alias = match[0];
+          alias = match ? match[0] : options.source;
         } else if (fileSources.length === 1) {
           alias = fileSources[0][0];
         } else {

--- a/packages/cli/src/utilities/figmaFileKey.ts
+++ b/packages/cli/src/utilities/figmaFileKey.ts
@@ -1,0 +1,60 @@
+/**
+ * Figma file key parsing — a pasted Figma URL or a bare file key resolve to the
+ * same thing, since a branch key works anywhere a main file key does at
+ * `GET /v1/files/:key`.
+ *
+ * Accepted URL shapes are the ones Figma serves today:
+ *   https://www.figma.com/design/<KEY>/<slug>?...
+ *   https://www.figma.com/file/<KEY>/<slug>?...
+ *   https://www.figma.com/design/<MAIN_KEY>/branch/<BRANCH_KEY>/<slug>?...
+ *
+ * The third is what the URL bar shows while a branch is open, and it names both
+ * files. The branch key is the one that means "this file" — reading the leading
+ * key instead would resolve a branch link to main, fetch the wrong document, and
+ * look entirely successful doing it.
+ */
+
+/** Figma file keys are URL-safe alphanumeric strings; 20+ chars in practice. */
+const FILE_KEY = /^[A-Za-z0-9]{10,128}$/;
+const FIGMA_URL = /^https?:\/\/(?:[\w-]+\.)*figma\.com\/(?:design|file)\/([A-Za-z0-9]{10,128})(?:\/branch\/([A-Za-z0-9]{10,128}))?(?:[/?#]|$)/;
+
+export class FigmaKeyError extends Error {}
+
+/**
+ * Resolve a bare file key or a Figma file/design URL to a file key.
+ * Throws `FigmaKeyError` with the input echoed back — the caller is always a
+ * command that should report this as a usage error, not a crash.
+ */
+export function resolveFigmaFileKey(input: string): string {
+  const value = input.trim();
+
+  if (FILE_KEY.test(value)) return value;
+
+  const match = FIGMA_URL.exec(value);
+  if (match) return match[2] ?? match[1];
+
+  if (/figma\.com/.test(value)) {
+    throw new FigmaKeyError(
+      `Not a Figma file URL: ${value}\n  Expected figma.com/design/<KEY>/... or figma.com/file/<KEY>/...`
+    );
+  }
+
+  throw new FigmaKeyError(
+    `Not a Figma file key or URL: ${value}\n  Pass a file key, or the URL of the file or branch as it appears in Figma`
+  );
+}
+
+/**
+ * Slugify a Figma branch name for use as a source alias: the alias becomes a
+ * filename stem (`<alias>.file.json`) and a manifest name, so it has to be
+ * filesystem- and CLI-safe.
+ */
+export function slugifyBranchName(name: string): string {
+  const slug = name
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'branch';
+}

--- a/packages/cli/tests/unit/commands/FetchCommand.test.ts
+++ b/packages/cli/tests/unit/commands/FetchCommand.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Fetch, formatDuration, formatRateLimitError, formatNotFoundError, formatAuthError } from '../../../src/commands/FetchCommand.js';
+import { Fetch, formatDuration, formatRateLimitError, formatNotFoundError, formatAuthError, parseAdHocSource } from '../../../src/commands/FetchCommand.js';
 
 describe('FetchCommand', () => {
   it('registers name and description', () => {
@@ -172,5 +172,58 @@ describe('formatAuthError', () => {
       '    • The file may be in personal drafts or a restricted team (403 = exists but no access)',
       '  Check: data.sources.library.key in /proj/specs.config.yaml'
     ].join('\n'));
+  });
+});
+
+/**
+ * `--source` is what a diff run pastes a branch URL into, so the parse has to accept
+ * what Figma's URL bar produces and refuse anything that would name a file on disk.
+ */
+describe('parseAdHocSource', () => {
+  const KEY = 'abcDEF123456789xyz01';
+
+  it('takes a bare URL and leaves the alias to be derived from the branch', () => {
+    expect(parseAdHocSource(`https://www.figma.com/design/${KEY}/DS?node-id=1-2`)).toEqual({
+      alias: undefined,
+      key: KEY,
+      raw: `https://www.figma.com/design/${KEY}/DS?node-id=1-2`
+    });
+  });
+
+  it('takes an explicit alias before the first =', () => {
+    expect(parseAdHocSource(`library-branch=${KEY}`)).toMatchObject({ alias: 'library-branch', key: KEY });
+  });
+
+  it('does not read a URL\'s query string as an alias', () => {
+    expect(parseAdHocSource(`https://www.figma.com/design/${KEY}/DS?t=a=b`)).toMatchObject({ alias: undefined, key: KEY });
+  });
+
+  it('rejects an alias that would not survive as a filename', () => {
+    expect(() => parseAdHocSource(`my branch=${KEY}`)).toThrow(/usable source alias/);
+  });
+
+  it('rejects a target that is neither a key nor a Figma URL', () => {
+    expect(() => parseAdHocSource('branch=data/library.file.json')).toThrow(/Figma file key or URL/);
+  });
+});
+
+/**
+ * An ad-hoc source has no config entry, so the config-shaped remedies in these errors
+ * would send the reader somewhere that says nothing about the key that failed.
+ */
+describe('error messages for ad-hoc sources', () => {
+  it('404 points at the pasted URL, not data.sources', () => {
+    const result = formatNotFoundError('library-branch', 'file', '/proj/config', 'adhoc');
+
+    expect(result).toContain('the key passed as --source library-branch');
+    expect(result).not.toContain('data.sources');
+  });
+
+  it('403 drops the config check and keeps the token remedies', () => {
+    const result = formatAuthError(403, 'library-branch', 'file', '/proj/config', undefined, 'adhoc');
+
+    expect(result).toContain('cannot access the file passed as --source');
+    expect(result).not.toContain('data.sources');
+    expect(result).toContain('SAML/SSO');
   });
 });

--- a/packages/cli/tests/unit/utilities/figmaFileKey.test.ts
+++ b/packages/cli/tests/unit/utilities/figmaFileKey.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFigmaFileKey, slugifyBranchName, FigmaKeyError } from '../../../src/utilities/figmaFileKey.js';
+
+/**
+ * The input here is whatever a person pasted out of Figma, so the cases that matter
+ * are the shapes Figma's own URL bar produces — and the near-misses that should fail
+ * loudly rather than resolve to a key that fetches someone else's file.
+ */
+describe('resolveFigmaFileKey', () => {
+  const KEY = 'abcDEF123456789xyz01';
+
+  it('passes a bare file key through', () => {
+    expect(resolveFigmaFileKey(KEY)).toBe(KEY);
+    expect(resolveFigmaFileKey(`  ${KEY}  `)).toBe(KEY);
+  });
+
+  it('extracts the key from both URL shapes Figma serves', () => {
+    expect(resolveFigmaFileKey(`https://www.figma.com/design/${KEY}/Design-System`)).toBe(KEY);
+    expect(resolveFigmaFileKey(`https://www.figma.com/file/${KEY}/Design-System`)).toBe(KEY);
+  });
+
+  it('ignores query strings and fragments, which carry the node id, not the file', () => {
+    expect(resolveFigmaFileKey(`https://www.figma.com/design/${KEY}/DS?node-id=1-2&t=abc`)).toBe(KEY);
+    expect(resolveFigmaFileKey(`https://figma.com/design/${KEY}`)).toBe(KEY);
+  });
+
+  it('takes a branch URL the same way — a branch key is a file key', () => {
+    expect(resolveFigmaFileKey(`https://www.figma.com/design/${KEY}/DS?branch=1`)).toBe(KEY);
+  });
+
+  it('rejects a Figma URL that is not a file URL', () => {
+    expect(() => resolveFigmaFileKey('https://www.figma.com/files/team/123')).toThrow(FigmaKeyError);
+    expect(() => resolveFigmaFileKey('https://www.figma.com/files/team/123')).toThrow(/Expected figma.com\/design/);
+  });
+
+  it('rejects anything that is neither a key nor a Figma URL', () => {
+    expect(() => resolveFigmaFileKey('data/library.file.json')).toThrow(FigmaKeyError);
+    expect(() => resolveFigmaFileKey('short')).toThrow(FigmaKeyError);
+    expect(() => resolveFigmaFileKey('')).toThrow(FigmaKeyError);
+  });
+});
+
+/**
+ * A branch name becomes a filename stem and a CLI argument, so it has to survive
+ * both. Figma puts no constraints on branch names.
+ */
+describe('slugifyBranchName', () => {
+  it('kebab-cases names, including camelCase splits', () => {
+    expect(slugifyBranchName('New nav tokens')).toBe('new-nav-tokens');
+    expect(slugifyBranchName('newNavTokens')).toBe('new-nav-tokens');
+    expect(slugifyBranchName('Fix/Card spacing')).toBe('fix-card-spacing');
+  });
+
+  it('strips characters a filename or shell would fight over', () => {
+    expect(slugifyBranchName('  v2 — "big" redesign!  ')).toBe('v2-big-redesign');
+  });
+
+  it('falls back rather than producing an empty stem', () => {
+    expect(slugifyBranchName('///')).toBe('branch');
+  });
+});
+
+/**
+ * The URL bar shows this shape while a branch is open, and it is what gets pasted.
+ * Both keys are real files, so reading the wrong one fetches a real document and
+ * fails silently — the branch key is the one that means "the file I am looking at".
+ */
+describe('resolveFigmaFileKey — branch URLs', () => {
+  const MAIN = 'MainFileKey0000000001';
+  const BRANCH = 'BranchFileKey00000002';
+
+  it('takes the branch key, not the main key it is nested under', () => {
+    expect(resolveFigmaFileKey(`https://www.figma.com/design/${MAIN}/branch/${BRANCH}/UI-kit?m=auto`)).toBe(BRANCH);
+  });
+
+  it('still takes the only key when the URL is not a branch', () => {
+    expect(resolveFigmaFileKey(`https://www.figma.com/design/${MAIN}/UI-kit?m=auto`)).toBe(MAIN);
+  });
+});

--- a/site/src/content/docs/cli/commands/fetch.md
+++ b/site/src/content/docs/cli/commands/fetch.md
@@ -36,6 +36,9 @@ specs fetch --data-dir ./custom-data
 ### `--only <alias[,alias...]>`
 Fetch only specific aliases from `data.sources`.
 
+### `--source <[alias=]url|key>`
+Fetch a file or branch that is not in `data.sources` — see [Fetching Figma Branches](#fetching-figma-branches). Repeatable.
+
 ### `--no-geometry`
 Omit geometry data from file payloads. By default, `fetch` requests `?geometry=paths` from the Figma API, which includes `fillGeometry`, `strokeGeometry`, `size`, and `relativeTransform` on every node. This roughly doubles the payload size.
 
@@ -109,15 +112,64 @@ The downloaded assets match the slugs referenced by generated component output (
 
 ## Fetching Figma Branches
 
-You can fetch data from a Figma branch instead of the main file by using the branch's file key in your `data.sources` config. Every Figma branch has its own unique key, which works anywhere a main file key does.
+A branch is a file with its own key, so nothing about fetching one is special — but a
+branch is usually short-lived and fetched to be compared against the library it came
+from, which is not worth an edit to `config/settings.yaml`. `--source` fetches a file
+that is not in config:
 
-```yaml
-# config/settings.yaml
-data:
-  sources:
-    library:
-      key: BRANCH_FILE_KEY   # branch key instead of main file key
-      fetch: ['file', 'variables', 'styles']
+```bash
+specs fetch --source "https://www.figma.com/design/BRANCH_KEY/Design-System?node-id=0-1"
+```
+
+Paste the branch's URL as it appears in Figma, or pass a bare file key. The flag is
+repeatable, and naming any `--source` means only those sources are fetched — the
+configured library is not re-downloaded unless `--only <alias>` asks for it.
+
+### What it resolves
+
+Before downloading anything, `fetch` reads the file's name and, for a branch, the file it
+branches from — one small request that also fails on a bad key or token before the large
+one starts. It reports what it found:
+
+```
+✓ Resolved: library-new-nav-tokens (branch of library) → file, variables, styles
+```
+
+- **The alias** — the file's name, prefixed with the configured source it branches from,
+  so payloads land beside the library's as `data/library-new-nav-tokens.file.json`.
+  Override it with `--source <alias>=<url>`. An alias that collides with a configured
+  source is refused rather than overwriting the payload you mean to compare against.
+- **The data kinds** — copied from the configured source the branch came from, so the two
+  payloads are comparable. Fetching a branch of a file that is not in `data.sources` is
+  fine; with nothing to copy from, `--only` decides and `file` alone is the default.
+
+A `<alias>.source.json` sidecar records the key and where it came from, since config has
+no record of them.
+
+### Using what you fetched
+
+The alias behaves like any other from here:
+
+```bash
+specs scan --source library-new-nav-tokens
+specs generate data/library-new-nav-tokens.manifest.md -o ./branch-specs
+```
+
+`generate` takes the manifest path, and `-o` matters — without it, branch specs are
+written into `spec.directory` over the specs generated from the library.
+
+Ad-hoc payloads contribute to the render cache only where the configured sources define
+nothing, so fetching a branch never changes how the library itself resolves. Icons, if
+inherited, are written to `_icons-<alias>/` rather than over `_icons/`.
+
+### Cleaning up
+
+Everything an ad-hoc source wrote is named after its alias, so a finished branch is
+removed with:
+
+```bash
+rm data/library-new-nav-tokens.*
+specs cache --force
 ```
 
 ### How to find a branch key
@@ -135,6 +187,20 @@ Open the branch in Figma — the URL contains the key: `figma.com/design/<KEY>/.
 ### Custom tokens on branches
 
 If you use `applyCustomTokens` with branch-fetched data, be aware that Figma variable and style IDs may differ between main and a branch. Your mapping file IDs must match the IDs in the branch's data files, not main's.
+
+### Keeping a branch in config
+
+A branch you fetch repeatedly over a long life is still worth a config entry — give it
+its own alias so the library keeps its own:
+
+```yaml
+# config/settings.yaml
+data:
+  sources:
+    library-redesign:
+      key: BRANCH_FILE_KEY
+      fetch: ['file', 'variables', 'styles']
+```
 
 ---
 

--- a/site/src/content/docs/cli/commands/scan.md
+++ b/site/src/content/docs/cli/commands/scan.md
@@ -162,12 +162,17 @@ Path to Figma REST API JSON file. When omitted, `scan` resolves the file from th
 - **2+ sources configured** → must specify one with `--source <alias>`
 - **No sources configured** → error; pass `[file]` explicitly
 
+`--source` also accepts an alias fetched by [`specs fetch --source`](/cli/commands/fetch/#fetching-figma-branches) — a branch, typically. Those aliases are not in config, so `scan` looks for `{data.directory}/<alias>.file.json` on disk.
+
 ```bash
 # Zero-config: auto-resolves when one source is configured
 specs scan
 
 # Select a specific source when multiple are configured
 specs scan --source library
+
+# A branch fetched with `specs fetch --source` works the same way
+specs scan --source library-new-nav-tokens
 
 # Or pass a file path explicitly
 specs scan data/library.file.json


### PR DESCRIPTION
`specs fetch --source <url|key>` defines a source on the command line that lives only for the run that names it. The case it exists for: a diff of a spec built from a durable library against the same file's branch. A branch is short-lived and gets fetched a few times over its life, so editing `config/settings.yaml` for it means editing it back.

Everything downstream of `fetch` is keyed by source alias rather than by file key, so an ad-hoc alias makes the paths, the manifest name and the cache slice fall out without new concepts.

## What changed

- **`fetch --source <[alias=]url|key>`**, repeatable. Resolves the file with one small `depth=1` request before downloading — names the alias after the branch, matches the branch to the configured source it came from and copies its data kinds, and fails on a bad key or token before the large request rather than after it.
- **`scan --source <alias>`** resolves an alias that has no config entry from `{data.directory}/<alias>.file.json` on disk.
- **`generate --get-images`** takes its Figma file key from the payload the specs were generated from — config key first, then the `<alias>.source.json` sidecar `fetch` writes — instead of always the configured source.
- **New `utilities/figmaFileKey.ts`** parses a bare key or a pasted Figma URL. Branch URLs are `/design/<MAIN_KEY>/branch/<BRANCH_KEY>/<slug>`, and the branch key is the one that means "this file" — reading the leading key would resolve a branch link to main, fetch the wrong document, and look successful doing it.

## Safety

Three ways an ad-hoc fetch could quietly damage durable state, all closed:

- An alias that collides with a configured source is refused, rather than overwriting the payload it exists to be compared against.
- Ad-hoc aliases are cached first, so where a branch and the library define the same node id or token name the library wins. A branch fetch cannot change how the library resolves.
- Inherited `icons` are written to `_icons-<alias>/`, not over `_icons/` — the slugs are identical across a branch and its parent.

Naming any `--source` fetches only those sources; the configured library is not re-downloaded unless `--only <alias>` asks for it.

## Verification

Fetched a real branch of a configured source into a test workspace: the branch URL parsed to the branch key, the alias defaulted to `<parent>-<branch name>`, all four data kinds were inherited, and the payloads landed beside the library's.

The `icons` path is the one part not confirmed end to end — that run stopped at an unrelated config-loading failure caused by the test binary resolving `specs-schema` to a build from a different branch, which drops every convention block. Unit tests cover the parser and the ad-hoc source parsing; the CLI suite passes.

## Docs

- `site/.../cli/commands/fetch.md` — "Fetching Figma Branches" rewritten. It previously told you to point `data.sources` at a branch key, which is now the long-lived option rather than the only one.
- `site/.../cli/commands/scan.md` — `--source` accepts a fetched alias.
- CLI CHANGELOG under 0.29.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)